### PR TITLE
Closes #17, Closes #18

### DIFF
--- a/example/example.cpp
+++ b/example/example.cpp
@@ -1866,6 +1866,9 @@ void deserializeGridHyperslabbingBlock(common::EpcDocument & pck)
 
 	// ONE SUGAR
 	AbstractIjkGridRepresentation* ijkGrid = static_cast<AbstractIjkGridRepresentation*>(pck.getResqmlAbstractObjectByUuid("e69bfe00-fa3d-11e5-b5eb-0002a5d5c51b"));
+	if (ijkGrid == nullptr) {
+		return;
+	}
 
 	cout << "--------------------------------------------------" << std::endl;
 	showAllMetadata(ijkGrid);
@@ -3469,7 +3472,6 @@ void prodml_deserialize(const string & inputFile)
 
 // filepath is defined in a macro to better check memory leak
 #define filePath "../../testingPackageCpp.epc"
-//#define filePath "C:/Dev/Data/huabei.epc"
 #define prodml_filePath "../../prodml_testingPackageCpp.epc"
 int main(int argc, char **argv)
 {

--- a/src/resqml2_0_1/GridConnectionSetRepresentation.cpp
+++ b/src/resqml2_0_1/GridConnectionSetRepresentation.cpp
@@ -93,6 +93,9 @@ string GridConnectionSetRepresentation::getHdfProxyUuid() const
 
 void GridConnectionSetRepresentation::setCellIndexPairsUsingExistingDataset(const ULONG64 & cellIndexPairCount, const std::string & cellIndexPair, const ULONG64 & nullValue, common::AbstractHdfProxy * proxy, const std::string & gridIndexPair)
 {
+	if (cellIndexPairCount == 0) {
+		throw std::invalid_argument("You cannot set zero cell index pair.");
+	}
 	_resqml2__GridConnectionSetRepresentation* const rep = static_cast<_resqml2__GridConnectionSetRepresentation* const>(gsoapProxy2_0_1);
 	rep->Count = cellIndexPairCount;
 

--- a/src/resqml2_0_1/LocalDepth3dCrs.cpp
+++ b/src/resqml2_0_1/LocalDepth3dCrs.cpp
@@ -48,8 +48,9 @@ void LocalDepth3dCrs::init(soap* soapContext, const std::string & guid, const st
 			const gsoap_resqml2_0_1::eml20__LengthUom & projectedUom,
 			const gsoap_resqml2_0_1::eml20__LengthUom & verticalUom, const bool & isUpOriented)
 {
-	if (!soapContext)
+	if (soapContext == nullptr) {
 		throw invalid_argument("The soap context where the local CRS will be instantiated must exist.");
+	}
 
 	gsoapProxy2_0_1 = soap_new_resqml2__obj_USCORELocalDepth3dCrs(soapContext, 1);
 	_resqml2__LocalDepth3dCrs* local3dCrs = static_cast<_resqml2__LocalDepth3dCrs*>(gsoapProxy2_0_1);
@@ -73,6 +74,9 @@ LocalDepth3dCrs::LocalDepth3dCrs(soap* soapContext, const std::string & guid, co
 			const gsoap_resqml2_0_1::eml20__LengthUom & projectedUom, const unsigned long & projectedEpsgCode,
 			const gsoap_resqml2_0_1::eml20__LengthUom & verticalUom, const unsigned int & verticalEpsgCode, const bool & isUpOriented)
 {
+	if (projectedEpsgCode == 0 || verticalEpsgCode == 0) {
+		throw invalid_argument("An EPSG code cannot be set to 0.");
+	}
 	init(soapContext, guid, title, originOrdinal1, originOrdinal2, originOrdinal3, arealRotation, projectedUom, verticalUom, isUpOriented);
 	_resqml2__LocalDepth3dCrs* local3dCrs = static_cast<_resqml2__LocalDepth3dCrs*>(gsoapProxy2_0_1);
 
@@ -113,6 +117,9 @@ LocalDepth3dCrs::LocalDepth3dCrs(soap* soapContext, const std::string & guid, co
 			const gsoap_resqml2_0_1::eml20__LengthUom & projectedUom, const unsigned long & projectedEpsgCode,
 			const gsoap_resqml2_0_1::eml20__LengthUom & verticalUom, const std::string & verticalUnknownReason, const bool & isUpOriented)
 {
+	if (projectedEpsgCode == 0) {
+		throw invalid_argument("An EPSG code cannot be set to 0.");
+	}
 	init(soapContext, guid, title, originOrdinal1, originOrdinal2, originOrdinal3, arealRotation, projectedUom, verticalUom, isUpOriented);
 	_resqml2__LocalDepth3dCrs* local3dCrs = static_cast<_resqml2__LocalDepth3dCrs*>(gsoapProxy2_0_1);
 
@@ -133,6 +140,9 @@ LocalDepth3dCrs::LocalDepth3dCrs(soap* soapContext, const std::string & guid, co
 			const gsoap_resqml2_0_1::eml20__LengthUom & projectedUom, const std::string & projectedUnknownReason,
 			const gsoap_resqml2_0_1::eml20__LengthUom & verticalUom, const unsigned int & verticalEpsgCode, const bool & isUpOriented)
 {
+	if (verticalEpsgCode == 0) {
+		throw invalid_argument("An EPSG code cannot be set to 0.");
+	}
 	init(soapContext, guid, title, originOrdinal1, originOrdinal2, originOrdinal3, arealRotation, projectedUom, verticalUom, isUpOriented);
 	_resqml2__LocalDepth3dCrs* local3dCrs = static_cast<_resqml2__LocalDepth3dCrs*>(gsoapProxy2_0_1);
 

--- a/src/resqml2_0_1/LocalTime3dCrs.cpp
+++ b/src/resqml2_0_1/LocalTime3dCrs.cpp
@@ -49,8 +49,9 @@ void LocalTime3dCrs::init(soap* soapContext, const std::string & guid, const std
 			const gsoap_resqml2_0_1::eml20__TimeUom & timeUom,
 			const gsoap_resqml2_0_1::eml20__LengthUom & verticalUom, const bool & isUpOriented)
 {
-	if (soapContext == nullptr)
+	if (soapContext == nullptr) {
 		throw invalid_argument("The EPC document where the local CRS will be stored cannot be null.");
+	}
 
 	gsoapProxy2_0_1 = soap_new_resqml2__obj_USCORELocalTime3dCrs(soapContext, 1);
 	_resqml2__LocalTime3dCrs* local3dCrs = static_cast<_resqml2__LocalTime3dCrs*>(gsoapProxy2_0_1);
@@ -76,6 +77,9 @@ LocalTime3dCrs::LocalTime3dCrs(soap* soapContext, const std::string & guid, cons
 			const gsoap_resqml2_0_1::eml20__TimeUom & timeUom,
 			const gsoap_resqml2_0_1::eml20__LengthUom & verticalUom, const unsigned int & verticalEpsgCode, const bool & isUpOriented)
 {
+	if (projectedEpsgCode == 0 || verticalEpsgCode == 0) {
+		throw invalid_argument("An EPSG code cannot be set to 0.");
+	}
 	init(soapContext, guid, title, originOrdinal1, originOrdinal2, originOrdinal3, arealRotation, projectedUom, timeUom, verticalUom, isUpOriented);
 	_resqml2__LocalTime3dCrs* local3dCrs = static_cast<_resqml2__LocalTime3dCrs*>(gsoapProxy2_0_1);
 
@@ -118,6 +122,9 @@ LocalTime3dCrs::LocalTime3dCrs(soap* soapContext, const std::string & guid, cons
 			const gsoap_resqml2_0_1::eml20__TimeUom & timeUom,
 			const gsoap_resqml2_0_1::eml20__LengthUom & verticalUom, const std::string & verticalUnknownReason, const bool & isUpOriented)
 {
+	if (projectedEpsgCode == 0) {
+		throw invalid_argument("An EPSG code cannot be set to 0.");
+	}
 	init(soapContext, guid, title, originOrdinal1, originOrdinal2, originOrdinal3, arealRotation, projectedUom, timeUom, verticalUom, isUpOriented);
 	_resqml2__LocalTime3dCrs* local3dCrs = static_cast<_resqml2__LocalTime3dCrs*>(gsoapProxy2_0_1);
 
@@ -139,6 +146,9 @@ LocalTime3dCrs::LocalTime3dCrs(soap* soapContext, const std::string & guid, cons
 			const gsoap_resqml2_0_1::eml20__TimeUom & timeUom,
 			const gsoap_resqml2_0_1::eml20__LengthUom & verticalUom, const unsigned int & verticalEpsgCode, const bool & isUpOriented)
 {
+	if (verticalEpsgCode == 0) {
+		throw invalid_argument("An EPSG code cannot be set to 0.");
+	}
 	init(soapContext, guid, title, originOrdinal1, originOrdinal2, originOrdinal3, arealRotation, projectedUom, timeUom, verticalUom, isUpOriented);
 	_resqml2__LocalTime3dCrs* local3dCrs = static_cast<_resqml2__LocalTime3dCrs*>(gsoapProxy2_0_1);
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Forbid some wrong usage of the standards (zero epsg code and zero cell pair in GridConnectionSet) 

Does this close any currently open issues?
------------------------------------------
Closes #17, Closes #18

Any other comments?
-------------------
Backward compatible

Where has this been tested?
---------------------------
**Operating System:** Ubuntu 16.04 64 bits

**Platform:** GCC 5.4.0
