### PR TITLE
Adding big IJK grids generation within unit tests

### DIFF
--- a/test/resqml2_0_1test/AbstractBigIjkGridRepresentationTest.cpp
+++ b/test/resqml2_0_1test/AbstractBigIjkGridRepresentationTest.cpp
@@ -1,0 +1,223 @@
+#include "resqml2_0_1test/AbstractBigIjkGridRepresentationTest.h"
+
+#include "catch.hpp"
+#include "resqml2_0_1test/LocalDepth3dCrsTest.h"
+
+#include "resqml2_0_1/LocalDepth3dCrs.h"
+#include "resqml2_0_1/IjkGridExplicitRepresentation.h"
+#include "resqml2_0_1/DiscreteProperty.h"
+#include "resqml2_0_1/ContinuousProperty.h"
+
+using namespace std;
+using namespace common;
+using namespace resqml2_0_1test;
+using namespace resqml2;
+
+AbstractBigIjkGridRepresentationTest::AbstractBigIjkGridRepresentationTest(
+	const string & epcDocPath,
+	const unsigned int & iCount, const unsigned int & jCount, const unsigned int & kCount,
+	const unsigned int & faultCount,
+	const double & xMin, const double & xMax, const double & yMin, const double & yMax, const double & zMin, const double & zMax,
+	const double & faultThrow, 
+	const char * defaultUuid, const char * defaultTitle)
+	: iCount(iCount), jCount(jCount), kCount(kCount), faultCount(faultCount), 
+	xMin(xMin), xMax(xMax), yMin(yMin), yMax(yMax), zMin(zMin), zMax(zMax), faultThrow(faultThrow),
+	AbstractIjkGridRepresentationTest(
+		epcDocPath, defaultUuid, defaultTitle, 
+		initNodesCountIjkGridRepresentation(iCount, jCount, kCount, faultCount),
+		initNodesIjkGridRepresentation(iCount, jCount, kCount, faultCount, xMin, xMax, yMin, yMax, zMin, zMax, faultThrow)) {
+	if ((iCount < 1) || (jCount < 1) || (kCount < 1))
+	{
+		throw invalid_argument("iCount, jCount and kCount must be >= 1.");
+	}
+
+	if (faultCount > (iCount - 1))
+	{
+		throw invalid_argument("faultCount must be strictly lesser than iCount.");
+	}
+
+	if ((xMin == xMax) || (yMin == yMax) || (zMin == zMax))
+	{
+		throw invalid_argument("In each dimension, grid lenght cannot be 0.");
+	}
+}
+
+AbstractBigIjkGridRepresentationTest::AbstractBigIjkGridRepresentationTest(EpcDocument * epcDoc, bool init,
+	const unsigned int & iCount, const unsigned int & jCount, const unsigned int & kCount,
+	const unsigned int & faultCount,
+	const double & xMin, const double & xMax, const double & yMin, const double & yMax, const double & zMin, const double & zMax,
+	const double & faultThrow,
+	const char * defaultUuid, const char * defaultTitle)
+	: iCount(iCount), jCount(jCount), kCount(kCount), faultCount(faultCount),
+	xMin(xMin), xMax(xMax), yMin(yMin), yMax(yMax), zMin(zMin), zMax(zMax), faultThrow(faultThrow), 
+	AbstractIjkGridRepresentationTest(epcDoc, defaultUuid, defaultTitle,
+		initNodesCountIjkGridRepresentation(iCount, jCount, kCount, faultCount),
+		initNodesIjkGridRepresentation(iCount, jCount, kCount, faultCount, xMin, xMax, yMin, yMax, zMin, zMax, faultThrow)) {
+	if ((iCount < 1) || (jCount < 1) || (kCount < 1))
+	{
+		throw invalid_argument("iCount, jCount and kCount must be >= 1.");
+	}
+
+	if (faultCount >(iCount - 1))
+	{
+		throw invalid_argument("faultCount must be strictly lesser than iCount.");
+	}
+
+	if ((xMin == xMax) || (yMin == yMax) || (zMin == zMax))
+	{
+		throw invalid_argument("In each dimension, grid lenght cannot be 0.");
+	}
+
+	if (init)
+			this->initEpcDoc();
+		else
+			this->readEpcDoc();
+}
+
+ULONG64 AbstractBigIjkGridRepresentationTest::initNodesCountIjkGridRepresentation(const unsigned int & iCount, const unsigned int & jCount, const unsigned int & kCount,
+	const unsigned int & faultCount)
+{
+	return ((iCount + 1) * (jCount + 1) * (kCount + 1)) + (faultCount * (jCount + 1) * (kCount + 1));
+}
+
+double * AbstractBigIjkGridRepresentationTest::initNodesIjkGridRepresentation(const unsigned int & iCount, const unsigned int & jCount, const unsigned int & kCount,
+	const unsigned int & faultCount,
+	const double & xMin, const double & xMax, const double & yMin, const double & yMax, const double & zMin, const double & zMax,
+	const double & faultThrow)
+{
+	ULONG64 nodeCount = this->initNodesCountIjkGridRepresentation(iCount, jCount, kCount, faultCount);
+	
+	nodesIjkGridRepresentation = new double[nodeCount * 3];
+	
+	double xIncr = (xMax - xMin) / iCount;
+	double yIncr = (yMax - yMin) / jCount;
+	double zIncr = (zMax - zMin) / kCount;
+
+	for (unsigned int k = 0; k < kCount + 1; ++k)
+		for (unsigned int j = 0; j < jCount + 1; ++j)
+		{
+			double cumulativeFaultThrow = 0.;
+
+			for (unsigned int i = 0; i < iCount + 1; ++i)
+			{
+				unsigned int currentIndex = k * ((iCount + 1) * (jCount + 1) + faultCount * (jCount + 1)) + j * (iCount + 1) + i;
+
+				nodesIjkGridRepresentation[3 * currentIndex] = i * xIncr;
+				nodesIjkGridRepresentation[3 * currentIndex + 1] = j * yIncr;
+				nodesIjkGridRepresentation[3 * currentIndex + 2] = k * zIncr + cumulativeFaultThrow;
+
+				if (i <= faultCount)
+				{
+					cumulativeFaultThrow = i*faultThrow;
+				}
+			}
+		}
+
+	for (unsigned int k = 0; k < kCount + 1; ++k)
+		for (unsigned int j = 0; j < jCount + 1; ++j)
+			for (unsigned int i = 1; i < faultCount + 1; ++i)
+			{
+				unsigned int currentIndex = k * ((iCount + 1) * (jCount + 1) + faultCount * (jCount + 1)) + (iCount + 1) * (jCount + 1) + j * faultCount + i - 1;
+
+				nodesIjkGridRepresentation[3 * currentIndex] = i * xIncr;
+				nodesIjkGridRepresentation[3 * currentIndex + 1] = j * yIncr;
+				nodesIjkGridRepresentation[3 * currentIndex + 2] = k * zIncr + i * faultThrow;
+			}
+
+	return nodesIjkGridRepresentation;
+}
+
+void AbstractBigIjkGridRepresentationTest::initSplitCoordinateLine(unsigned int * pillarOfCoordinateLine,
+	unsigned int * splitCoordinateLineColumnCumulativeCount,
+	unsigned int * splitCoordinateLineColumns)
+{
+	//*************************************
+	// initializing  pillarOfCoordinateLine
+	
+	unsigned int currentIndex = 0;
+	for (unsigned int j = 0; j < jCount + 1; ++j)
+		for (unsigned int i = 1; i < faultCount + 1; ++i)
+		{
+			pillarOfCoordinateLine[currentIndex] = j * (iCount + 1) + i;
+			++currentIndex;
+		}
+
+	//******************************************************
+	// initializing splitCoordinateLineColumnCumulativeCount
+
+	unsigned int currentCumulativeCount = 0;
+	for (unsigned int faultIndex = 0; faultIndex < faultCount; ++faultIndex)
+	{
+		++currentCumulativeCount;
+		splitCoordinateLineColumnCumulativeCount[faultIndex] = currentCumulativeCount;
+	}
+
+	for (unsigned int jIndex = 1; jIndex < jCount; ++jIndex)
+	{
+		for (unsigned int faultIndex = 0; faultIndex < faultCount; ++faultIndex)
+		{
+			currentCumulativeCount += 2;
+			splitCoordinateLineColumnCumulativeCount[jIndex * faultCount + faultIndex] = currentCumulativeCount;
+		}
+	}
+
+	for (unsigned int faultIndex = 0; faultIndex < faultCount; ++faultIndex)
+	{
+		++currentCumulativeCount;
+		splitCoordinateLineColumnCumulativeCount[jCount * faultCount + faultIndex] = currentCumulativeCount;
+	}
+
+	//****************************************
+	// initializing splitCoordinateLineColumns
+
+	currentIndex = 0;
+	for (unsigned int faultIndex = 0; faultIndex < faultCount; ++faultIndex)
+	{
+		splitCoordinateLineColumns[currentIndex] = faultIndex + 1;
+		++currentIndex;
+	}
+
+	for (unsigned int jIndex = 1; jIndex < jCount; ++jIndex)
+		for (unsigned int faultIndex = 0; faultIndex < faultCount; ++faultIndex)
+		{
+			splitCoordinateLineColumns[currentIndex] = ((jIndex - 1) * iCount) + faultIndex + 1;
+			splitCoordinateLineColumns[currentIndex + 1] = (jIndex * iCount) + faultIndex + 1;
+			currentIndex += 2;
+		}
+
+	for (unsigned int faultIndex = 0; faultIndex < faultCount; ++faultIndex)
+	{
+		splitCoordinateLineColumns[currentIndex] = ((jCount - 1) * iCount) + faultIndex + 1;
+		++currentIndex;
+	}
+}
+
+void AbstractBigIjkGridRepresentationTest::initDiscreteProperty(unsigned short * discretePropertyValues)
+{
+	for (unsigned short k = 0; k < kCount; ++k)
+		for (unsigned int j = 0; j < jCount; ++j)
+			for (unsigned int i = 0; i < iCount; ++i)
+			{
+				discretePropertyValues[k * iCount * jCount + j * iCount + i] = k;
+			}
+}
+
+void AbstractBigIjkGridRepresentationTest::initContinuousProperty(double * continuousPropertyValues)
+{
+	double valueIncr;
+	if ((iCount - 1) != 0)
+	{
+		valueIncr = 1. / (iCount - 1);
+	}
+	else
+	{
+		valueIncr = 0.;
+	}
+
+	for (unsigned short k = 0; k < kCount; ++k)
+		for (unsigned int j = 0; j < jCount; ++j)
+			for (unsigned int i = 0; i < iCount; ++i)
+			{
+				continuousPropertyValues[k * iCount * jCount + j * iCount + i] = i * valueIncr;
+			}
+}

--- a/test/resqml2_0_1test/AbstractBigIjkGridRepresentationTest.cpp
+++ b/test/resqml2_0_1test/AbstractBigIjkGridRepresentationTest.cpp
@@ -33,12 +33,12 @@ AbstractBigIjkGridRepresentationTest::AbstractBigIjkGridRepresentationTest(
 
 	if (faultCount > (iCount - 1))
 	{
-		throw invalid_argument("faultCount must be strictly lesser than iCount.");
+		throw invalid_argument("faultCount must be strictly less than iCount.");
 	}
 
 	if ((xMin == xMax) || (yMin == yMax) || (zMin == zMax))
 	{
-		throw invalid_argument("In each dimension, grid lenght cannot be 0.");
+		throw invalid_argument("In each dimension, grid length cannot be 0.");
 	}
 }
 
@@ -60,12 +60,12 @@ AbstractBigIjkGridRepresentationTest::AbstractBigIjkGridRepresentationTest(EpcDo
 
 	if (faultCount >(iCount - 1))
 	{
-		throw invalid_argument("faultCount must be strictly lesser than iCount.");
+		throw invalid_argument("faultCount must be strictly less than iCount.");
 	}
 
 	if ((xMin == xMax) || (yMin == yMax) || (zMin == zMax))
 	{
-		throw invalid_argument("In each dimension, grid lenght cannot be 0.");
+		throw invalid_argument("In each dimension, grid length cannot be 0.");
 	}
 
 	if (init)
@@ -204,15 +204,7 @@ void AbstractBigIjkGridRepresentationTest::initDiscreteProperty(unsigned short *
 
 void AbstractBigIjkGridRepresentationTest::initContinuousProperty(double * continuousPropertyValues)
 {
-	double valueIncr;
-	if ((iCount - 1) != 0)
-	{
-		valueIncr = 1. / (iCount - 1);
-	}
-	else
-	{
-		valueIncr = 0.;
-	}
+	double valueIncr = (iCount - 1) != 0 ? valueIncr = 1. / (iCount - 1) : 0.;
 
 	for (unsigned short k = 0; k < kCount; ++k)
 		for (unsigned int j = 0; j < jCount; ++j)

--- a/test/resqml2_0_1test/AbstractBigIjkGridRepresentationTest.h
+++ b/test/resqml2_0_1test/AbstractBigIjkGridRepresentationTest.h
@@ -70,7 +70,7 @@ namespace resqml2_0_1test {
 		 * @param yMax maximum y value of the grid.
 		 * @param zMin minimum z value of the grid (without considering any fault throw).
 		 * @param zMax maximum z value of the grid (without considering any fault throw).
-		 * @param faultThrow lenght of the fault throw along z axis.
+		 * @param faultThrow length of the fault throw along z axis.
 		 * @return nodesIjkGridRepresentation.
 		 */
 		double * initNodesIjkGridRepresentation(const unsigned int & iCount, const unsigned int & jCount, const unsigned int & kCount,

--- a/test/resqml2_0_1test/AbstractBigIjkGridRepresentationTest.h
+++ b/test/resqml2_0_1test/AbstractBigIjkGridRepresentationTest.h
@@ -1,0 +1,107 @@
+#pragma once
+
+#include "AbstractIjkGridRepresentationTest.h"
+#include <iostream>
+
+namespace common {
+	class EpcDocument;
+}
+
+namespace resqml2_0_1test {
+	class AbstractBigIjkGridRepresentationTest : public AbstractIjkGridRepresentationTest {
+	public:
+		const unsigned int iCount;
+		const unsigned int jCount;
+		const unsigned int kCount;
+		const unsigned int faultCount;
+		const double xMin;
+		const double xMax;
+		const double yMin;
+		const double yMax;
+		const double zMin;
+		const double zMax;
+		const double faultThrow;
+		double* nodesIjkGridRepresentation;
+
+		AbstractBigIjkGridRepresentationTest(
+			const std::string & epcDocPath,
+			const unsigned int & iCount, const unsigned int & jCount, const unsigned int & kCount, 
+			const unsigned int & faultCount, 
+			const double & xMin, const double & xMax, const double & yMin, const double & yMax, const double & zMin, const double & zMax,
+			const double & faultThrow,
+			const char * defaultUuid, const char * defaultTitle);
+
+		AbstractBigIjkGridRepresentationTest(common::EpcDocument * epcDoc, bool init,
+			const unsigned int & iCount, const unsigned int & jCount, const unsigned int & kCount,
+			const unsigned int & faultCount,
+			const double & xMin, const double & xMax, const double & yMin, const double & yMax, const double & zMin, const double & zMax,
+			const double & faultThrow,
+			const char * defaultUuid, const char * defaultTitle);
+
+		~AbstractBigIjkGridRepresentationTest() {
+			if (nodesIjkGridRepresentation != nullptr)
+			{
+				delete[] nodesIjkGridRepresentation;
+			}
+		}
+	protected:
+		virtual void initEpcDocHandler() = 0;
+		virtual void readEpcDocHandler() = 0;
+
+		/**
+		 * Get the number of nodes (including splitted ones) of the generated grid. 
+		 * @param iCount number of cells in the I direction.
+		 * @param jCount number of cells in the J direction.
+		 * @param kCount number of cells in the K direction.
+		 * @param faultCount number of faults. Faults are parallel to YZ plane (they fit with i-interfaces). faultCount in [0; iCount[.
+		 */
+		ULONG64 initNodesCountIjkGridRepresentation(const unsigned int & iCount, const unsigned int & jCount, const unsigned int & kCount,
+			const unsigned int & faultCount);
+
+		/**
+		 * Initialize generated grid geometry. Result is stored into class variable nodesIjkGridRepresentation.
+		 * @param iCount number of cells in the I direction.
+		 * @param jCount number of cells in the J direction.
+		 * @param kCount number of cells in the K direction.
+		 * @param faultCount number of faults. Faults are parallel to YZ plane (they fit with i-interfaces). faultCount in [0; iCount[.
+		 * @param xMin minimum x value of the grid.
+		 * @param xMax maximum x value of the grid.
+		 * @param yMin minimum y value of the grid.
+		 * @param yMax maximum y value of the grid.
+		 * @param zMin minimum z value of the grid (without considering any fault throw).
+		 * @param zMax maximum z value of the grid (without considering any fault throw).
+		 * @param faultThrow lenght of the fault throw along z axis.
+		 * @return nodesIjkGridRepresentation.
+		 */
+		double * initNodesIjkGridRepresentation(const unsigned int & iCount, const unsigned int & jCount, const unsigned int & kCount,
+			const unsigned int & faultCount,
+			const double & xMin, const double & xMax, const double & yMin, const double & yMax, const double & zMin, const double & zMax,
+			const double & faultThrow);
+		
+		/**
+		 * Initialize split coordinate lines informations.
+		 * @param pillarOfCoordinateLine					Properly allocated output parameter. For each split coordinate line, indicates which pillar it belongs to. 
+		 * @param splitCoordinateLineColumnCumulativeCount	Properly allocated output parameter. For each split coordinate line, indicates how many columns of the ijk grid are incident to it.
+															See IjkGridExplicitRepresentation documentation for more information. 
+		* @param splitCoordinateLineColumns					For each split coordinate line, indicates which columns are incident to it.
+	
+		 */
+		void initSplitCoordinateLine(unsigned int * pillarOfCoordinateLine, 
+			unsigned int * splitCoordinateLineColumnCumulativeCount,
+			unsigned int * splitCoordinateLineColumns);
+
+		/**
+		 * Initialize generated grid discrete property values. For a given cell, corresponding value
+		 * if its k index.
+		 * @param discretePropertyValues Properly allocated output parameter.
+		 */
+		void initDiscreteProperty(unsigned short * discretePropertyValues);
+
+		/**
+		 * Initialize generated grid continuous property values. For a given cell, corresponding value
+		 * is taken in [0.; 1.] by applying an homogeneous gradient from 0. to 1. in the I direction. 
+		 * @param continuousPropertyValues Properly allocated output parameter.
+		 */
+		void initContinuousProperty(double * continuousPropertyValues);
+	};
+}

--- a/test/resqml2_0_1test/BigIjkGridExplicitRepresentationTest.cpp
+++ b/test/resqml2_0_1test/BigIjkGridExplicitRepresentationTest.cpp
@@ -1,0 +1,89 @@
+#include "resqml2_0_1test/BigIjkGridExplicitRepresentationTest.h"
+
+#include "catch.hpp"
+#include "resqml2_0_1test/LocalDepth3dCrsTest.h"
+
+#include "resqml2_0_1/LocalDepth3dCrs.h"
+#include "resqml2_0_1/IjkGridExplicitRepresentation.h"
+#include "resqml2_0_1/DiscreteProperty.h"
+#include "resqml2_0_1/ContinuousProperty.h"
+
+using namespace std;
+using namespace common;
+using namespace resqml2_0_1test;
+using namespace resqml2;
+
+const char* BigIjkGridExplicitRepresentationTest::defaultUuid = "f889e5d2-249e-4827-8532-ce60a1d05b99";
+const char* BigIjkGridExplicitRepresentationTest::defaultTitle = "Ijk Grid Explicit Representation";
+const char* BigIjkGridExplicitRepresentationTest::discretePropertyUuid = "265343eb-6d1b-4015-b08b-8b4abbe7f84b";
+const char* BigIjkGridExplicitRepresentationTest::discretePropertyTitle = "Explicit IJK Grid K Index";
+const char* BigIjkGridExplicitRepresentationTest::continuousPropertyUuid = "a4e8e307-0844-47e9-b9fd-6ad0a1f99b88";
+const char* BigIjkGridExplicitRepresentationTest::continuousPropertyTitle = "Explicit IJK Grid Continuous Property";
+
+BigIjkGridExplicitRepresentationTest::BigIjkGridExplicitRepresentationTest(
+	const string & epcDocPath,
+	const unsigned int & iCount, const unsigned int & jCount, const unsigned int & kCount,
+	const unsigned int & faultCount,
+	const double & xMin, const double & xMax, const double & yMin, const double & yMax, const double & zMin, const double & zMax,
+	const double & faultThrow)
+	: AbstractBigIjkGridRepresentationTest(epcDocPath, iCount, jCount, kCount, faultCount, xMin, xMax, yMin, yMax, zMin, zMax, faultThrow, defaultUuid, defaultTitle) {
+}
+
+BigIjkGridExplicitRepresentationTest::BigIjkGridExplicitRepresentationTest(EpcDocument * epcDoc, bool init,
+	const unsigned int & iCount, const unsigned int & jCount, const unsigned int & kCount,
+	const unsigned int & faultCount,
+	const double & xMin, const double & xMax, const double & yMin, const double & yMax, const double & zMin, const double & zMax,
+	const double & faultThrow)
+	: AbstractBigIjkGridRepresentationTest(epcDoc, init, iCount, jCount, kCount, faultCount, xMin, xMax, yMin, yMax, zMin, zMax, faultThrow, defaultUuid, defaultTitle) {
+}
+
+void BigIjkGridExplicitRepresentationTest::initEpcDocHandler() {
+	// getting the local depth 3d crs
+	LocalDepth3dCrsTest* crsTest = new LocalDepth3dCrsTest(this->epcDoc, true);
+	resqml2_0_1::LocalDepth3dCrs* crs = epcDoc->getResqmlAbstractObjectByUuid<resqml2_0_1::LocalDepth3dCrs>(LocalDepth3dCrsTest::defaultUuid);
+
+	// getting the hdf proxy
+	AbstractHdfProxy* hdfProxy = this->epcDoc->getHdfProxySet()[0];
+
+	// creating the ijk grid
+	resqml2_0_1::IjkGridExplicitRepresentation* ijkGrid = this->epcDoc->createIjkGridExplicitRepresentation(crs, uuid, title, iCount, jCount, kCount);
+	REQUIRE(ijkGrid != nullptr);
+	unsigned int * pillarOfCoordinateLine = new unsigned int[faultCount * (jCount + 1)];
+	unsigned int * splitCoordinateLineColumnCumulativeCount = new unsigned int[faultCount * (jCount + 1)];
+	unsigned int * splitCoordinateLineColumns = new unsigned int[(faultCount * (jCount + 1)) + (faultCount * (jCount - 1))];
+	initSplitCoordinateLine(pillarOfCoordinateLine, splitCoordinateLineColumnCumulativeCount, splitCoordinateLineColumns);
+	ijkGrid->setGeometryAsCoordinateLineNodes(gsoap_resqml2_0_1::resqml2__PillarShape__vertical, gsoap_resqml2_0_1::resqml2__KDirection__down, false, this->xyzPointsOfAllPatchesInGlobalCrs, hdfProxy,
+		faultCount * (jCount + 1), pillarOfCoordinateLine, splitCoordinateLineColumnCumulativeCount, splitCoordinateLineColumns);
+
+	// adding a discrete property
+	resqml2_0_1::DiscreteProperty* discreteProperty = this->epcDoc->createDiscreteProperty(
+		ijkGrid, discretePropertyUuid, discretePropertyTitle,
+		1, 
+		gsoap_resqml2_0_1::resqml2__IndexableElements__cells, 
+		gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind__index);
+	unsigned short * discretePropertyValues = new unsigned short[iCount * jCount * kCount];
+	initDiscreteProperty(discretePropertyValues);
+	discreteProperty->pushBackUShortHdf5Array3dOfValues(discretePropertyValues, iCount, jCount, kCount, hdfProxy, -1);
+
+	// adding a continuous property
+	resqml2_0_1::ContinuousProperty* continuousProperty = this->epcDoc->createContinuousProperty(
+		ijkGrid, continuousPropertyUuid, continuousPropertyTitle,
+		1,
+		gsoap_resqml2_0_1::resqml2__IndexableElements__cells,
+		gsoap_resqml2_0_1::resqml2__ResqmlUom__m,
+		gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind__length);
+	double * continuousPropertyValues = new double[iCount * jCount * kCount];
+	initContinuousProperty(continuousPropertyValues);
+	continuousProperty->pushBackDoubleHdf5Array1dOfValues(continuousPropertyValues, iCount * jCount * kCount, hdfProxy);
+
+	// cleaning
+	delete crsTest;
+	delete[] pillarOfCoordinateLine;
+	delete[] splitCoordinateLineColumnCumulativeCount;
+	delete[] splitCoordinateLineColumns;
+	delete[] discretePropertyValues;
+	delete[] continuousPropertyValues;
+}
+
+void BigIjkGridExplicitRepresentationTest::readEpcDocHandler() {
+}

--- a/test/resqml2_0_1test/BigIjkGridExplicitRepresentationTest.h
+++ b/test/resqml2_0_1test/BigIjkGridExplicitRepresentationTest.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include "AbstractBigIjkGridRepresentationTest.h"
+#include <iostream>
+
+namespace common {
+	class EpcDocument;
+}
+
+namespace resqml2_0_1test {
+	class BigIjkGridExplicitRepresentationTest : public AbstractBigIjkGridRepresentationTest {
+	public:
+		static const char* defaultUuid;
+		static const char* defaultTitle;
+		static const char* discretePropertyUuid;
+		static const char* discretePropertyTitle;
+		static const char* continuousPropertyUuid;
+		static const char* continuousPropertyTitle;
+	
+		/**
+		* Creation of an explicit IJK grid representation from an EPC document path. Resulting grid is 
+		* aligned along axis (I direction along X, J direction along Y and K direction along Z). 
+		* Resulting grid carries both discrete and continuous properties on cells.
+		* At serialize() call, exising .epc file will be erased. 
+		* @param epcDocPath	the path of the .epc file (including .epc extension)
+		* @param iCount		number of cells in the I direction.
+		* @param jCount		number of cells in the J direction.
+		* @param kCount		number of cells in the K direction.
+		* @param faultCount	number of faults. Faults are parallel to YZ plane (they fit with i-interfaces). faultCount in [0; iCount[.
+		* @param xMin		minimum x value of the grid.
+		* @param xMax		maximum x value of the grid.
+		* @param yMin		minimum y value of the grid.
+		* @param yMax		maximum y value of the grid.
+		* @param zMin		minimum z value of the grid (without considering any fault throw).
+		* @param zMax		maximum z value of the grid (without considering any fault throw).
+		* @param faultThrow	lenght of the fault throw along z axis. 
+		*/
+		BigIjkGridExplicitRepresentationTest(
+			const std::string & epcDocPath,
+			const unsigned int & iCount, const unsigned int & jCount, const unsigned int & kCount, 
+			const unsigned int & faultCount, 
+			const double & xMin, const double & xMax, const double & yMin, const double & yMax, const double & zMin, const double & zMax,
+			const double & faultThrow);
+
+		/**
+		* Creation of an explicit IJK grid representation from an existing EPC document. Resulting grid is 
+		* aligned along axis (I direction along X, J direction along Y and K direction along Z).
+		* Resulting grid carries both discrete and continuous properties on cells. 
+		* @param epcDoc		an existing EPC document
+		* @param init		true if this object is created for initialization purpose else false if it is 
+		*					created for reading purpose. According to init value a iniEpcDoc() or readEpcDoc() is called.
+		* @param iCount		number of cells in the I direction.
+		* @param jCount		number of cells in the J direction.
+		* @param kCount		number of cells in the K direction.
+		* @param faultCount	number of faults. Faults are parallel to YZ plane (they fit with i-interfaces). faultCount in [0; iCount[.
+		* @param xMin		minimum x value of the grid.
+		* @param xMax		maximum x value of the grid.
+		* @param yMin		minimum y value of the grid.
+		* @param yMax		maximum y value of the grid.
+		* @param zMin		minimum z value of the grid (without considering any fault throw).
+		* @param zMax		maximum z value of the grid (without considering any fault throw).
+		* @param faultThrow	lenght of the fault throw along z axis.
+		*/
+		BigIjkGridExplicitRepresentationTest(common::EpcDocument * epcDoc, bool init,
+			const unsigned int & iCount, const unsigned int & jCount, const unsigned int & kCount,
+			const unsigned int & faultCount,
+			const double & xMin, const double & xMax, const double & yMin, const double & yMax, const double & zMin, const double & zMax,
+			const double & faultThrow);
+
+	protected:
+		void initEpcDocHandler();
+		void readEpcDocHandler();
+	};
+}

--- a/test/resqml2_0_1test/BigIjkGridExplicitRepresentationTest.h
+++ b/test/resqml2_0_1test/BigIjkGridExplicitRepresentationTest.h
@@ -33,7 +33,7 @@ namespace resqml2_0_1test {
 		* @param yMax		maximum y value of the grid.
 		* @param zMin		minimum z value of the grid (without considering any fault throw).
 		* @param zMax		maximum z value of the grid (without considering any fault throw).
-		* @param faultThrow	lenght of the fault throw along z axis. 
+		* @param faultThrow	length of the fault throw along z axis. 
 		*/
 		BigIjkGridExplicitRepresentationTest(
 			const std::string & epcDocPath,
@@ -59,7 +59,7 @@ namespace resqml2_0_1test {
 		* @param yMax		maximum y value of the grid.
 		* @param zMin		minimum z value of the grid (without considering any fault throw).
 		* @param zMax		maximum z value of the grid (without considering any fault throw).
-		* @param faultThrow	lenght of the fault throw along z axis.
+		* @param faultThrow	length of the fault throw along z axis.
 		*/
 		BigIjkGridExplicitRepresentationTest(common::EpcDocument * epcDoc, bool init,
 			const unsigned int & iCount, const unsigned int & jCount, const unsigned int & kCount,

--- a/test/resqml2_0_1test/BigIjkGridParametricRepresentationTest.h
+++ b/test/resqml2_0_1test/BigIjkGridParametricRepresentationTest.h
@@ -33,7 +33,7 @@ namespace resqml2_0_1test {
 		* @param yMax		maximum y value of the grid.
 		* @param zMin		minimum z value of the grid (without considering any fault throw).
 		* @param zMax		maximum z value of the grid (without considering any fault throw).
-		* @param faultThrow	lenght of the fault throw along z axis. 
+		* @param faultThrow	length of the fault throw along z axis. 
 		*/
 		BigIjkGridParametricRepresentationTest(
 			const std::string & epcDocPath,
@@ -59,7 +59,7 @@ namespace resqml2_0_1test {
 		* @param yMax		maximum y value of the grid.
 		* @param zMin		minimum z value of the grid (without considering any fault throw).
 		* @param zMax		maximum z value of the grid (without considering any fault throw).
-		* @param faultThrow	lenght of the fault throw along z axis.
+		* @param faultThrow	length of the fault throw along z axis.
 		*/
 		BigIjkGridParametricRepresentationTest(common::EpcDocument * epcDoc, bool init,
 			const unsigned int & iCount, const unsigned int & jCount, const unsigned int & kCount,

--- a/test/resqml2_0_1test/BigIjkGridParametricRepresentationTest.h
+++ b/test/resqml2_0_1test/BigIjkGridParametricRepresentationTest.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include "AbstractBigIjkGridRepresentationTest.h"
+#include <iostream>
+
+namespace common {
+	class EpcDocument;
+}
+
+namespace resqml2_0_1test {
+	class BigIjkGridParametricRepresentationTest : public AbstractBigIjkGridRepresentationTest {
+	public:
+		static const char* defaultUuid;
+		static const char* defaultTitle;
+		static const char* discretePropertyUuid;
+		static const char* discretePropertyTitle;
+		static const char* continuousPropertyUuid;
+		static const char* continuousPropertyTitle;
+
+		/**
+		* Creation of a parametric IJK grid representation from an EPC document path. Resulting grid is 
+		* aligned along axis (I direction along X, J direction along Y and K direction along Z). 
+		* Resulting grid carries both discrete and continuous properties on cells.
+		* At serialize() call, exising .epc file will be erased. 
+		* @param epcDocPath	the path of the .epc file (including .epc extension)
+		* @param iCount		number of cells in the I direction.
+		* @param jCount		number of cells in the J direction.
+		* @param kCount		number of cells in the K direction.
+		* @param faultCount	number of faults. Faults are parallel to YZ plane (they fit with i-interfaces). faultCount in [0; iCount[.
+		* @param xMin		minimum x value of the grid.
+		* @param xMax		maximum x value of the grid.
+		* @param yMin		minimum y value of the grid.
+		* @param yMax		maximum y value of the grid.
+		* @param zMin		minimum z value of the grid (without considering any fault throw).
+		* @param zMax		maximum z value of the grid (without considering any fault throw).
+		* @param faultThrow	lenght of the fault throw along z axis. 
+		*/
+		BigIjkGridParametricRepresentationTest(
+			const std::string & epcDocPath,
+			const unsigned int & iCount, const unsigned int & jCount, const unsigned int & kCount, 
+			const unsigned int & faultCount, 
+			const double & xMin, const double & xMax, const double & yMin, const double & yMax, const double & zMin, const double & zMax,
+			const double & faultThrow);
+
+		/**
+		* Creation of a parametric IJK grid representation from an existing EPC document. Resulting grid is 
+		* aligned along axis (I direction along X, J direction along Y and K direction along Z).
+		* Resulting grid carries both discrete and continuous properties on cells. 
+		* @param epcDoc		an existing EPC document
+		* @param init		true if this object is created for initialization purpose else false if it is 
+		*					created for reading purpose. According to init value a iniEpcDoc() or readEpcDoc() is called.
+		* @param iCount		number of cells in the I direction.
+		* @param jCount		number of cells in the J direction.
+		* @param kCount		number of cells in the K direction.
+		* @param faultCount	number of faults. Faults are parallel to YZ plane (they fit with i-interfaces). faultCount in [0; iCount[.
+		* @param xMin		minimum x value of the grid.
+		* @param xMax		maximum x value of the grid.
+		* @param yMin		minimum y value of the grid.
+		* @param yMax		maximum y value of the grid.
+		* @param zMin		minimum z value of the grid (without considering any fault throw).
+		* @param zMax		maximum z value of the grid (without considering any fault throw).
+		* @param faultThrow	lenght of the fault throw along z axis.
+		*/
+		BigIjkGridParametricRepresentationTest(common::EpcDocument * epcDoc, bool init,
+			const unsigned int & iCount, const unsigned int & jCount, const unsigned int & kCount,
+			const unsigned int & faultCount,
+			const double & xMin, const double & xMax, const double & yMin, const double & yMax, const double & zMin, const double & zMax,
+			const double & faultThrow);
+
+	protected:
+		void initEpcDocHandler();
+		void readEpcDocHandler();
+	private:
+		/**
+		* Initialize generated grid parameters and control points.
+		* @param parameters Properly allocated output parameter.
+		* @param controlPoints Properly allocated output parameter.
+		*/
+		void initParametersAndControlPoints(double * parameters, double * controlPoints);
+	};
+}

--- a/test/unitTest.cpp
+++ b/test/unitTest.cpp
@@ -31,6 +31,8 @@
 #include "resqml2_0_1test/DiscretePropertyUsingLocalKindOnWellFrameTest.h"
 #include "resqml2_0_1test/HorizonOnSeismicLine.h"
 #include "resqml2_0_1test/RightHanded4x3x2ExplicitIjkGrid.h"
+#include "resqml2_0_1test/BigIjkGridExplicitRepresentationTest.h"
+#include "resqml2_0_1test/BigIjkGridParametricRepresentationTest.h"
 #include "resqml2_0_1test/SubRepresentationOnPartialGridConnectionSet.h"
 #include "resqml2_0_1test/LgrOnRightHanded4x3x2ExplicitIjkGrid.h"
 #include "resqml2_0_1test/InterpretationDomain.h"
@@ -72,6 +74,22 @@ FESAPI_TEST("Export and import a generic creation activity template", "[activity
 FESAPI_TEST("Export and import an activity", "[activity]", ActivityCreationTest)
 
 FESAPI_TEST("Export and import a 4*3*2 explicit right handed ijk grid", "[grid]", RightHanded4x3x2ExplicitIjkGrid)
+
+TEST_CASE("Export and import a big explicit ijk grid", "[grid][property]")
+{
+	BigIjkGridExplicitRepresentationTest* test = new BigIjkGridExplicitRepresentationTest("../../BigIjkGridExplicitRepresentationTest.epc", 10, 10, 5, 9, 0., 100., 0., 100., 0., 50., 10);
+	test->serialize();
+	test->deserialize();
+	delete test;
+}
+
+TEST_CASE("Export and import a big parametric ijk grid", "[grid][property]")
+{
+	BigIjkGridParametricRepresentationTest* test = new BigIjkGridParametricRepresentationTest("../../BigIjkGridParametricRepresentationTest.epc", 20, 20, 10, 10, 0., 100., 0., 100., 0., 50., 10);
+	test->serialize();
+	test->deserialize();
+	delete test;
+}
 
 FESAPI_TEST("Export and import a LGR on a 4*3*2 explicit right handed ijk grid", "[grid]", LgrOnRightHanded4x3x2ExplicitIjkGrid)
 


### PR DESCRIPTION
Hi,

Here is a pull request adding big IJK grid generation capabilities within fesapi unit tests.

Regards,
Mathieu

What does this implement/fix? Explain your changes.
---------------------------------------------------
Test classes have been added to generate some big explicit and parametric IJK grids. Some parameters allow user to tune the size and shape of these grids. Each generated grid carries one discrete and one continuous property. 

Does this close any currently open issues?
------------------------------------------
No.

Any relevant logs, error output, etc?
-------------------------------------
Output grids are located at root of the fesapi build directory.

Any other comments?
-------------------
Entry point for looking at these new features: test cases "Export and import a big explicit ijk grid" and "Export and import a big parametric ijk grid" (lines 78 and 86 of unitTest.cpp).

Where has this been tested?
---------------------------
Operating System: Windows 10 64bits

Platform: Visual Studio Community 2015