### PR TITLE
Corrected dataset name typo for compressed "elements" dataset.

### DIFF
--- a/src/common/HdfProxy.cpp
+++ b/src/common/HdfProxy.cpp
@@ -407,7 +407,7 @@ void HdfProxy::writeItemizedListOfList(const string & groupName,
 		H5Pset_deflate (dcpl, compressionLevel);
 		H5Pset_chunk (dcpl, 1, &elementsSize);
 
-		datasetE = H5Dcreate(grp, CUMULATIVE_LENGTH_DS_NAME, elementsDatatype, fspaceE, H5P_DEFAULT, dcpl, H5P_DEFAULT);
+		datasetE = H5Dcreate(grp, ELEMENTS_DS_NAME, elementsDatatype, fspaceE, H5P_DEFAULT, dcpl, H5P_DEFAULT);
 
 		H5Pclose(dcpl);
 	}


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------

I was working with an extremely sparse dataset and found that if I turned on HDF5 compression, I could not read back the RESQML export afterwards.  Turns out that the "elements" HDF5 dataset was missing from the ijkGridRepresentation's ColumnsPerSplitCoordinateLine group.

I eventually found a typo in HdfProxy.cpp where the dataset name had apparently been copied from the previous group for the compressed case.

Does this close any currently open issues?
------------------------------------------

Not that I could find.


Any relevant logs, error output, etc?
-------------------------------------

No.

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
Windows 10, VS2015

Current git master of fesapi
