### PR TITLE
Fix #30

### DIFF
--- a/src/resqml2/AbstractLocal3dCrs.cpp
+++ b/src/resqml2/AbstractLocal3dCrs.cpp
@@ -297,3 +297,12 @@ gsoap_resqml2_0_1::eml20__AxisOrder2d AbstractLocal3dCrs::getAxisOrder() const
 	}
 }
 
+void AbstractLocal3dCrs::setAxisOrder(const gsoap_resqml2_0_1::eml20__AxisOrder2d & axisOrder) const
+{
+	if (gsoapProxy2_0_1 != nullptr) {
+		static_cast<gsoap_resqml2_0_1::resqml2__AbstractLocal3dCrs*>(gsoapProxy2_0_1)->ProjectedAxisOrder = axisOrder;
+	}
+	else {
+		throw logic_error("Not implemented yet");
+	}
+}

--- a/src/resqml2/AbstractLocal3dCrs.h
+++ b/src/resqml2/AbstractLocal3dCrs.h
@@ -153,6 +153,11 @@ namespace resqml2
 		*/
 		gsoap_resqml2_0_1::eml20__AxisOrder2d getAxisOrder() const;
 
+		/**
+		* Set the axis order of the projected Crs
+		*/
+		void setAxisOrder(const gsoap_resqml2_0_1::eml20__AxisOrder2d & axisOrder) const;
+
 		void convertXyzPointsToGlobalCrs(double * xyzPoints, const ULONG64 & xyzPointCount, bool withoutTranslation = false) const;
 
 	protected:

--- a/src/resqml2_0_1/LocalDepth3dCrs.cpp
+++ b/src/resqml2_0_1/LocalDepth3dCrs.cpp
@@ -42,6 +42,7 @@ void LocalDepth3dCrs::init(soap* soapContext, const std::string & guid, const st
 	local3dCrs->ArealRotation = soap_new_eml20__PlaneAngleMeasure(gsoapProxy2_0_1->soap, 1);
 	local3dCrs->ArealRotation->__item = arealRotation;
 	local3dCrs->ArealRotation->uom = eml20__PlaneAngleUom__rad;
+	local3dCrs->ProjectedAxisOrder = eml20__AxisOrder2d__easting_x0020northing;
 	local3dCrs->XOffset = originOrdinal1;
 	local3dCrs->YOffset = originOrdinal2;
 	local3dCrs->ZOffset = originOrdinal3;

--- a/src/resqml2_0_1/LocalDepth3dCrs.h
+++ b/src/resqml2_0_1/LocalDepth3dCrs.h
@@ -83,7 +83,7 @@ namespace resqml2_0_1
 			const gsoap_resqml2_0_1::eml20__LengthUom & verticalUom, const std::string & verticalUnknownReason, const bool & isUpOriented);
 
 		/**
-		* Creates a local depth 3d CRS which is identified by an EPSG code for its projected part and which is unkown for its vertial part.
+		* Creates a local depth 3d CRS which is identified by an EPSG code for its projected part and which is unkown for its vertical part.
 		* @param soapContext			The soap context where the underlying gsoap proxy is going to be created.
 		* @param guid					The guid to set to the local 3d crs. If empty then a new guid will be generated.
 		* @param title					A title for the instance to create.

--- a/src/resqml2_0_1/LocalTime3dCrs.cpp
+++ b/src/resqml2_0_1/LocalTime3dCrs.cpp
@@ -43,6 +43,7 @@ void LocalTime3dCrs::init(soap* soapContext, const std::string & guid, const std
 	local3dCrs->ArealRotation = soap_new_eml20__PlaneAngleMeasure(gsoapProxy2_0_1->soap, 1);
 	local3dCrs->ArealRotation->__item = arealRotation;
 	local3dCrs->ArealRotation->uom = eml20__PlaneAngleUom__rad;
+	local3dCrs->ProjectedAxisOrder = eml20__AxisOrder2d__easting_x0020northing;
 	local3dCrs->XOffset = originOrdinal1;
 	local3dCrs->YOffset = originOrdinal2;
 	local3dCrs->ZOffset = originOrdinal3;

--- a/swig/swigResqml2Include.i
+++ b/swig/swigResqml2Include.i
@@ -176,7 +176,9 @@ namespace resqml2
 		std::string getProjectedCrsUnitAsString() const;
 		gsoap_resqml2_0_1::eml20__LengthUom getVerticalCrsUnit() const;
 		std::string getVerticalCrsUnitAsString() const;
+		
 		gsoap_resqml2_0_1::eml20__AxisOrder2d getAxisOrder() const;
+		void setAxisOrder(const gsoap_resqml2_0_1::eml20__AxisOrder2d & axisOrder) const;
 	};
 	
 	class MdDatum : public common::AbstractObject


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- Explicitely set the default axis order to easting northing at Local 3d crs construction time.
- Allow to set it whenever the user wants

Does this close any currently open issues?
------------------------------------------
#30 


Any relevant logs, error output, etc?
-------------------------------------
no

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Operating System:** … vs 2013
**Platform:** Win 10 x64
