### PR TITLE
Fix #23

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,11 @@ compiler:
 script: cmake
 install:
   - sudo apt-get install uuid-dev
+  - sudo apt-get install libminizip-dev
   - mkdir ../dependencies
   - cd ../dependencies
   - wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8/hdf5-1.8.18/bin/linux-centos7-x86_64-gcc485-noszip/hdf5-1.8.18-linux-centos7-x86_64-gcc485-noszip-shared.tar.gz
   - tar -xzvf hdf5-1.8.18-linux-centos7-x86_64-gcc485-noszip-shared.tar.gz
-  - wget https://github.com/F2I-Consulting/minizip/releases/download/v1.0.0.0/minizip-1.0.0.0-linux-ubuntu1604-x86_64-gcc540.tar.gz
-  - tar -xzvf minizip-1.0.0.0-linux-ubuntu1604-x86_64-gcc540.tar.gz
   - mkdir ../build
   - cd ../build
 script:
@@ -21,8 +20,8 @@ script:
     -DUUID_LIBRARY_RELEASE=/usr/lib/x86_64-linux-gnu/libuuid.so
     -DHDF5_C_INCLUDE_DIR=$TRAVIS_BUILD_DIR/../dependencies/hdf5-1.8.18-linux-centos7-x86_64-gcc485-noszip-shared/include
     -DHDF5_C_LIBRARY_RELEASE=$TRAVIS_BUILD_DIR/../dependencies/hdf5-1.8.18-linux-centos7-x86_64-gcc485-noszip-shared/lib/libhdf5.so
-    -DMINIZIP_INCLUDE_DIR=$TRAVIS_BUILD_DIR/../dependencies/minizip-1.0.0.0-linux-ubuntu1604-x86_64-gcc540/include
-    -DMINIZIP_LIBRARY_RELEASE=$TRAVIS_BUILD_DIR/../dependencies/minizip-1.0.0.0-linux-ubuntu1604-x86_64-gcc540/lib/libminizip.a
+    -DMINIZIP_INCLUDE_DIR=/usr/include/minizip
+    -DMINIZIP_LIBRARY_RELEASE=/usr/lib/x86_64-linux-gnu/libminizip.a
     $TRAVIS_BUILD_DIR
   - make
   - ./example/example

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ install:
   - mkdir ../dependencies
   - cd ../dependencies
   - wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8/hdf5-1.8.18/bin/linux-centos7-x86_64-gcc485-noszip/hdf5-1.8.18-linux-centos7-x86_64-gcc485-noszip-shared.tar.gz
-  - tar -xzvf hdf5-1.8.18-linux-centos7-x86_64-gcc485-noszip-shared.tar.gz
+  - tar -xzf hdf5-1.8.18-linux-centos7-x86_64-gcc485-noszip-shared.tar.gz
+  - wget https://github.com/F2I-Consulting/Minizip/releases/download/1.1/minizip-1.1-linux-ubuntu1604-x86_64-gcc540.tar.gz
+  - tar -xzf minizip-1.1-linux-ubuntu1604-x86_64-gcc540.tar.gz
   - mkdir ../build
   - cd ../build
 script:
@@ -19,8 +21,8 @@ script:
     -DUUID_LIBRARY_RELEASE=/usr/lib/x86_64-linux-gnu/libuuid.so
     -DHDF5_C_INCLUDE_DIR=$TRAVIS_BUILD_DIR/../dependencies/hdf5-1.8.18-linux-centos7-x86_64-gcc485-noszip-shared/include
     -DHDF5_C_LIBRARY_RELEASE=$TRAVIS_BUILD_DIR/../dependencies/hdf5-1.8.18-linux-centos7-x86_64-gcc485-noszip-shared/lib/libhdf5.so
-    -DMINIZIP_INCLUDE_DIR=/usr/include/minizip
-    -DMINIZIP_LIBRARY_RELEASE=/usr/lib/x86_64-linux-gnu/libminizip.a
+    -DMINIZIP_INCLUDE_DIR=$TRAVIS_BUILD_DIR/../dependencies/minizip-1.1-linux-ubuntu1604-x86_64-gcc540/include
+    -DMINIZIP_LIBRARY_RELEASE=$TRAVIS_BUILD_DIR/../dependencies/minizip-1.1-linux-ubuntu1604-x86_64-gcc540/lib/libminizip.a
     $TRAVIS_BUILD_DIR
   - make
   - ./example/example

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ compiler:
 script: cmake
 install:
   - sudo apt-get install uuid-dev
-  - sudo apt-get install libminizip-dev
   - mkdir ../dependencies
   - cd ../dependencies
   - wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8/hdf5-1.8.18/bin/linux-centos7-x86_64-gcc485-noszip/hdf5-1.8.18-linux-centos7-x86_64-gcc485-noszip-shared.tar.gz

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # Prepare your build environment
  - Create a folder called fesapiEnv.
  - In this folder create the three following folders
@@ -7,7 +8,7 @@
 # Prepare the dependencies
 Download (build and install if necessary) third party libraries:
 - HDF5: All versions of 1.8.* starting from 1.8.18 should be ok. Versions 1.10.* are not supported yet (even if they should work) https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8/
-- MINIZIP : the following version is recommended https://github.com/F2I-Consulting/minizip It is also highly recommended to link minzip to the same zlib library than the one associated to your HDF5 library. From this source code, it is recommended to create a *static* library of minizip dynamically linked to the same zlib library than the one used for the hdf5 library.
+- MINIZIP : Version 1.1 is needed : it is the official version included in current zlib distribution https://www.zlib.net/ (look into "contrib" folder). You can directly install minizip developement package on most of Linux distributions. On Windows, you can copy the CMakeLists.txt file from fesapi/cmake/minizip to the minizip directory to help you to build minizip (or we provide a copy of minizip 1.1 with cmake files on github : https://github.com/F2I-Consulting/Minizip). It is also highly recommended to link minizip to the same zlib library than the one associated to your HDF5 library.
 - UUID-DEV package *(ONLY FOR LINUX)* : Source code can be found in https://www.kernel.org/pub/linux/utils/util-linux/
 
 We advise you to install these third party libraries respectively into
@@ -28,7 +29,7 @@ Fesapi uses cmake as its build tool. A 3.2 version or later of cmake is required
 	- MINIZIP
 		- MINIZIP_INCLUDE_DIR : where the HDF5 headers are located
 		- MINIZIP_LIBRARY_RELEASE : the MINIZIP library you want to link to
-	- ZLIB (It is most of time required since fesapi is supposed to be statically linked to minizip which should be dynamically linked to zlib. It is also required if fesapi is statically linked to hdf5 and if hdf5 is dynamically linked to zlib.)
+	- ZLIB (It is most of time required since fesapi is often statically linked to minizip which is often dynamically linked to zlib. It is also required if fesapi is statically linked to hdf5 and if hdf5 is dynamically linked to zlib.)
 		- ZLIB_LIBRARY_RELEASE : the ZLIB library you want to link to. It must be the same as the one which is linked to HDF5 library and MINIZIP library otherwise you will get a warning from CMake. This warning can be ignored most of time but it can really create unpredictable bugs in some circumstances.
 	- SZIP (it is only required when you statically link to HDF5 AND when HDF5 has been built using SZIP)
 		- SZIP_LIBRARY_RELEASE : the SZIP library you want to link to. This warning can be ignored most of time but it can really create unpredictable bugs in some circumstances (static linking to HDF5 with HDF5 making use of szip).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 # Prepare the dependencies
 Download (build and install if necessary) third party libraries:
 - HDF5: All versions of 1.8.* starting from 1.8.18 should be ok. Versions 1.10.* are not supported yet (even if they should work) https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8/
-- MINIZIP : Version 1.1 is needed : it is the official version included in current zlib distribution https://www.zlib.net/ (look into "contrib" folder). You can directly install minizip developement package on most of Linux distributions. On Windows, you can copy the CMakeLists.txt file from fesapi/cmake/minizip to the minizip directory to help you to build minizip (or we provide a copy of minizip 1.1 with cmake files on github : https://github.com/F2I-Consulting/Minizip). It is also highly recommended to link minizip to the same zlib library than the one associated to your HDF5 library.
+- MINIZIP : Version 1.1 is needed : it is the official version included in current zlib distribution https://www.zlib.net/ (look into "contrib" folder). You can directly install minizip development package on most of Linux distributions (https://packages.ubuntu.com/xenial/libminizip-dev). On Windows (or older Linux distributions), you can copy the CMakeLists.txt file from fesapi/cmake/minizip to the zlib minizip directory to help you to build minizip (we also provide a copy of minizip 1.1 with cmake files on github : https://github.com/F2I-Consulting/Minizip). It is also highly recommended to link minizip to the same zlib library than the one associated to your HDF5 library.
 - UUID-DEV package *(ONLY FOR LINUX)* : Source code can be found in https://www.kernel.org/pub/linux/utils/util-linux/
 
 We advise you to install these third party libraries respectively into

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,7 +40,7 @@ install:
   - 7z x hdf5-1.8.18-win64-vs2013-noszip.zip -oC:\projects\fesapiEnv\dependencies > nul
   - msiexec.exe /i "C:\projects\fesapiEnv\dependencies\hdf5\HDF5-1.8.18-win64.msi" /qn INSTALL_ROOT=C:\projects\fesapiEnv\dependencies\hdf5-1.8.18-win64-vs2013-noszip
   - appveyor DownloadFile https://github.com/F2I-Consulting/Minizip/releases/download/1.1/minizip-1.1-win64-vs2013-static.zip
-  - 7z x minizip-1.1-win64-vs2013.zip -oC:\projects\fesapiEnv\dependencies > nul
+  - 7z x minizip-1.1-win64-vs2013-static.zip -oC:\projects\fesapiEnv\dependencies > nul
   - appveyor DownloadFile http://prdownloads.sourceforge.net/swig/swigwin-3.0.12.zip
   - 7z x swigwin-3.0.12.zip -oC:\projects\fesapiEnv\dependencies > nul
   - cd ..

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,8 +39,8 @@ install:
   - appveyor DownloadFile https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8/hdf5-1.8.18/bin/windows/noszip/hdf5-1.8.18-win64-vs2013-noszip.zip
   - 7z x hdf5-1.8.18-win64-vs2013-noszip.zip -oC:\projects\fesapiEnv\dependencies > nul
   - msiexec.exe /i "C:\projects\fesapiEnv\dependencies\hdf5\HDF5-1.8.18-win64.msi" /qn INSTALL_ROOT=C:\projects\fesapiEnv\dependencies\hdf5-1.8.18-win64-vs2013-noszip
-  - appveyor DownloadFile https://github.com/F2I-Consulting/minizip/releases/download/v1.0.0.0/minizip-1.0.0.0-win64-vs2013.zip
-  - 7z x minizip-1.0.0.0-win64-vs2013.zip -oC:\projects\fesapiEnv\dependencies > nul
+  - appveyor DownloadFile https://github.com/F2I-Consulting/Minizip/releases/download/1.1/minizip-1.1-win64-vs2013-static.zip
+  - 7z x minizip-1.1-win64-vs2013.zip -oC:\projects\fesapiEnv\dependencies > nul
   - appveyor DownloadFile http://prdownloads.sourceforge.net/swig/swigwin-3.0.12.zip
   - 7z x swigwin-3.0.12.zip -oC:\projects\fesapiEnv\dependencies > nul
   - cd ..
@@ -77,8 +77,8 @@ before_build:
     -DHDF5_BUILT_AS_DYNAMIC_LIB=TRUE
     -DHDF5_C_INCLUDE_DIR=c:/projects/fesapiEnv/dependencies/hdf5-1.8.18-win64-vs2013-noszip/include
     -DHDF5_C_LIBRARY_RELEASE=c:/projects/fesapiEnv/dependencies/hdf5-1.8.18-win64-vs2013-noszip/lib/hdf5.lib
-    -DMINIZIP_INCLUDE_DIR=c:/projects/fesapiEnv/dependencies/minizip-1.0.0.0-win64-vs2013/include
-    -DMINIZIP_LIBRARY_RELEASE=c:/projects/fesapiEnv/dependencies/minizip-1.0.0.0-win64-vs2013/lib/minizip.lib
+    -DMINIZIP_INCLUDE_DIR=c:/projects/fesapiEnv/dependencies/minizip-1.1-win64-vs2013/include
+    -DMINIZIP_LIBRARY_RELEASE=c:/projects/fesapiEnv/dependencies/minizip-1.1-win64-vs2013/lib/minizip.lib
     -DZLIB_LIBRARY_RELEASE=c:/projects/fesapiEnv/dependencies/hdf5-1.8.18-win64-vs2013-noszip/lib/zlib.lib
     -DWITH_DOTNET_WRAPPING=TRUE
     -DSWIG_EXECUTABLE=c:/projects/fesapiEnv/dependencies/swigwin-3.0.12/swig.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -77,8 +77,8 @@ before_build:
     -DHDF5_BUILT_AS_DYNAMIC_LIB=TRUE
     -DHDF5_C_INCLUDE_DIR=c:/projects/fesapiEnv/dependencies/hdf5-1.8.18-win64-vs2013-noszip/include
     -DHDF5_C_LIBRARY_RELEASE=c:/projects/fesapiEnv/dependencies/hdf5-1.8.18-win64-vs2013-noszip/lib/hdf5.lib
-    -DMINIZIP_INCLUDE_DIR=c:/projects/fesapiEnv/dependencies/minizip-1.1-win64-vs2013/include
-    -DMINIZIP_LIBRARY_RELEASE=c:/projects/fesapiEnv/dependencies/minizip-1.1-win64-vs2013/lib/minizip.lib
+    -DMINIZIP_INCLUDE_DIR=c:/projects/fesapiEnv/dependencies/minizip-1.1-win64-vs2013-static/include
+    -DMINIZIP_LIBRARY_RELEASE=c:/projects/fesapiEnv/dependencies/minizip-1.1-win64-vs2013-static/lib/minizip.lib
     -DZLIB_LIBRARY_RELEASE=c:/projects/fesapiEnv/dependencies/hdf5-1.8.18-win64-vs2013-noszip/lib/zlib.lib
     -DWITH_DOTNET_WRAPPING=TRUE
     -DSWIG_EXECUTABLE=c:/projects/fesapiEnv/dependencies/swigwin-3.0.12/swig.exe

--- a/cmake/minizip/CMakeLists.txt
+++ b/cmake/minizip/CMakeLists.txt
@@ -1,0 +1,69 @@
+CMAKE_MINIMUM_REQUIRED (VERSION 2.6)
+
+PROJECT (minizip)
+
+SET (MINIZIP_ROOT_DIR ${CMAKE_SOURCE_DIR})
+SET (MINIZIP_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
+GET_FILENAME_COMPONENT (MINIZIP_PARENT_DIR ${CMAKE_CURRENT_SOURCE_DIR} DIRECTORY)
+
+# setting header and source files into HEADERS
+file(GLOB_RECURSE SOURCE_FILES ${MINIZIP_ROOT_DIR}/*.c)
+file(GLOB_RECURSE HEADER_FILES ${MINIZIP_ROOT_DIR}/*.h)
+
+SET (CMAKE_INSTALL_PREFIX ${MINIZIP_BINARY_DIR}/install CACHE PATH "Minizip install prefix" FORCE)
+
+# Zlib
+FIND_PACKAGE (ZLIB)
+MARK_AS_ADVANCED(CLEAR ZLIB_LIBRARY_RELEASE)
+IF (NOT EXISTS ${ZLIB_LIBRARY_RELEASE})
+	MESSAGE(WARNING "The zlib library (ZLIB_LIBRARY_RELEASE variable) does not look to be a valid file. Please modify it.")
+ENDIF ()
+IF (NOT IS_DIRECTORY ${ZLIB_INCLUDE_DIR})
+	MESSAGE(WARNING "The zlib include dir (ZLIB_INCLUDE_DIR variable) does not look to be a valid directory. Please modify it.")
+ENDIF ()
+
+	include_directories( ${ZLIB_INCLUDE_DIR} )
+
+IF (UNIX)
+
+	list(REMOVE_ITEM HEADER_FILES ${MINIZIP_ROOT_DIR}/iowin32.h)
+	list(REMOVE_ITEM SOURCE_FILES ${MINIZIP_ROOT_DIR}/iowin32.c)
+
+ELSEIF (WIN32)
+
+# on Windows checking if the target architecture is 32 bits or 64 bits
+	STRING (FIND ${CMAKE_GENERATOR} 64 POS)
+	IF (POS EQUAL -1) 
+		#SET (ARCHITECTURE "x86" CACHE STRING "Set dependencies to "x64" (resp. "x86") default values")
+		SET (ARCHITECTURE "x86")
+	ELSE (POS EQUAL -1)
+		#SET (ARCHITECTURE "x64" CACHE STRING "Set dependencies to "x64" (resp. "x86") default values")
+		SET (ARCHITECTURE "x64")
+	ENDIF (POS EQUAL -1)
+
+ENDIF (UNIX)
+
+ADD_LIBRARY(minizip STATIC ${SOURCE_FILES})
+TARGET_LINK_LIBRARIES (minizip ${ZLIB_LIBRARY_RELEASE})
+
+#-----------------------------------------------------------------------------
+#
+# To fix compilation problem: relocation R_X86_64_32 against `a local symbol' can not be
+# used when making a shared object; recompile with -fPIC
+# See http://www.cmake.org/pipermail/cmake/2007-May/014350.html
+#
+IF (UNIX)
+	SET_TARGET_PROPERTIES(minizip PROPERTIES COMPILE_FLAGS "-fPIC")
+ENDIF (UNIX)
+
+INSTALL (
+	TARGETS minizip
+	DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
+)
+
+# headers
+INSTALL (
+	FILES ${HEADER_FILES}
+	DESTINATION ${CMAKE_INSTALL_PREFIX}/include
+)
+

--- a/src/epc/Package.cpp
+++ b/src/epc/Package.cpp
@@ -257,11 +257,11 @@ std::vector<std::string> Package::openForReading(const std::string & pkgPathName
 #endif
 
     char current_filename[UNZ_MAXFILENAMEINZIP+1];
-	int err = unzGoToFirstFile2(d_ptr->unzipped, nullptr, current_filename, sizeof(current_filename) - 1, nullptr, 0, nullptr, 0);
+	int err = unzGoToFirstFile(d_ptr->unzipped);
     while (err == UNZ_OK)
     {
 		d_ptr->name2file[current_filename] = *(unz64_s*)d_ptr->unzipped;
-		err = unzGoToNextFile2(d_ptr->unzipped, nullptr, current_filename, sizeof(current_filename) - 1, nullptr, 0, nullptr, 0);
+		err = unzGoToNextFile(d_ptr->unzipped);
     }
 #endif
 
@@ -598,7 +598,7 @@ void Package::writePackage()
 	}
 
 	// Close the zip archive
-	int err = zipClose(d_ptr->zf, nullptr, d_ptr->isZip64);
+	int err = zipClose(d_ptr->zf, "");
 	if (err != ZIP_OK) {
 		throw invalid_argument("Could not close " + d_ptr->pathName.substr(0, d_ptr->pathName.size() - 4));
 	}


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Too many people wonder what and where is the minizip library to be used with fesapi.
Furthermore, the current minizip library was a github one which has been removed now. We don't know so much the source and it is not maintained.

Does this close any currently open issues?
------------------------------------------
Fix #23 

Any relevant logs, error output, etc?
-------------------------------------


Any other comments?
-------------------
We know that it may exist an error with the zlib minizip version and MS OPC. Details are given in comment of #23

Where has this been tested?
---------------------------
**Operating System:** Win 10 64 bit

**Platform:** vs 2013 x64
