### PR TITLE
Fixed VS2017 compiler warnings

### DIFF
--- a/src/resqml2_0_1/PolylineSetRepresentation.cpp
+++ b/src/resqml2_0_1/PolylineSetRepresentation.cpp
@@ -338,7 +338,7 @@ bool PolylineSetRepresentation::areAllPolylinesClosedOfPatch(const unsigned int 
 		{
 			unsigned int* tmp = new unsigned int[polylineCount];
 			hdfProxy->readArrayNdOfUIntValues(static_cast<resqml2__BooleanHdf5Array*>(patch->ClosedPolylines)->Values->PathInHdfFile, tmp);
-			if (find(tmp, tmp + polylineCount, 0) != tmp + polylineCount)
+			if (find(tmp, tmp + polylineCount, 0u) != tmp + polylineCount)
 				result = false;
 			delete [] tmp;
 		}
@@ -354,7 +354,7 @@ bool PolylineSetRepresentation::areAllPolylinesClosedOfPatch(const unsigned int 
 		{
 			unsigned long* tmp = new unsigned long[polylineCount];
 			hdfProxy->readArrayNdOfULongValues(static_cast<resqml2__BooleanHdf5Array*>(patch->ClosedPolylines)->Values->PathInHdfFile, tmp);
-			if (find(tmp, tmp + polylineCount, 0) != tmp + polylineCount)
+			if (find(tmp, tmp + polylineCount, 0u) != tmp + polylineCount)
 				result = false;
 			delete [] tmp;
 		}


### PR DESCRIPTION


What does this implement/fix? Explain your changes.
---------------------------------------------------

Just fixing two very minor type mismatch warnings (C4389) from our VS2017 builds.


Does this close any currently open issues?
------------------------------------------
no


Any relevant logs, error output, etc?
-------------------------------------
 C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Tools\MSVC\14.12.25827\include\xutility(3481): warning C4389: '==': signed/unsigned mismatch (compiling source file .\resqml2_0_1\PolylineSetRepresentation.cpp)
C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Tools\MSVC\14.12.25827\include\xutility(3494): note: see reference to function template instantiation '_InIt std::_Find_unchecked1<_InIt,_Ty>(_InIt,_InIt,const _Ty &,std::false_type)' being compiled
        with
        [
            _InIt=unsigned int *,
            _Ty=int
        ] (compiling source file .\resqml2_0_1\PolylineSetRepresentation.cpp)
C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Tools\MSVC\14.12.25827\include\xutility(3503): note: see reference to function template instantiation '_InIt std::_Find_unchecked<_Iter,_Ty>(_InIt,_InIt,const _Ty &)' being compiled
        with
        [
            _InIt=unsigned int *,
            _Iter=unsigned int *,
            _Ty=int
        ] (compiling source file .\resqml2_0_1\PolylineSetRepresentation.cpp)
.\resqml2_0_1\PolylineSetRepresentation.cpp(356): note: see reference to function template instantiation '_InIt *std::find<unsigned int*,int>(_InIt,_InIt,const _Ty &)' being compiled
        with
        [
            _InIt=unsigned int *,
            _Ty=int
        ]

Any other comments?
-------------------
FYI These are the only warnings encountered in our VS2017 experimental build.

Where has this been tested?
---------------------------
**Operating System:**  Windows 10

**Platform:**  VS2017
