### PR TITLE
An hdf5 uuid file attribute can block the import

### DIFF
--- a/example/example.cpp
+++ b/example/example.cpp
@@ -1478,12 +1478,14 @@ void showAllProperties(RESQML2_NS::AbstractRepresentation * rep, bool* enabledCe
 				std::cout << "\tFirst value is " << values[0] << endl;
 				std::cout << "\tSecond value is " << values[1] << endl;
 
-				for (size_t cellIndex = 0; cellIndex < valueCount; ++cellIndex) {
-					if (enabledCells != nullptr && !enabledCells[cellIndex]) {
-						continue;
-					}
-					if (values[cellIndex] > maxValue || values[cellIndex] < minValue) {
-						std::cerr << "\tERROR of min max range on : cell " << cellIndex << " has value " << values[cellIndex] << endl;
+				if (continuousProp->getElementCountPerValue() == 1) {
+					for (size_t cellIndex = 0; cellIndex < valueCount; ++cellIndex) {
+						if (enabledCells != nullptr && !enabledCells[cellIndex]) {
+							continue;
+						}
+						if (values[cellIndex] > maxValue || values[cellIndex] < minValue) {
+							std::cerr << "\tERROR of min max range on : cell " << cellIndex << " has value " << values[cellIndex] << endl;
+						}
 					}
 				}
 

--- a/src/common/HdfProxy.cpp
+++ b/src/common/HdfProxy.cpp
@@ -1076,10 +1076,14 @@ std::string HdfProxy::readStringAttribute(const std::string & obj_name,
 	if (atype < 0) {
 		throw invalid_argument("Cannot read the type of the \"" + attr_name + "\" attribute of \"" + obj_name + "\".");
 	}
-	size_t aSize = H5Tget_size(atype);
+	const size_t aSize = H5Tget_size(atype);
 	char* buf = nullptr;
 	if (H5Tis_variable_str(atype) <= 0) {
-		buf = new char[aSize];
+		const hid_t attDs = H5Aget_space(uuidAtt);
+		const hssize_t stringCount = H5Sget_simple_extent_npoints(attDs);
+		buf = new char[aSize * stringCount];
+		H5Sclose(attDs);
+
 	} // else buf is allocated directly by HDF5
 	hid_t readingError = H5Aread(uuidAtt, atype, buf);
 	if (readingError < 0) {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
If a HDF5 string attribute is actually an array of strings, fesapi crashes.
With this PR, it no more crashes.

Does this close any currently open issues?
------------------------------------------
Fix #45 

Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Operating System:** Win 64 home 64 bits

**Platform:** vs2013 64 bits
