### PR TITLE
Can get all grid 2d representations from Epc Document

### DIFF
--- a/src/common/EpcDocument.cpp
+++ b/src/common/EpcDocument.cpp
@@ -282,6 +282,8 @@ const std::vector<RESQML2_0_1_NS::TectonicBoundaryFeature*> & EpcDocument::getFr
 
 const std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation*> & EpcDocument::getAllTriangulatedSetRepSet() const { return triangulatedSetRepresentationSet; }
 
+const std::vector<resqml2_0_1::Grid2dRepresentation*> & EpcDocument::getAllGrid2dRepresentationSet() const { return grid2dRepresentationSet; }
+
 const std::vector<RESQML2_0_1_NS::SeismicLineFeature*> & EpcDocument::getSeismicLineSet() const { return seismicLineSet; }
 
 const std::vector<RESQML2_0_1_NS::WellboreFeature*> & EpcDocument::getWellboreSet() const { return wellboreSet; }
@@ -408,6 +410,7 @@ void EpcDocument::close()
 	representationSetRepresentationSet.clear();
 	witsmlTrajectorySet.clear();
 	triangulatedSetRepresentationSet.clear();
+	grid2dRepresentationSet.clear();
 	polylineRepresentationSet.clear();
 	ijkGridRepresentationSet.clear();
 	unstructuredGridRepresentationSet.clear();
@@ -547,6 +550,9 @@ void EpcDocument::addGsoapProxy(COMMON_NS::AbstractObject* proxy)
 	}
 	else if (xmlTag.compare(TriangulatedSetRepresentation::XML_TAG) == 0) {
 		triangulatedSetRepresentationSet.push_back(static_cast<TriangulatedSetRepresentation* const>(proxy));
+	}
+	else if (xmlTag.compare(Grid2dRepresentation::XML_TAG) == 0) {
+		grid2dRepresentationSet.push_back(static_cast<Grid2dRepresentation* const>(proxy));
 	}
 	else if (xmlTag.compare(FrontierFeature::XML_TAG) == 0) {
 		frontierSet.push_back(static_cast<FrontierFeature* const>(proxy));

--- a/src/common/EpcDocument.h
+++ b/src/common/EpcDocument.h
@@ -438,6 +438,11 @@ namespace COMMON_NS
 		const std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation*> & getAllTriangulatedSetRepSet() const;
 
 		/**
+		* Get all the grid 2d representations of the EPC document
+		*/
+		const std::vector<RESQML2_0_1_NS::Grid2dRepresentation*> & getAllGrid2dRepresentationSet() const;
+
+		/**
 		* Get all the triangulated set representations of the EPC document which are not horizon and fault neither.
 		*/
 		std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation*> getUnclassifiedTriangulatedSetRepSet() const;
@@ -1211,15 +1216,16 @@ namespace COMMON_NS
 		std::vector<RESQML2_0_1_NS::WellboreFeature*>					wellboreSet;
 		std::vector<RESQML2_NS::RepresentationSetRepresentation*>		representationSetRepresentationSet;
 		std::vector<WITSML1_4_1_1_NS::Trajectory*>						witsmlTrajectorySet;
-		std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation*>	triangulatedSetRepresentationSet;
+		std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation*>		triangulatedSetRepresentationSet;
+		std::vector<resqml2_0_1::Grid2dRepresentation*>					grid2dRepresentationSet;
 		std::vector<RESQML2_0_1_NS::PolylineRepresentation*>			polylineRepresentationSet;
-		std::vector<RESQML2_0_1_NS::AbstractIjkGridRepresentation*>	ijkGridRepresentationSet;
+		std::vector<RESQML2_0_1_NS::AbstractIjkGridRepresentation*>		ijkGridRepresentationSet;
 		std::vector<RESQML2_0_1_NS::UnstructuredGridRepresentation*>	unstructuredGridRepresentationSet;
 		std::vector<RESQML2_0_1_NS::StratigraphicColumn*>				stratigraphicColumnSet;
 		std::vector<RESQML2_0_1_NS::FrontierFeature*>					frontierSet;
 		std::vector<RESQML2_0_1_NS::OrganizationFeature*> 				organizationSet;
 		std::vector<RESQML2_NS::TimeSeries*> 							timeSeriesSet;
-		std::vector<RESQML2_NS::SubRepresentation*>					subRepresentationSet;
+		std::vector<RESQML2_NS::SubRepresentation*>						subRepresentationSet;
 		std::vector<RESQML2_0_1_NS::PointSetRepresentation*>			pointSetRepresentationSet;
 
 		RESQML2_0_1_NS::PropertyKindMapper* propertyKindMapper;


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
It is not possible to get all grid 2D representations of an EPC document. It is only possible to get grid 2D rep which are associated to horizons. This is not enough.

Does this close any currently open issues?
------------------------------------------
no


Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Operating System:** WIN10 64 bits

**Platform:** VS 2013 64 bits
