### PR TITLE
Fix #50

### DIFF
--- a/example/example.cpp
+++ b/example/example.cpp
@@ -580,7 +580,7 @@ void serializeGrid(COMMON_NS::EpcDocument * pck, COMMON_NS::AbstractHdfProxy* hd
 	ULONG64 cellConn[6] = { 0, 9999, 0, 1, 9999, 1 };
 	gridConnSet->setCellIndexPairs(3, cellConn, 9999, hdfProxy);
 	int localFacePerCellIndexPairs[6] = { 3, 9999, 3, 5, 9999, 5 };
-	gridConnSet->setLocalFacePerCellIndexPairs(3, localFacePerCellIndexPairs, hdfProxy);
+	gridConnSet->setLocalFacePerCellIndexPairs(3, localFacePerCellIndexPairs, 9999, hdfProxy);
 
 	if (fault1Interp1 != nullptr)
 	{
@@ -607,12 +607,12 @@ void serializeGrid(COMMON_NS::EpcDocument * pck, COMMON_NS::AbstractHdfProxy* hd
 		3, 5, 3, 5, 3, 5,
 		9999, 5, 9999, 5, 9999, 5
 	};
-	gridConnSet432->setLocalFacePerCellIndexPairs(15, localFacePerCellIndexPairs432, hdfProxy);
+	gridConnSet432->setLocalFacePerCellIndexPairs(15, localFacePerCellIndexPairs432, 9999, hdfProxy);
 
 	RESQML2_NS::GridConnectionSetRepresentation * gridConnSet432rh = pck->createGridConnectionSetRepresentation("a3d1462a-04e3-4374-921b-a4a1e9ba3ea3", "GridConnectionSetRepresentation");
 	gridConnSet432rh->pushBackSupportingGridRepresentation(ijkgrid432rh);
 	gridConnSet432rh->setCellIndexPairs(15, cellConn432, 9999, hdfProxy);
-	gridConnSet432rh->setLocalFacePerCellIndexPairs(15, localFacePerCellIndexPairs432, hdfProxy);
+	gridConnSet432rh->setLocalFacePerCellIndexPairs(15, localFacePerCellIndexPairs432, 9999, hdfProxy);
 
 	//**************
 	// Properties
@@ -3096,6 +3096,11 @@ void deserialize(const string & inputFile)
 				RESQML2_NS::AbstractFeatureInterpretation* faultInterpOfGridConn = gridConnectionSet->getInterpretationFromIndex(0);
 				std::cout << "Interpretation of this grid connection set is : " << faultInterpOfGridConn->getTitle() << " With UUID " << faultInterpOfGridConn->getUuid() << endl;
 			}
+
+			int* localFacePerCellIndexPairs = new int[gridConnectionSet->getCellIndexPairCount() * 2];
+			LONG64 gcsNullValue = gridConnectionSet->getLocalFacePerCellIndexPairs(localFacePerCellIndexPairs);
+			std::cout << "Null Value for LocalFacePerCellIndexPairs : " << gcsNullValue << endl;
+			delete[] localFacePerCellIndexPairs;
 		}
 
 		//*****************************

--- a/src/nsDefinitions.h
+++ b/src/nsDefinitions.h
@@ -18,8 +18,8 @@ under the License.
 -----------------------------------------------------------------------*/
 #pragma once
 
-#define COMMON_NS common
-#define PRODML2_0_NS prodml2_0
-#define RESQML2_NS resqml2
-#define RESQML2_0_1_NS resqml2_0_1
-#define WITSML1_4_1_1_NS witsml1_4_1_1
+#define COMMON_NS common_test
+#define PRODML2_0_NS prodml2_0_test
+#define RESQML2_NS resqml2_test
+#define RESQML2_0_1_NS resqml2_0_1_test
+#define WITSML1_4_1_1_NS witsml1_4_1_1_test

--- a/src/resqml2/GridConnectionSetRepresentation.cpp
+++ b/src/resqml2/GridConnectionSetRepresentation.cpp
@@ -136,7 +136,7 @@ void GridConnectionSetRepresentation::importRelationshipSetFromEpc(COMMON_NS::Ep
 	}
 }
 
-void GridConnectionSetRepresentation::setCellIndexPairs(const ULONG64 & cellIndexPairCount, ULONG64 * cellIndexPair, const ULONG64 & nullValue, COMMON_NS::AbstractHdfProxy * proxy, ULONG64 * gridIndexPair)
+void GridConnectionSetRepresentation::setCellIndexPairs(const ULONG64 & cellIndexPairCount, ULONG64 * cellIndexPair, const LONG64 & nullValue, COMMON_NS::AbstractHdfProxy * proxy, ULONG64 * gridIndexPair)
 {
 	const std::string uuid = getUuid();
 	setCellIndexPairsUsingExistingDataset(cellIndexPairCount, "/RESQML/" + getUuid() + "/CellIndexPairs", nullValue, proxy, gridIndexPair != nullptr ? "/RESQML/" + getUuid() + "/GridIndexPairs" : "");

--- a/src/resqml2/GridConnectionSetRepresentation.h
+++ b/src/resqml2/GridConnectionSetRepresentation.h
@@ -127,10 +127,12 @@ namespace RESQML2_NS
 		virtual bool hasLocalFacePerCell() const = 0;
 
 		/**
-		* Get the local face cell index pairs of this grid connection representation
-		* The count of localFacePerCellIndexPairs must be getCellIndexPairCount()*2.
+		* Get the local face cell index pairs of this grid connection representation.
+		*
+		* @param localFacePerCellIndexPairs Tis array must be pre allocated and won't be deallocated byt fesapi. The count of localFacePerCellIndexPairs must be getCellIndexPairCount()*2.
+		* @return The used null value in localFacePerCellIndexPairs
 		*/
-		virtual void getLocalFacePerCellIndexPairs(int * localFacePerCellIndexPairs) const = 0;
+		virtual LONG64 getLocalFacePerCellIndexPairs(int * localFacePerCellIndexPairs) const = 0;
 
 		/**
 		* Indicates if the grid connection set representation is based on several grids.
@@ -151,7 +153,7 @@ namespace RESQML2_NS
 		* @param proxy				The HDF proxy where the numerical values (cell indices) are stored.
         * @param gridIndexPair		The HDF dataset path where we can find all the grid index pair in a 1d Array where the grid indices go faster than the pair. The grid at an index must correspond to the cell at the same index in the cellIndexPair array.
 		*/
-		virtual void setCellIndexPairsUsingExistingDataset(const ULONG64 & cellIndexPairCount, const std::string & cellIndexPair, const ULONG64 & nullValue, COMMON_NS::AbstractHdfProxy * proxy, const std::string & gridIndexPair = "") = 0;
+		virtual void setCellIndexPairsUsingExistingDataset(const ULONG64 & cellIndexPairCount, const std::string & cellIndexPair, const LONG64 & nullValue, COMMON_NS::AbstractHdfProxy * proxy, const std::string & gridIndexPair = "") = 0;
 
 		/**
 		* Set the cell index pairs of the grid connections representation
@@ -161,14 +163,13 @@ namespace RESQML2_NS
         * @param proxy				The HDF proxy where the numerical values (cell indices) are stored.
         * @param gridIndexPair		All the grid index pair in a 1d Array where the grid indices go faster than the pair. The grid at an index must correspond to the cell at the same index in the cellIndexPair array.
 		*/
-		void setCellIndexPairs(const ULONG64 & cellIndexPairCount, ULONG64 * cellIndexPair, const ULONG64 & nullValue, COMMON_NS::AbstractHdfProxy * proxy, ULONG64 * gridIndexPair = nullptr);
+		void setCellIndexPairs(const ULONG64 & cellIndexPairCount, ULONG64 * cellIndexPair, const LONG64 & nullValue, COMMON_NS::AbstractHdfProxy * proxy, ULONG64 * gridIndexPair = nullptr);
 
 		/**
 		* Optional 2 x #Connections array of local face-per-cell indices for (Cell1,Cell2) for each connection. Local face-per-cell indices are used because global face indices need not have been defined.
 		* If no face-per-cell definition occurs as part of the grid representation, e.g., for a block-centered grid, then this array need not appear.
-		* Null value = -1 by dcoumentation
 		*/
-		virtual void setLocalFacePerCellIndexPairs(const ULONG64 & cellIndexPairCount, int * localFacePerCellIndexPair, COMMON_NS::AbstractHdfProxy * proxy) = 0;
+		virtual void setLocalFacePerCellIndexPairs(const ULONG64 & cellIndexPairCount, int * localFacePerCellIndexPair, const LONG64 & nullValue, COMMON_NS::AbstractHdfProxy * proxy) = 0;
 
 		/**
 		* For each connection in the grid connection set representation, allow to map zero or one feature interpretation. TODO: Resqml allows to map with more than one feature interpretation.
@@ -177,7 +178,7 @@ namespace RESQML2_NS
 		* @param nullValue					The null value must be used as the corresponding interpretation index for each connection which are not associated to any interpretation.
 		* @param proxy						The Hdf proxy where the numerical values will be stored.
 		*/
-		virtual void setConnectionInterpretationIndices(unsigned int * interpretationIndices, const unsigned int & interpretationIndiceCount, const ULONG64 & nullValue, COMMON_NS::AbstractHdfProxy * proxy) = 0;
+		virtual void setConnectionInterpretationIndices(unsigned int * interpretationIndices, const unsigned int & interpretationIndiceCount, const LONG64 & nullValue, COMMON_NS::AbstractHdfProxy * proxy) = 0;
 
 		/**
 		* Push back an interpretation which can be mapped with some connections.

--- a/src/resqml2_0_1/BlockedWellboreRepresentation.cpp
+++ b/src/resqml2_0_1/BlockedWellboreRepresentation.cpp
@@ -151,7 +151,7 @@ void BlockedWellboreRepresentation::setIntevalGridCells(unsigned int * gridIndic
 		dimLocalFacePerCellIndicesNullValue, 1);
 }
 
-unsigned int BlockedWellboreRepresentation::getCellCount() const
+ULONG64 BlockedWellboreRepresentation::getCellCount() const
 {
 	return static_cast<_resqml2__BlockedWellboreRepresentation*>(gsoapProxy2_0_1)->CellCount;
 }

--- a/src/resqml2_0_1/BlockedWellboreRepresentation.h
+++ b/src/resqml2_0_1/BlockedWellboreRepresentation.h
@@ -77,7 +77,7 @@ namespace RESQML2_0_1_NS
 		/**
 		* The number of non-null entries in the grid indices array.
 		*/
-		unsigned int getCellCount() const;
+		ULONG64 getCellCount() const;
 
 		/**
 		* Size of array = IntervalCount on the wellbore frame rep. The grids (and there indices) are defined using pushBackSupportingGridRepresentation method.

--- a/src/resqml2_0_1/GridConnectionSetRepresentation.cpp
+++ b/src/resqml2_0_1/GridConnectionSetRepresentation.cpp
@@ -75,7 +75,7 @@ string GridConnectionSetRepresentation::getHdfProxyUuid() const
 	throw std::logic_error("Not implemented yet");
 }
 
-void GridConnectionSetRepresentation::setCellIndexPairsUsingExistingDataset(const ULONG64 & cellIndexPairCount, const std::string & cellIndexPair, const ULONG64 & nullValue, COMMON_NS::AbstractHdfProxy * proxy, const std::string & gridIndexPair)
+void GridConnectionSetRepresentation::setCellIndexPairsUsingExistingDataset(const ULONG64 & cellIndexPairCount, const std::string & cellIndexPair, const LONG64 & nullValue, COMMON_NS::AbstractHdfProxy * proxy, const std::string & gridIndexPair)
 {
 	if (cellIndexPairCount == 0) {
 		throw std::invalid_argument("You cannot set zero cell index pair.");
@@ -106,7 +106,7 @@ void GridConnectionSetRepresentation::setCellIndexPairsUsingExistingDataset(cons
 	}
 }
 
-void GridConnectionSetRepresentation::setLocalFacePerCellIndexPairsUsingExistingDataset(const std::string & localFacePerCellIndexPair, COMMON_NS::AbstractHdfProxy * proxy)
+void GridConnectionSetRepresentation::setLocalFacePerCellIndexPairsUsingExistingDataset(const std::string & localFacePerCellIndexPair, const LONG64 & nullValue, COMMON_NS::AbstractHdfProxy * proxy)
 {
 	_resqml2__GridConnectionSetRepresentation* rep = static_cast<_resqml2__GridConnectionSetRepresentation*>(gsoapProxy2_0_1);
 
@@ -118,14 +118,14 @@ void GridConnectionSetRepresentation::setLocalFacePerCellIndexPairsUsingExisting
 	resqmlHDF5dataset->HdfProxy = hdfProxy->newResqmlReference();
 	resqmlHDF5dataset->PathInHdfFile = localFacePerCellIndexPair;
 	integerArray->Values = resqmlHDF5dataset;
-	integerArray->NullValue = -1;
+	integerArray->NullValue = nullValue;
 	rep->LocalFacePerCellIndexPairs = integerArray;
 }
 
-void GridConnectionSetRepresentation::setLocalFacePerCellIndexPairs(const ULONG64 & cellIndexPairCount, int * localFacePerCellIndexPair, COMMON_NS::AbstractHdfProxy * proxy)
+void GridConnectionSetRepresentation::setLocalFacePerCellIndexPairs(const ULONG64 & cellIndexPairCount, int * localFacePerCellIndexPair, const LONG64 & nullValue, COMMON_NS::AbstractHdfProxy * proxy)
 {
 	const std::string uuid = getUuid();
-	setLocalFacePerCellIndexPairsUsingExistingDataset("/RESQML/" + uuid + "/LocalFacePerCellIndexPairs", proxy);
+	setLocalFacePerCellIndexPairsUsingExistingDataset("/RESQML/" + uuid + "/LocalFacePerCellIndexPairs", nullValue, proxy);
 
 	// ************ HDF ************		
 	hsize_t numValues[] = {cellIndexPairCount,2};
@@ -397,7 +397,7 @@ void GridConnectionSetRepresentation::getGridIndexPairs(ULONG64 * gridIndexPairs
 		hdfProxy->readArrayNdOfGSoapULong64Values(static_cast<resqml2__IntegerHdf5Array*>(rep->GridIndexPairs)->Values->PathInHdfFile, gridIndexPairs);
 	}
 	else {
-		throw std::logic_error("Not yet implemented");
+		throw std::logic_error("Not implemented yet");
 	}
 }
 
@@ -406,7 +406,7 @@ bool GridConnectionSetRepresentation::hasLocalFacePerCell() const
 	return static_cast<_resqml2__GridConnectionSetRepresentation*>(gsoapProxy2_0_1)->LocalFacePerCellIndexPairs != nullptr;
 }
 
-void GridConnectionSetRepresentation::getLocalFacePerCellIndexPairs(int * localFaceCellIndexPairs) const
+LONG64 GridConnectionSetRepresentation::getLocalFacePerCellIndexPairs(int * localFaceCellIndexPairs) const
 {
 	if (!hasLocalFacePerCell()) {
 		throw std::invalid_argument("This representation has no local face per cell.");
@@ -416,9 +416,10 @@ void GridConnectionSetRepresentation::getLocalFacePerCellIndexPairs(int * localF
 
 	if (rep->LocalFacePerCellIndexPairs->soap_type() == SOAP_TYPE_gsoap_resqml2_0_1_resqml2__IntegerHdf5Array) {
 		hdfProxy->readArrayNdOfIntValues(static_cast<resqml2__IntegerHdf5Array*>(rep->LocalFacePerCellIndexPairs)->Values->PathInHdfFile, localFaceCellIndexPairs);
+		return static_cast<resqml2__IntegerHdf5Array*>(rep->LocalFacePerCellIndexPairs)->NullValue;
 	}
 	else {
-		throw std::logic_error("Not yet implemented");
+		throw std::logic_error("Not implemented yet");
 	}
 }
 
@@ -427,7 +428,7 @@ void GridConnectionSetRepresentation::pushBackXmlSupportingGridRepresentation(RE
 	static_cast<_resqml2__GridConnectionSetRepresentation*>(gsoapProxy2_0_1)->Grid.push_back(supportingGridRep->newResqmlReference());
 }
 
-void GridConnectionSetRepresentation::setConnectionInterpretationIndices(unsigned int * interpretationIndices, const unsigned int & interpretationIndiceCount, const ULONG64 & nullValue, COMMON_NS::AbstractHdfProxy * proxy)
+void GridConnectionSetRepresentation::setConnectionInterpretationIndices(unsigned int * interpretationIndices, const unsigned int & interpretationIndiceCount, const LONG64 & nullValue, COMMON_NS::AbstractHdfProxy * proxy)
 {
 	_resqml2__GridConnectionSetRepresentation* rep = static_cast<_resqml2__GridConnectionSetRepresentation*>(gsoapProxy2_0_1);
 	if (rep->ConnectionInterpretations == nullptr) {

--- a/src/resqml2_0_1/GridConnectionSetRepresentation.h
+++ b/src/resqml2_0_1/GridConnectionSetRepresentation.h
@@ -142,10 +142,12 @@ namespace RESQML2_0_1_NS
 		bool hasLocalFacePerCell() const;
 
 		/**
-		* Get the local face cell index pairs of this grid connection representation
-		* The count of localFacePerCellIndexPairs must be getCellIndexPairCount()*2.
+		* Get the local face cell index pairs of this grid connection representation.
+		*
+		* @param localFacePerCellIndexPairs Tis array must be pre allocated and won't be deallocated byt fesapi. The count of localFacePerCellIndexPairs must be getCellIndexPairCount()*2.
+		* @return The used null value in localFacePerCellIndexPairs
 		*/
-		void getLocalFacePerCellIndexPairs(int * localFacePerCellIndexPairs) const;
+		LONG64 getLocalFacePerCellIndexPairs(int * localFacePerCellIndexPairs) const;
 
 		/**
 		* Indicates if the grid connection set representation is based on several grids.
@@ -166,7 +168,7 @@ namespace RESQML2_0_1_NS
 		* @param proxy				The HDF proxy where the numerical values (cell indices) are stored.
         * @param gridIndexPair		The HDF dataset path where we can find all the grid index pair in a 1d Array where the grid indices go faster than the pair. The grid at an index must correspond to the cell at the same index in the cellIndexPair array.
 		*/
-		void setCellIndexPairsUsingExistingDataset(const ULONG64 & cellIndexPairCount, const std::string & cellIndexPair, const ULONG64 & nullValue, COMMON_NS::AbstractHdfProxy * proxy, const std::string & gridIndexPair = "");
+		void setCellIndexPairsUsingExistingDataset(const ULONG64 & cellIndexPairCount, const std::string & cellIndexPair, const LONG64 & nullValue, COMMON_NS::AbstractHdfProxy * proxy, const std::string & gridIndexPair = "");
 
 		/**
 		* The numerical values
@@ -176,7 +178,7 @@ namespace RESQML2_0_1_NS
 		* @param localFacePerCellIndexPair	The HDF dataset path where we can find all the local Face Per CellIndex Pair in a 1d Array.
 		* @param proxy						The HDF proxy where the numerical values (cell indices) are stored.
 		*/
-		void setLocalFacePerCellIndexPairsUsingExistingDataset(const std::string & localFacePerCellIndexPair, COMMON_NS::AbstractHdfProxy * proxy);
+		void setLocalFacePerCellIndexPairsUsingExistingDataset(const std::string & localFacePerCellIndexPair, const LONG64 & nullValue, COMMON_NS::AbstractHdfProxy * proxy);
 
 		/**
 		* 2 x #Connections array of local face-per-cell indices for (Cell1,Cell2) for each connection. Local face-per-cell indices are used because global face indices need not have been defined.
@@ -186,7 +188,7 @@ namespace RESQML2_0_1_NS
 		* @param localFacePerCellIndexPair	The HDF dataset path where we can find all the local Face Per CellIndex Pair in a 1d Array.
 		* @param proxy						The HDF proxy where the numerical values (cell indices) are stored.
 		*/
-		void setLocalFacePerCellIndexPairs(const ULONG64 & cellIndexPairCount, int * localFacePerCellIndexPair, COMMON_NS::AbstractHdfProxy * proxy);
+		void setLocalFacePerCellIndexPairs(const ULONG64 & cellIndexPairCount, int * localFacePerCellIndexPair, const LONG64 & nullValue, COMMON_NS::AbstractHdfProxy * proxy);
 
 		/**
 		* For each connection in the grid connection set representation, allow to map zero or one feature interpretation. TODO: Resqml allows to map with more than one feature interpretation.
@@ -195,7 +197,7 @@ namespace RESQML2_0_1_NS
 		* @param nullValue					The null value must be used as the corresponding interpretation index for each connection which are not associated to any interpretation.
 		* @param proxy						The Hdf proxy where the numerical values will be stored.
 		*/
-		void setConnectionInterpretationIndices(unsigned int * interpretationIndices, const unsigned int & interpretationIndiceCount, const ULONG64 & nullValue, COMMON_NS::AbstractHdfProxy * proxy);
+		void setConnectionInterpretationIndices(unsigned int * interpretationIndices, const unsigned int & interpretationIndiceCount, const LONG64 & nullValue, COMMON_NS::AbstractHdfProxy * proxy);
 		
 		/**
 		* Get the count of the supporting grid representations of this grid connection representation.

--- a/swig/swigResqml2Include.i
+++ b/swig/swigResqml2Include.i
@@ -415,15 +415,15 @@ namespace RESQML2_NS
 		ULONG64 getCellIndexPairs(ULONG64 * cellIndexPairs) const;
 		void getGridConnectionSetInformationFromInterpretationIndex(ULONG64 * cellIndexPairs, ULONG64 * gridIndexPairs, int * localFaceIndexPairs, const unsigned int & interpretationIndex) const;
 		bool hasLocalFacePerCell() const;
-		void getLocalFacePerCellIndexPairs(int * localFacePerCellIndexPairs) const;
+		LONG64 getLocalFacePerCellIndexPairs(int * localFacePerCellIndexPairs) const;
 		bool isBasedOnMultiGrids() const;
 		void getGridIndexPairs(ULONG64 * gridIndexPairs) const;
 		
 		void pushBackSupportingGridRepresentation(AbstractGridRepresentation * supportingGridRep);
 		
-		void setCellIndexPairs(const ULONG64 & cellIndexPairCount, ULONG64 * cellIndexPair, const ULONG64 & nullValue, COMMON_NS::AbstractHdfProxy * proxy, ULONG64 * gridIndexPair = nullptr);
-		void setLocalFacePerCellIndexPairs(const ULONG64 & cellIndexPairCount, int * localFacePerCellIndexPair, COMMON_NS::AbstractHdfProxy * proxy);
-		void setConnectionInterpretationIndices(unsigned int * interpretationIndices, const unsigned int & interpretationIndiceCount, const ULONG64 & nullValue, COMMON_NS::AbstractHdfProxy * proxy);
+		void setCellIndexPairs(const ULONG64 & cellIndexPairCount, ULONG64 * cellIndexPair, const LONG64 & nullValue, COMMON_NS::AbstractHdfProxy * proxy, ULONG64 * gridIndexPair = nullptr);
+		void setLocalFacePerCellIndexPairs(const ULONG64 & cellIndexPairCount, int * localFacePerCellIndexPair, const LONG64 & nullValue, COMMON_NS::AbstractHdfProxy * proxy);
+		void setConnectionInterpretationIndices(unsigned int * interpretationIndices, const unsigned int & interpretationIndiceCount, const LONG64 & nullValue, COMMON_NS::AbstractHdfProxy * proxy);
 		void pushBackInterpretation(AbstractFeatureInterpretation* interp);
 		
 		std::string getInterpretationUuidFromIndex(const unsigned int & interpretationIndex) const;

--- a/test/resqml2_0_1test/RightHanded4x3x2ExplicitIjkGrid.cpp
+++ b/test/resqml2_0_1test/RightHanded4x3x2ExplicitIjkGrid.cpp
@@ -107,7 +107,7 @@ void RightHanded4x3x2ExplicitIjkGrid::initEpcDocHandler() {
 		3, 5, 3, 5, 3, 5,
 		9999, 5, 9999, 5, 9999, 5
 	};
-	gridConnSet432->setLocalFacePerCellIndexPairs(15, localFacePerCellIndexPairs432, hdfProxy);
+	gridConnSet432->setLocalFacePerCellIndexPairs(15, localFacePerCellIndexPairs432, 9999, hdfProxy);
 
 	// Discrete property
 	RESQML2_0_1_NS::DiscreteProperty* discreteProp = epcDoc->createDiscreteProperty(ijkGrid, "0a8fb2aa-d1e1-4914-931c-e9e6bf2aabe5", "Cell index", 1,


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Allow to read the null value from the GridConnectionSetRepresentation::LocalFacePerCellIndexPairs

Does this close any currently open issues?
------------------------------------------
Fix #50

Where has this been tested?
---------------------------
**Operating System:** Win 10 64bits

**Platform:** VS2013 64 bits
