### PR TITLE
Added static casts to quiet C4267 warnings.

### DIFF
--- a/src/resqml2/AbstractGridRepresentation.h
+++ b/src/resqml2/AbstractGridRepresentation.h
@@ -90,7 +90,7 @@ namespace RESQML2_NS
 		 * Get the GridConnectionSetRepresentation count into this EPC document which are associated to this grid.
 		 * It is mainly used in SWIG context for parsing the vector from a non C++ language.
 		 */
-		unsigned int getGridConnectionSetRepresentationCount() const {return gridConnectionSetRepresentationSet.size();}
+		unsigned int getGridConnectionSetRepresentationCount() const {return static_cast<unsigned int>(gridConnectionSetRepresentationSet.size());}
 
 		/**
 		 * Get a particular ijk parametric grid according to its position in the EPC document.
@@ -124,7 +124,7 @@ namespace RESQML2_NS
 		/**
 		* Return the count of child grid in this grid.
 		*/
-		unsigned int getChildGridCount() const {return childGridSet.size();}
+		unsigned int getChildGridCount() const {return static_cast<unsigned int>(childGridSet.size());}
 
 		/**
 		* Return the count of child grid in this grid.


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------
Quiet two Visual Studio C4267 warnings.

Does this close any currently open issues?
------------------------------------------
Issue #72 


Any relevant logs, error output, etc?
-------------------------------------

No.

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Operating System:** Windows 10

**Platform:** MSVC 2015
