### PR TITLE
Fix setAge and getAge methods of horizon

### DIFF
--- a/example/example.cpp
+++ b/example/example.cpp
@@ -288,6 +288,7 @@ void serializeBoundaries(COMMON_NS::EpcDocument * pck, COMMON_NS::AbstractHdfPro
 	timeStruct.tm_mon = 1;
 	timeStruct.tm_year = 0;
 	horizon1->setCreation(timeStruct);
+	horizon1->setAge(300000000);
 	horizon2 = pck->createHorizon("fd7950a6-f62e-4e47-96c4-048820a61c59", "Horizon2");
 	horizon2->setVersionString("my version string");
 	fault1 = pck->createFault("1424bcc2-3d9d-4f30-b1f9-69dcb897e33b", "Fault1");
@@ -2739,6 +2740,9 @@ void deserialize(const string & inputFile)
 	std::cout << "HORIZONS" << endl;
 	for (size_t i = 0; i < horizonSet.size(); i++) {
 		showAllMetadata(horizonSet[i]);
+		if (horizonSet[i]->hasAnAge()) {
+			cout << "Age " << horizonSet[i]->getAge() << " years" << endl;
+		}
 		std::cout << std::endl;
 	}
 

--- a/src/resqml2_0_1/GeneticBoundaryFeature.cpp
+++ b/src/resqml2_0_1/GeneticBoundaryFeature.cpp
@@ -46,12 +46,13 @@ void GeneticBoundaryFeature::setAge(const ULONG64 & age)
 	gsoap_resqml2_0_1::_resqml2__GeneticBoundaryFeature* feature = static_cast<gsoap_resqml2_0_1::_resqml2__GeneticBoundaryFeature*>(gsoapProxy2_0_1);
 	if (!hasAnAge()) {
 		feature->AbsoluteAge = gsoap_resqml2_0_1::soap_new_resqml2__Timestamp(getGsoapContext());
+		feature->AbsoluteAge->DateTime.tm_mday = 1;
 	}
 	if (feature->AbsoluteAge->YearOffset == nullptr) {
 		feature->AbsoluteAge->YearOffset = static_cast<LONG64*>(soap_malloc(getGsoapContext(), sizeof(LONG64)));
 	}
 
-	*(feature->AbsoluteAge->YearOffset) = age;
+	*(feature->AbsoluteAge->YearOffset) = -age;
 }
 
 bool GeneticBoundaryFeature::hasAnAge() const
@@ -65,6 +66,6 @@ ULONG64 GeneticBoundaryFeature::getAge() const
 		throw invalid_argument("This feature has not an age.");
 	}
 
-	return static_cast<gsoap_resqml2_0_1::_resqml2__GeneticBoundaryFeature*>(gsoapProxy2_0_1)->AbsoluteAge->YearOffset == nullptr ? 0 : abs(*(static_cast<gsoap_resqml2_0_1::_resqml2__GeneticBoundaryFeature*>(gsoapProxy2_0_1)->AbsoluteAge->YearOffset));
+	return abs(*(static_cast<gsoap_resqml2_0_1::_resqml2__GeneticBoundaryFeature*>(gsoapProxy2_0_1)->AbsoluteAge->YearOffset));
 }
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
* SetAge now serialize a valid value ("one" day instead of "zero" day)
* SetAge now set negative offset
* GetAge does no more verify twice the age existency

Does this close any currently open issues?
------------------------------------------
Fix #83 

Where has this been tested?
---------------------------
**Operating System:** Win10 64bits

**Platform:** VS2015 64 bits
