### PR TITLE
IJK grids: early calls to getEnabledCells cause HDF5 access exception

### DIFF
--- a/src/common/AbstractHdfProxy.h
+++ b/src/common/AbstractHdfProxy.h
@@ -71,13 +71,13 @@ namespace COMMON_NS
 		 * Get the used (native) datatype in a dataset
 		* To compare with H5T_NATIVE_INT, H5T_NATIVE_UINT, H5T_NATIVE_FLOAT, etc...
 		 */
-		virtual int getHdfDatatypeInDataset(const std::string & datasetName) const = 0;
+		virtual int getHdfDatatypeInDataset(const std::string & datasetName) = 0;
 
 		/**
 		* Get the used datatype class in a dataset
 		* To compare with H5T_INTEGER, H5T_FLOAT , H5T_STRING , etc...
 		*/
-		virtual int getHdfDatatypeClassInDataset(const std::string & datasetName) const = 0;
+		virtual int getHdfDatatypeClassInDataset(const std::string & datasetName) = 0;
 
 		/**
 		* Write an itemized list of list into the HDF file by means of a single group containing 2 datasets.

--- a/src/common/HdfProxy.h
+++ b/src/common/HdfProxy.h
@@ -156,13 +156,13 @@ namespace COMMON_NS
 		* Get the used (native) datatype in a dataset
 		* To compare with H5T_NATIVE_INT, H5T_NATIVE_UINT, H5T_NATIVE_FLOAT, etc...
 		*/
-		int getHdfDatatypeInDataset(const std::string & groupName) const;
+		int getHdfDatatypeInDataset(const std::string & groupName);
 
 		/**
 		* Get the used datatype class in a dataset
 		* To compare with H5T_INTEGER, H5T_FLOAT , H5T_STRING , etc...
 		*/
-		int getHdfDatatypeClassInDataset(const std::string & datasetName) const;
+		int getHdfDatatypeClassInDataset(const std::string & datasetName);
 		
 		/**
 		* Write an itemized list of list into the HDF file by means of a single group containing 2 datasets.

--- a/src/prodml2_0/HdfProxy.h
+++ b/src/prodml2_0/HdfProxy.h
@@ -46,8 +46,6 @@ namespace PRODML2_0_NS
 		* Get the XML namespace for the tags for the XML serialization of this instance
 		*/
 		std::string getXmlNamespace() const;
-
-		int openOrCreateAcquisitionGroup();
 	};
 }
 

--- a/src/resqml2_0_1/SealedSurfaceFrameworkRepresentation.h
+++ b/src/resqml2_0_1/SealedSurfaceFrameworkRepresentation.h
@@ -59,7 +59,7 @@ namespace RESQML2_0_1_NS
 		/**
 		 * Pushes back a contact representation in the structural framework with implicit identical nodes.
 		 *
-		 * After calling the following method, ContactPatch containter of the newly pushed SealedContactRepresentation
+		 * After calling the following method, ContactPatch container of the newly pushed SealedContactRepresentation
 		 * remains empty. After this call, do not forget to call the pushBackContactPatch method for each ContactPatch of
 		 * the SealedContactRepresentation.
 		 *
@@ -70,7 +70,7 @@ namespace RESQML2_0_1_NS
 		/**
 		 * Pushes back a contact representation in the structural framework.
 		 *
-		 * After calling the following method, ContactPatch containter of the newly pushed SealedContactRepresentation
+		 * After calling the following method, ContactPatch container of the newly pushed SealedContactRepresentation
 		 * remains empty. After this call, do not forget to call the pushBackContactPatch method for each ContactPatch of
 		 * the SealedContactRepresentation.
 		 *
@@ -118,7 +118,7 @@ namespace RESQML2_0_1_NS
 		  * @param sealedContactRepresentationsCount    The number of sealed contact representations involved within the identity.
 		  * @param sealedContactRepresentationsIndexes  The sealed contact representations involved within the identity.
 		  * @param identicalNodesCount                  The number of identical nodes.
-		  * @param identicalNodesIndexes                The indexes of the identical nodes.
+		  * @param identicalNodesIndexes                The indices of the identical nodes.
 		  * @param proxy                                The hdf proxy.
 		  */
 		 void pushBackContactIdentity(


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Open automatically the hdf proxy if necessary when asking for info on datatype of a dataset

Does this close any currently open issues?
------------------------------------------
Fix #95

Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)

Any other comments?
-------------------
The hdf proxy methods are no more const since they could open the HDF5 file.

Where has this been tested?
---------------------------
**Operating System:** WIN64 10

**Platform:** VS2015 64
