### PR TITLE
Add a getter for all polyline set rep

### DIFF
--- a/src/common/EpcDocument.cpp
+++ b/src/common/EpcDocument.cpp
@@ -261,11 +261,13 @@ const std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation*> & EpcDocument:
 
 const std::vector<resqml2_0_1::Grid2dRepresentation*> & EpcDocument::getAllGrid2dRepresentationSet() const { return grid2dRepresentationSet; }
 
+const std::vector<RESQML2_0_1_NS::PolylineSetRepresentation*> & EpcDocument::getAllPolylineSetRepSet() const { return polylineSetRepresentationSet; }
+
 const std::vector<RESQML2_0_1_NS::SeismicLineFeature*> & EpcDocument::getSeismicLineSet() const { return seismicLineSet; }
 
 const std::vector<RESQML2_0_1_NS::WellboreFeature*> & EpcDocument::getWellboreSet() const { return wellboreSet; }
 
-std::vector<RESQML2_0_1_NS::PolylineRepresentation*> EpcDocument::getPolylineRepresentationSet() const { return polylineRepresentationSet; }
+const std::vector<RESQML2_0_1_NS::PolylineRepresentation*> & EpcDocument::getAllPolylineRepresentationSet() const { return polylineRepresentationSet; }
 
 const std::vector<RESQML2_0_1_NS::AbstractIjkGridRepresentation*> & EpcDocument::getIjkGridRepresentationSet() const { return ijkGridRepresentationSet; }
 unsigned int EpcDocument::getIjkGridRepresentationCount() const { return ijkGridRepresentationSet.size(); }
@@ -389,6 +391,7 @@ void EpcDocument::close()
 	triangulatedSetRepresentationSet.clear();
 	grid2dRepresentationSet.clear();
 	polylineRepresentationSet.clear();
+	polylineSetRepresentationSet.clear();
 	ijkGridRepresentationSet.clear();
 	unstructuredGridRepresentationSet.clear();
 	stratigraphicColumnSet.clear();
@@ -496,6 +499,9 @@ void EpcDocument::addGsoapProxy(COMMON_NS::AbstractObject* proxy)
 	}
 	else if (xmlTag.compare(PolylineRepresentation::XML_TAG) == 0) {
 		polylineRepresentationSet.push_back(static_cast<PolylineRepresentation* const>(proxy));
+	}
+	else if (xmlTag.compare(PolylineSetRepresentation::XML_TAG) == 0) {
+		polylineSetRepresentationSet.push_back(static_cast<PolylineSetRepresentation* const>(proxy));
 	}
 	else if (xmlTag.compare(AbstractIjkGridRepresentation::XML_TAG) == 0 || xmlTag.compare(AbstractIjkGridRepresentation::XML_TAG_TRUNCATED) == 0) {
 		ijkGridRepresentationSet.push_back(static_cast<AbstractIjkGridRepresentation* const>(proxy));
@@ -1282,7 +1288,7 @@ vector<IjkGridExplicitRepresentation*> EpcDocument::getIjkGridExplicitRepresenta
 std::vector<PolylineRepresentation*> EpcDocument::getSeismicLinePolylineRepSet() const
 {
 	vector<PolylineRepresentation*> result;
-	vector<PolylineRepresentation*> polylineRepSet = getPolylineRepresentationSet();
+	vector<PolylineRepresentation*> polylineRepSet = getAllPolylineRepresentationSet();
 
 	for (size_t i = 0; i < polylineRepSet.size(); ++i) {
 		if (polylineRepSet[i]->isASeismicLine() || polylineRepSet[i]->isAFaciesLine()) {

--- a/src/common/EpcDocument.h
+++ b/src/common/EpcDocument.h
@@ -430,6 +430,11 @@ namespace COMMON_NS
 		const std::vector<RESQML2_0_1_NS::Grid2dRepresentation*> & getAllGrid2dRepresentationSet() const;
 
 		/**
+		* Get all the polyline set representations of the EPC document
+		*/
+		const std::vector<RESQML2_0_1_NS::PolylineSetRepresentation*> & getAllPolylineSetRepSet() const;
+
+		/**
 		* Get all the triangulated set representations of the EPC document which are not horizon and fault neither.
 		*/
 		std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation*> getUnclassifiedTriangulatedSetRepSet() const;
@@ -470,9 +475,9 @@ namespace COMMON_NS
 		RESQML2_NS::RepresentationSetRepresentation* getRepresentationSetRepresentation(const unsigned int & index) const;
 
 		/**
-		* Get all the polyline representation contained into the EPC document.
+		* Get all the polyline representations contained into the EPC document.
 		*/
-		std::vector<RESQML2_0_1_NS::PolylineRepresentation*> getPolylineRepresentationSet() const;
+		const std::vector<RESQML2_0_1_NS::PolylineRepresentation*> & getAllPolylineRepresentationSet() const;
 
 		/**
 		* Get all the single polyline representations contained into the EPC document which correspond to a seismic line.
@@ -1183,6 +1188,7 @@ namespace COMMON_NS
 		std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation*>		triangulatedSetRepresentationSet;
 		std::vector<RESQML2_0_1_NS::Grid2dRepresentation*>				grid2dRepresentationSet;
 		std::vector<RESQML2_0_1_NS::PolylineRepresentation*>			polylineRepresentationSet;
+		std::vector<RESQML2_0_1_NS::PolylineSetRepresentation*>			polylineSetRepresentationSet;
 		std::vector<RESQML2_0_1_NS::AbstractIjkGridRepresentation*>		ijkGridRepresentationSet;
 		std::vector<RESQML2_0_1_NS::UnstructuredGridRepresentation*>	unstructuredGridRepresentationSet;
 		std::vector<RESQML2_0_1_NS::StratigraphicColumn*>				stratigraphicColumnSet;

--- a/swig/swigModule.i
+++ b/swig/swigModule.i
@@ -252,27 +252,35 @@ namespace COMMON_NS
 		
 		const std::vector<RESQML2_0_1_NS::StratigraphicColumn*> & getStratigraphicColumnSet() const;
 		
+		const std::vector<RESQML2_0_1_NS::FrontierFeature*> & getFrontierSet() const;
+		std::vector<RESQML2_0_1_NS::PolylineSetRepresentation*> getFrontierPolylineSetRepSet() const;
+		
 		const std::vector<RESQML2_0_1_NS::TectonicBoundaryFeature*> & getFaultSet() const;
 		const std::vector<RESQML2_0_1_NS::TectonicBoundaryFeature*> & getFractureSet() const {return fractureSet;}
-		const std::vector<RESQML2_0_1_NS::FrontierFeature*> & getFrontierSet() const;
 		std::vector<RESQML2_0_1_NS::PolylineSetRepresentation*> getFaultPolylineSetRepSet() const;
 		std::vector<RESQML2_0_1_NS::PolylineSetRepresentation*> getFracturePolylineSetRepSet() const;
-		std::vector<RESQML2_0_1_NS::PolylineSetRepresentation*> getFrontierPolylineSetRepSet() const;
 		std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation*> getFaultTriangulatedSetRepSet() const;
 		std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation*> getFractureTriangulatedSetRepSet() const;
 		
-		std::vector<RESQML2_0_1_NS::Horizon*> getHorizonSet() const;
 		unsigned int getGeobodyBoundaryCount() const;
 		RESQML2_0_1_NS::GeneticBoundaryFeature* getGeobodyBoundary(unsigned int index) const;
 		const std::vector<RESQML2_0_1_NS::GeobodyFeature*> & getGeobodySet() const;
+		
+		std::vector<RESQML2_0_1_NS::Horizon*> getHorizonSet() const;
 		std::vector<RESQML2_0_1_NS::Grid2dRepresentation*> getHorizonGrid2dRepSet() const;
 		std::vector<RESQML2_0_1_NS::PolylineRepresentation*> getHorizonPolylineRepSet() const;
 		std::vector<RESQML2_0_1_NS::PolylineSetRepresentation*> getHorizonPolylineSetRepSet() const;
 		std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation*> getHorizonTriangulatedSetRepSet() const;
+		
 		const std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation*> & getAllTriangulatedSetRepSet() const;
 		std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation*> getUnclassifiedTriangulatedSetRepSet() const;
+		const std::vector<RESQML2_0_1_NS::Grid2dRepresentation*> & getAllGrid2dRepresentationSet() const;
+		const std::vector<RESQML2_0_1_NS::PolylineSetRepresentation*> & getAllPolylineSetRepSet() const;
+		const std::vector<RESQML2_0_1_NS::PolylineRepresentation*> & getAllPolylineRepresentationSet() const;
 		
 		const std::vector<RESQML2_0_1_NS::SeismicLineFeature*> & getSeismicLineSet() const;
+		std::vector<RESQML2_0_1_NS::PolylineRepresentation*> getSeismicLinePolylineRepSet() const;
+		std::vector<RESQML2_0_1_NS::IjkGridLatticeRepresentation*> getIjkSeismicCubeGridRepresentationSet() const;
 		
 		const std::vector<RESQML2_0_1_NS::WellboreFeature*> & getWellboreSet() const;
 		std::vector<RESQML2_0_1_NS::WellboreTrajectoryRepresentation*> getWellboreTrajectoryRepresentationSet() const;
@@ -289,9 +297,6 @@ namespace COMMON_NS
 		std::vector<RESQML2_0_1_NS::IjkGridExplicitRepresentation*> getIjkGridExplicitRepresentationSet() const;
 		std::vector<RESQML2_0_1_NS::IjkGridParametricRepresentation*> getIjkGridParametricRepresentationSet() const;
 
-		std::vector<RESQML2_0_1_NS::PolylineRepresentation*> getSeismicLinePolylineRepSet() const;
-		std::vector<RESQML2_0_1_NS::IjkGridLatticeRepresentation*> getIjkSeismicCubeGridRepresentationSet() const;
-		
 		const std::vector<RESQML2_0_1_NS::UnstructuredGridRepresentation*> & getUnstructuredGridRepresentationSet() const;
 		
 		unsigned int getSubRepresentationCount() const;


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
It adds a getter for all polyline set rep of an epc document.
It also renames the getter for polyline rep for more naming consistency

Does this close any currently open issues?
------------------------------------------
No

Where has this been tested?
---------------------------
**Operating System:** Win10 64

**Platform:** VS2015 64
