### PR TITLE
No more link error on installed example.

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -24,6 +24,18 @@ ENDIF (UNIX)
 # ============================================================================
 # build example
 # ============================================================================
+# use, i.e. don't skip the full RPATH for the build tree
+SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
+
+# when building, don't use the install RPATH already
+# (but later on when installing)
+SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+
+SET(CMAKE_INSTALL_RPATH "\$ORIGIN/lib")
+
+# add the automatically determined parts of the RPATH
+# which point to directories outside the build tree to the install RPATH
+SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 ADD_EXECUTABLE (example ${CMAKE_CURRENT_SOURCE_DIR}/example.cpp)
 ADD_DEPENDENCIES (example ${CPP_LIBRARY_NAME})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -304,6 +304,18 @@ IF (WIN32)
 	ENDIF (HDF5_BUILT_AS_DYNAMIC_LIB)
 ENDIF (WIN32)
 
+# use, i.e. don't skip the full RPATH for the build tree
+SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
+
+# when building, don't use the install RPATH already
+# (but later on when installing)
+SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+
+# add the automatically determined parts of the RPATH
+# which point to directories outside the build tree to the install RPATH
+SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+
 ADD_LIBRARY (${CPP_LIBRARY_NAME} ${LIB_TYPE} ${ALL_SOURCES_AND_HEADERS})
 
 # Linker instructions


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
It fixes problem when installed "example" executable cannot find dependent libraries on Linux

Does this close any currently open issues?
------------------------------------------
Fix #100 

Any other comments?
-------------------
Use Cmake Rpath commands.
Not sure it would work on MacOs and/or Windows since I don't know how they handle rpath.

Where has this been tested?
---------------------------
**Operating System:** Debian WSL

**Platform:** gcc 6
