### PR TITLE
Grid2dRepresentation ignores LocalCrs

### DIFF
--- a/src/resqml2/AbstractLocal3dCrs.cpp
+++ b/src/resqml2/AbstractLocal3dCrs.cpp
@@ -41,7 +41,7 @@ vector<Relationship> AbstractLocal3dCrs::getAllEpcRelationships() const
 	vector<Relationship> result;
 
 	// Geometry/Representation set
-	for (size_t i = 0; i < repSet.size(); i++)
+	for (size_t i = 0; i < repSet.size(); ++i)
 	{
 		Relationship rel(repSet[i]->getPartNameInEpcDocument(), "", repSet[i]->getUuid());
 		rel.setSourceObjectType();
@@ -49,7 +49,7 @@ vector<Relationship> AbstractLocal3dCrs::getAllEpcRelationships() const
 	}
 
 	// MD information set
-	for (size_t i = 0; i < mdDatumSet.size(); i++)
+	for (size_t i = 0; i < mdDatumSet.size(); ++i)
 	{
 		Relationship rel(mdDatumSet[i]->getPartNameInEpcDocument(), "", mdDatumSet[i]->getUuid());
 		rel.setSourceObjectType();
@@ -59,7 +59,7 @@ vector<Relationship> AbstractLocal3dCrs::getAllEpcRelationships() const
 	return result;
 }
 
-void AbstractLocal3dCrs::convertXyzPointsToGlobalCrs(double * xyzPoints, const ULONG64 & xyzPointCount, bool withoutTranslation) const
+void AbstractLocal3dCrs::convertXyzPointsToGlobalCrs(double * xyzPoints, ULONG64 xyzPointCount, bool withoutTranslation) const
 {
 	ULONG64 coordinateCount = xyzPointCount * 3;
 
@@ -76,9 +76,9 @@ void AbstractLocal3dCrs::convertXyzPointsToGlobalCrs(double * xyzPoints, const U
 
 	if (!withoutTranslation)
 	{
-		double originOrdinal1 = getOriginOrdinal1();
-		double originOrdinal2 = getOriginOrdinal2();
-		double originOrdinal3 = getZOffset();
+		const double originOrdinal1 = getOriginOrdinal1();
+		const double originOrdinal2 = getOriginOrdinal2();
+		const double originOrdinal3 = getZOffset();
 		if (originOrdinal1 == .0 && originOrdinal2 == .0 && originOrdinal3 == .0)
 			return;
 
@@ -299,7 +299,7 @@ gsoap_resqml2_0_1::eml20__AxisOrder2d AbstractLocal3dCrs::getAxisOrder() const
 	}
 }
 
-void AbstractLocal3dCrs::setAxisOrder(const gsoap_resqml2_0_1::eml20__AxisOrder2d & axisOrder) const
+void AbstractLocal3dCrs::setAxisOrder(gsoap_resqml2_0_1::eml20__AxisOrder2d axisOrder) const
 {
 	if (gsoapProxy2_0_1 != nullptr) {
 		static_cast<gsoap_resqml2_0_1::resqml2__AbstractLocal3dCrs*>(gsoapProxy2_0_1)->ProjectedAxisOrder = axisOrder;

--- a/src/resqml2/AbstractLocal3dCrs.h
+++ b/src/resqml2/AbstractLocal3dCrs.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_NS
 {
-	class DLL_IMPORT_OR_EXPORT AbstractLocal3dCrs : public COMMON_NS::AbstractObject
+	class AbstractLocal3dCrs : public COMMON_NS::AbstractObject
 	{
 	protected:
 
@@ -61,104 +61,104 @@ namespace RESQML2_NS
 		/**
 		* Get the first origin ordinal (usually called X) of the local CRS in the global projected CRS.
 		*/
-		double getOriginOrdinal1() const;
+		DLL_IMPORT_OR_EXPORT double getOriginOrdinal1() const;
 
 		/**
 		* Get the second origin ordinal (usually called Y) of the local CRS in the global projected CRS.
 		*/
-		double getOriginOrdinal2() const;
+		DLL_IMPORT_OR_EXPORT double getOriginOrdinal2() const;
 
 		/**
 		* Get the depth or elevation origin of this local CRS in the global vertical CRS.
 		* If this local CRS is a time CRS, this value defines the Seismic Reference Datum.
 		*/
-		double getOriginDepthOrElevation() const;
+		DLL_IMPORT_OR_EXPORT double getOriginDepthOrElevation() const;
 
 		/**
 		* Get the rotation in radians of the the local Y axis relative to the global projected axis which is 90 degrees counter-clockwise from the other global axis.
 		* A positive value indicates a clockwise rotation from the global axis.
 		* A negative value indicates a counterclockwise rotation form the global axis.
 		*/
-		double getArealRotation() const;
+		DLL_IMPORT_OR_EXPORT double getArealRotation() const;
 
 		/**
 		* Indicates if the depth or elevation values given in this local CRS are depth ones or elevation ones.
 		*/
-		bool isDepthOriented() const;
+		DLL_IMPORT_OR_EXPORT bool isDepthOriented() const;
 
 		/**
 		* Indicates either the associated projected Crs is identified by means of EPSG or not.
 		*/
-		bool isProjectedCrsDefinedWithEpsg() const;
+		DLL_IMPORT_OR_EXPORT bool isProjectedCrsDefinedWithEpsg() const;
 
 		/**
 		* Indicates either the associated projected Crs is unknown.
 		*/
-		virtual bool isProjectedCrsUnknown() const;
+		DLL_IMPORT_OR_EXPORT virtual bool isProjectedCrsUnknown() const;
 
 		/**
 		* Get the reason why the projected Crs is unknown.
 		*/
-		const std::string & getProjectedCrsUnknownReason() const;
+		DLL_IMPORT_OR_EXPORT const std::string & getProjectedCrsUnknownReason() const;
 
 		/**
 		* Get the EPSG code of the projected CRS
 		*/
-		unsigned long long getProjectedCrsEpsgCode() const;
+		DLL_IMPORT_OR_EXPORT unsigned long long getProjectedCrsEpsgCode() const;
 
 		/**
 		* Indicates either the associated vertical Crs is identified by means of EPSG or not.
 		*/
-		bool isVerticalCrsDefinedWithEpsg() const;
+		DLL_IMPORT_OR_EXPORT bool isVerticalCrsDefinedWithEpsg() const;
 
 		/**
 		* Indicates either the associated vertical Crs is unknown.
 		*/
-		bool isVerticalCrsUnknown() const;
+		DLL_IMPORT_OR_EXPORT bool isVerticalCrsUnknown() const;
 
 		/**
 		* Get the reason why the vertical Crs is unknown.
 		*/
-		const std::string & getVerticalCrsUnknownReason() const;
+		DLL_IMPORT_OR_EXPORT const std::string & getVerticalCrsUnknownReason() const;
 
 		/**
 		* Get the EPSG code of the vertical CRS
 		*/
-		unsigned long long getVerticalCrsEpsgCode() const;
+		DLL_IMPORT_OR_EXPORT unsigned long long getVerticalCrsEpsgCode() const;
 
 		/**
 		 * Get the vertical crs unit as a string
 		 */
-		std::string getVerticalCrsUnitAsString() const;
+		DLL_IMPORT_OR_EXPORT std::string getVerticalCrsUnitAsString() const;
 
 		gsoap_resqml2_0_1::eml20__PlaneAngleUom getArealRotationUom() const;
 
 		/**
 		* Get the projected crs unit
 		*/
-		gsoap_resqml2_0_1::eml20__LengthUom getProjectedCrsUnit() const;
+		DLL_IMPORT_OR_EXPORT gsoap_resqml2_0_1::eml20__LengthUom getProjectedCrsUnit() const;
 
 		/**
 		* Get the projected crs unit as a string
 		*/
-		std::string getProjectedCrsUnitAsString() const;
+		DLL_IMPORT_OR_EXPORT std::string getProjectedCrsUnitAsString() const;
 
 		/**
 		* Get the vertical crs unit
 		*/
-		gsoap_resqml2_0_1::eml20__LengthUom getVerticalCrsUnit() const;
+		DLL_IMPORT_OR_EXPORT gsoap_resqml2_0_1::eml20__LengthUom getVerticalCrsUnit() const;
 
 		/**
 		* Get the axis order of the projected Crs
 		*/
-		gsoap_resqml2_0_1::eml20__AxisOrder2d getAxisOrder() const;
+		DLL_IMPORT_OR_EXPORT gsoap_resqml2_0_1::eml20__AxisOrder2d getAxisOrder() const;
 
 		/**
 		* Set the axis order of the projected Crs
 		*/
-		void setAxisOrder(const gsoap_resqml2_0_1::eml20__AxisOrder2d & axisOrder) const;
+		DLL_IMPORT_OR_EXPORT void setAxisOrder(gsoap_resqml2_0_1::eml20__AxisOrder2d axisOrder) const;
 
-		void convertXyzPointsToGlobalCrs(double * xyzPoints, const ULONG64 & xyzPointCount, bool withoutTranslation = false) const;
+		void convertXyzPointsToGlobalCrs(double * xyzPoints, ULONG64 xyzPointCount, bool withoutTranslation = false) const;
 
 	protected:
 		

--- a/src/resqml2_0_1/Grid2dRepresentation.cpp
+++ b/src/resqml2_0_1/Grid2dRepresentation.cpp
@@ -251,14 +251,14 @@ double Grid2dRepresentation::getZOrigin() const
 	return std::numeric_limits<double>::signaling_NaN();
 }
 
-double Grid2dRepresentation::getComponentInGlobalCrs(double x, double y, double z, size_t componentIndex) const
+double Grid2dRepresentation::getComponentInGlobalCrs(double x, double y, double z, size_t componentIndex, bool withoutTranslation) const
 {
 	double result[] = { x, y, z };
 	if (result[componentIndex] != result[componentIndex]) {
 		return result[componentIndex];
 	}
 
-	localCrs->convertXyzPointsToGlobalCrs(result, 1, true);
+	localCrs->convertXyzPointsToGlobalCrs(result, 1, withoutTranslation);
 
 	return result[componentIndex];
 }
@@ -337,17 +337,17 @@ double Grid2dRepresentation::getZJOffset() const
 
 double Grid2dRepresentation::getXJOffsetInGlobalCrs() const
 {
-	return getComponentInGlobalCrs(getXJOffset(), getYJOffset(), getZJOffset(), 0);
+	return getComponentInGlobalCrs(getXJOffset(), getYJOffset(), getZJOffset(), 0, true);
 }
 
 double Grid2dRepresentation::getYJOffsetInGlobalCrs() const
 {
-	return getComponentInGlobalCrs(getXJOffset(), getYJOffset(), getZJOffset(), 1);
+	return getComponentInGlobalCrs(getXJOffset(), getYJOffset(), getZJOffset(), 1, true);
 }
 
 double Grid2dRepresentation::getZJOffsetInGlobalCrs() const
 {
-	return getComponentInGlobalCrs(getXJOffset(), getYJOffset(), getZJOffset(), 2);
+	return getComponentInGlobalCrs(getXJOffset(), getYJOffset(), getZJOffset(), 2, true);
 }
 
 double Grid2dRepresentation::getXIOffset() const
@@ -409,17 +409,17 @@ double Grid2dRepresentation::getZIOffset() const
 
 double Grid2dRepresentation::getXIOffsetInGlobalCrs() const
 {
-	return getComponentInGlobalCrs(getXIOffset(), getYIOffset(), getZIOffset(), 0);
+	return getComponentInGlobalCrs(getXIOffset(), getYIOffset(), getZIOffset(), 0, true);
 }
 
 double Grid2dRepresentation::getYIOffsetInGlobalCrs() const
 {
-	return getComponentInGlobalCrs(getXIOffset(), getYIOffset(), getZIOffset(), 1);
+	return getComponentInGlobalCrs(getXIOffset(), getYIOffset(), getZIOffset(), 1, true);
 }
 
 double Grid2dRepresentation::getZIOffsetInGlobalCrs() const
 {
-	return getComponentInGlobalCrs(getXIOffset(), getYIOffset(), getZIOffset(), 2);
+	return getComponentInGlobalCrs(getXIOffset(), getYIOffset(), getZIOffset(), 2, true);
 }
 
 bool Grid2dRepresentation::isJSpacingConstant() const

--- a/src/resqml2_0_1/Grid2dRepresentation.h
+++ b/src/resqml2_0_1/Grid2dRepresentation.h
@@ -36,9 +36,12 @@ namespace RESQML2_0_1_NS
 		void setSupportingRepresentation(Grid2dRepresentation * supportingRep);
 
 		/**
-		* @param componentIndex	0 is X, 1 is Y and 2 is Z
+		* Get a component of an XYZ structure.
+		*
+		* @param componentIndex		The XYZ structure component index to get : 0 is X, 1 is Y and 2 is Z
+		* @param withoutTranslation	Sometime we jsut wnat to apply rotation but not translation. For example, it is the case for offset which are XYZ "vectors" and not "XYZ" points.
 		*/
-		double getComponentInGlobalCrs(double x, double y, double z, size_t componentIndex) const;
+		double getComponentInGlobalCrs(double x, double y, double z, size_t componentIndex, bool withoutTranslation = false) const;
 
 	public:
 

--- a/src/resqml2_0_1/LocalDepth3dCrs.h
+++ b/src/resqml2_0_1/LocalDepth3dCrs.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT LocalDepth3dCrs : public RESQML2_NS::AbstractLocal3dCrs
+	class LocalDepth3dCrs : public RESQML2_NS::AbstractLocal3dCrs
 	{
 	private:
 		void init(soap* soapContext, const std::string & guid, const std::string & title,
@@ -139,8 +139,8 @@ namespace RESQML2_0_1_NS
 		//********** INHERITED FROM AbstractObjectWithDcMetadata ***********
 		//******************************************************************
 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT std::string getXmlTag() const {return XML_TAG;}
 	};
 }
 

--- a/swig/swigResqml2Include.i
+++ b/swig/swigResqml2Include.i
@@ -178,7 +178,7 @@ namespace RESQML2_NS
 		std::string getVerticalCrsUnitAsString() const;
 		
 		gsoap_resqml2_0_1::eml20__AxisOrder2d getAxisOrder() const;
-		void setAxisOrder(const gsoap_resqml2_0_1::eml20__AxisOrder2d & axisOrder) const;
+		void setAxisOrder(gsoap_resqml2_0_1::eml20__AxisOrder2d axisOrder) const;
 	};
 	
 	class MdDatum : public COMMON_NS::AbstractObject

--- a/test/resqml2_0_1test/AbstractColumnLayerGridRepresentationTest.cpp
+++ b/test/resqml2_0_1test/AbstractColumnLayerGridRepresentationTest.cpp
@@ -22,11 +22,11 @@ using namespace std;
 using namespace COMMON_NS;
 using namespace resqml2_0_1test;
 
-AbstractColumnLayerGridRepresentationTest::AbstractColumnLayerGridRepresentationTest(const string & epcDocPath, const string & uuid, const string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInGlobalCrs)
-	: AbstractGridRepresentationTest(epcDocPath, uuid, title, xyzPointCountOfAllPatches, xyzPointsOfAllPatchesInGlobalCrs) {
+AbstractColumnLayerGridRepresentationTest::AbstractColumnLayerGridRepresentationTest(const string & epcDocPath, const string & uuid, const string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInLocalCrs)
+	: AbstractGridRepresentationTest(epcDocPath, uuid, title, xyzPointCountOfAllPatches, xyzPointsOfAllPatchesInLocalCrs) {
 }
 
-AbstractColumnLayerGridRepresentationTest::AbstractColumnLayerGridRepresentationTest(EpcDocument * epcDoc, const string & uuid, const string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInGlobalCrs)
-	: AbstractGridRepresentationTest(epcDoc, uuid, title, xyzPointCountOfAllPatches, xyzPointsOfAllPatchesInGlobalCrs) {
+AbstractColumnLayerGridRepresentationTest::AbstractColumnLayerGridRepresentationTest(EpcDocument * epcDoc, const string & uuid, const string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInLocalCrs)
+	: AbstractGridRepresentationTest(epcDoc, uuid, title, xyzPointCountOfAllPatches, xyzPointsOfAllPatchesInLocalCrs) {
 }
 

--- a/test/resqml2_0_1test/AbstractColumnLayerGridRepresentationTest.h
+++ b/test/resqml2_0_1test/AbstractColumnLayerGridRepresentationTest.h
@@ -28,8 +28,8 @@ namespace COMMON_NS {
 namespace resqml2_0_1test {
 	class AbstractColumnLayerGridRepresentationTest : public AbstractGridRepresentationTest {
 	public:
-		AbstractColumnLayerGridRepresentationTest(const std::string & epcDocPath, const std::string & uuid, const std::string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInGlobalCrs);
-		AbstractColumnLayerGridRepresentationTest(COMMON_NS::EpcDocument * epcDoc, const std::string & uuid, const std::string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInGlobalCrs);
+		AbstractColumnLayerGridRepresentationTest(const std::string & epcDocPath, const std::string & uuid, const std::string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInLocalCrs);
+		AbstractColumnLayerGridRepresentationTest(COMMON_NS::EpcDocument * epcDoc, const std::string & uuid, const std::string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInLocalCrs);
 	};
 }
 

--- a/test/resqml2_0_1test/AbstractGridRepresentationTest.cpp
+++ b/test/resqml2_0_1test/AbstractGridRepresentationTest.cpp
@@ -22,11 +22,11 @@ using namespace std;
 using namespace COMMON_NS;
 using namespace resqml2_0_1test;
 
-AbstractGridRepresentationTest::AbstractGridRepresentationTest(const string & epcDocPath, const string & uuid, const string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInGlobalCrs)
-	: AbstractRepresentationTest(epcDocPath, uuid, title, xyzPointCountOfAllPatches, xyzPointsOfAllPatchesInGlobalCrs) {
+AbstractGridRepresentationTest::AbstractGridRepresentationTest(const string & epcDocPath, const string & uuid, const string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInLocalCrs)
+	: AbstractRepresentationTest(epcDocPath, uuid, title, xyzPointCountOfAllPatches, xyzPointsOfAllPatchesInLocalCrs) {
 }
 
-AbstractGridRepresentationTest::AbstractGridRepresentationTest(EpcDocument * epcDoc, const string & uuid, const string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInGlobalCrs)
-	: AbstractRepresentationTest(epcDoc, uuid, title, xyzPointCountOfAllPatches, xyzPointsOfAllPatchesInGlobalCrs) {
+AbstractGridRepresentationTest::AbstractGridRepresentationTest(EpcDocument * epcDoc, const string & uuid, const string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInLocalCrs)
+	: AbstractRepresentationTest(epcDoc, uuid, title, xyzPointCountOfAllPatches, xyzPointsOfAllPatchesInLocalCrs) {
 }
 

--- a/test/resqml2_0_1test/AbstractGridRepresentationTest.h
+++ b/test/resqml2_0_1test/AbstractGridRepresentationTest.h
@@ -28,8 +28,8 @@ namespace COMMON_NS {
 namespace resqml2_0_1test {
 	class AbstractGridRepresentationTest : public AbstractRepresentationTest {
 	public:
-		AbstractGridRepresentationTest(const std::string & epcDocPath, const std::string & uuid, const std::string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInGlobalCrs);
-		AbstractGridRepresentationTest(COMMON_NS::EpcDocument * epcDoc, const std::string & uuid, const std::string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInGlobalCrs);
+		AbstractGridRepresentationTest(const std::string & epcDocPath, const std::string & uuid, const std::string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInLocalCrs);
+		AbstractGridRepresentationTest(COMMON_NS::EpcDocument * epcDoc, const std::string & uuid, const std::string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInLocalCrs);
 	};
 }
 

--- a/test/resqml2_0_1test/AbstractIjkGridRepresentationTest.cpp
+++ b/test/resqml2_0_1test/AbstractIjkGridRepresentationTest.cpp
@@ -22,11 +22,11 @@ using namespace std;
 using namespace COMMON_NS;
 using namespace resqml2_0_1test;
 
-AbstractIjkGridRepresentationTest::AbstractIjkGridRepresentationTest(const string & epcDocPath, const string & uuid, const string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInGlobalCrs)
-	: AbstractColumnLayerGridRepresentationTest(epcDocPath, uuid, title, xyzPointCountOfAllPatches, xyzPointsOfAllPatchesInGlobalCrs) {
+AbstractIjkGridRepresentationTest::AbstractIjkGridRepresentationTest(const string & epcDocPath, const string & uuid, const string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInLocalCrs)
+	: AbstractColumnLayerGridRepresentationTest(epcDocPath, uuid, title, xyzPointCountOfAllPatches, xyzPointsOfAllPatchesInLocalCrs) {
 }
 
-AbstractIjkGridRepresentationTest::AbstractIjkGridRepresentationTest(EpcDocument * epcDoc, const string & uuid, const string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInGlobalCrs)
-	: AbstractColumnLayerGridRepresentationTest(epcDoc, uuid, title, xyzPointCountOfAllPatches, xyzPointsOfAllPatchesInGlobalCrs) {
+AbstractIjkGridRepresentationTest::AbstractIjkGridRepresentationTest(EpcDocument * epcDoc, const string & uuid, const string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInLocalCrs)
+	: AbstractColumnLayerGridRepresentationTest(epcDoc, uuid, title, xyzPointCountOfAllPatches, xyzPointsOfAllPatchesInLocalCrs) {
 }
 

--- a/test/resqml2_0_1test/AbstractIjkGridRepresentationTest.h
+++ b/test/resqml2_0_1test/AbstractIjkGridRepresentationTest.h
@@ -28,8 +28,8 @@ namespace COMMON_NS {
 namespace resqml2_0_1test {
 	class AbstractIjkGridRepresentationTest : public AbstractColumnLayerGridRepresentationTest {
 	public:
-		AbstractIjkGridRepresentationTest(const std::string & epcDocPath, const std::string & uuid, const std::string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInGlobalCrs);
-		AbstractIjkGridRepresentationTest(COMMON_NS::EpcDocument * epcDoc, const std::string & uuid, const std::string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInGlobalCrs);
+		AbstractIjkGridRepresentationTest(const std::string & epcDocPath, const std::string & uuid, const std::string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInLocalCrs);
+		AbstractIjkGridRepresentationTest(COMMON_NS::EpcDocument * epcDoc, const std::string & uuid, const std::string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInLocalCrs);
 	};
 }
 

--- a/test/resqml2_0_1test/AbstractRepresentationTest.cpp
+++ b/test/resqml2_0_1test/AbstractRepresentationTest.cpp
@@ -29,12 +29,12 @@ using namespace std;
 using namespace resqml2_0_1test;
 using namespace RESQML2_NS;
 
-AbstractRepresentationTest::AbstractRepresentationTest(const std::string & epcDocPath, const string & uuid, const string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInGlobalCrs) 
-	: AbstractResqmlDataObjectTest(epcDocPath, uuid, title), xyzPointsOfAllPatchesInGlobalCrs(xyzPointsOfAllPatchesInGlobalCrs), xyzPointCountOfAllPatches(xyzPointCountOfAllPatches) {
+AbstractRepresentationTest::AbstractRepresentationTest(const std::string & epcDocPath, const string & uuid, const string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInLocalCrs) 
+	: AbstractResqmlDataObjectTest(epcDocPath, uuid, title), xyzPointsOfAllPatchesInLocalCrs(xyzPointsOfAllPatchesInLocalCrs), xyzPointCountOfAllPatches(xyzPointCountOfAllPatches) {
 }
 
-AbstractRepresentationTest::AbstractRepresentationTest(COMMON_NS::EpcDocument* epcDoc, const string & uuid, const string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInGlobalCrs)
-	: AbstractResqmlDataObjectTest(epcDoc, uuid, title), xyzPointsOfAllPatchesInGlobalCrs(xyzPointsOfAllPatchesInGlobalCrs), xyzPointCountOfAllPatches(xyzPointCountOfAllPatches) {
+AbstractRepresentationTest::AbstractRepresentationTest(COMMON_NS::EpcDocument* epcDoc, const string & uuid, const string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInLocalCrs)
+	: AbstractResqmlDataObjectTest(epcDoc, uuid, title), xyzPointsOfAllPatchesInLocalCrs(xyzPointsOfAllPatchesInLocalCrs), xyzPointCountOfAllPatches(xyzPointCountOfAllPatches) {
 }
 
 void AbstractRepresentationTest::readEpcDoc() {
@@ -43,7 +43,7 @@ void AbstractRepresentationTest::readEpcDoc() {
 	// ****************
 	// geometry testing
 
-	if (this->xyzPointsOfAllPatchesInGlobalCrs != nullptr) {
+	if (xyzPointsOfAllPatchesInLocalCrs != nullptr) {
 		// checking number of points in the geometry
 		AbstractRepresentation* representation = static_cast<AbstractRepresentation*>(this->epcDoc->getDataObjectByUuid(this->uuid));
 		REQUIRE( representation->getXyzPointCountOfAllPatches() == this->xyzPointCountOfAllPatches );
@@ -51,9 +51,9 @@ void AbstractRepresentationTest::readEpcDoc() {
 		// checking values
 		ULONG64 pointCount = 3*this->xyzPointCountOfAllPatches;
 		double * xyzPoint = new double[pointCount];
-		representation->getXyzPointsOfAllPatchesInGlobalCrs(xyzPoint);
+		representation->getXyzPointsOfAllPatches(xyzPoint);
 		for (ULONG64 i=0; i<pointCount; ++i) {
-			REQUIRE( this->xyzPointsOfAllPatchesInGlobalCrs[i] == xyzPoint[i] ); 
+			REQUIRE( xyzPointsOfAllPatchesInLocalCrs[i] == xyzPoint[i] ); 
 		}
 		delete[] xyzPoint;
 	}

--- a/test/resqml2_0_1test/AbstractRepresentationTest.h
+++ b/test/resqml2_0_1test/AbstractRepresentationTest.h
@@ -44,7 +44,7 @@ namespace resqml2_0_1test {
 		 * @param xyzPointCountOfAllPatches count of xyz points in the whole representation (default 0)
 		 * @param xyzPointsOfAllPatchesInGlobalCrs xyz points values (default nullptr)
 		 */
-		AbstractRepresentationTest(const std::string & epcDocPath, const std::string & uuid, const std::string & title, const ULONG64 & xyzPointCountOfAllPatches = 0, double * xyzPointsOfAllPatchesInGlobalCrs = nullptr);
+		AbstractRepresentationTest(const std::string & epcDocPath, const std::string & uuid, const std::string & title, const ULONG64 & xyzPointCountOfAllPatches = 0, double * xyzPointsOfAllPatchesInLocalCrs = nullptr);
 		
 		/**
 		 * Creation of a testing object from an existing EPC document.
@@ -56,7 +56,7 @@ namespace resqml2_0_1test {
 		 * @param xyzPointCountOfAllPatches count of xyz points in the whole representation (default 0)
 		 * @param xyzPointsOfAllPatchesInGlobalCrs xyz points values (default nullptr)
 		 */
-		AbstractRepresentationTest(COMMON_NS::EpcDocument* epcDoc, const std::string & uuid, const std::string & title, const ULONG64 & xyzPointCountOfAllPatches = 0, double * xyzPointsOfAllPatchesInGlobalCrs = nullptr);
+		AbstractRepresentationTest(COMMON_NS::EpcDocument* epcDoc, const std::string & uuid, const std::string & title, const ULONG64 & xyzPointCountOfAllPatches = 0, double * xyzPointsOfAllPatchesInLocalCrs = nullptr);
 		
 		/**
 		 * Overrides (and calls) AbstractObject::readEpcDoc(). 
@@ -65,7 +65,7 @@ namespace resqml2_0_1test {
 		 */
 		void readEpcDoc();
 	protected:
-		double * xyzPointsOfAllPatchesInGlobalCrs;
+		double * xyzPointsOfAllPatchesInLocalCrs;
 		const ULONG64 xyzPointCountOfAllPatches;
 	};
 }

--- a/test/resqml2_0_1test/AbstractSurfaceRepresentationTest.cpp
+++ b/test/resqml2_0_1test/AbstractSurfaceRepresentationTest.cpp
@@ -21,11 +21,11 @@ under the License.
 using namespace std;
 using namespace resqml2_0_1test;
 
-AbstractSurfaceRepresentationTest::AbstractSurfaceRepresentationTest(const std::string & epcDocPath, const string & uuid, const string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInGlobalCrs) 
-	: AbstractRepresentationTest(epcDocPath, uuid, title, xyzPointCountOfAllPatches, xyzPointsOfAllPatchesInGlobalCrs) {
+AbstractSurfaceRepresentationTest::AbstractSurfaceRepresentationTest(const std::string & epcDocPath, const string & uuid, const string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInLocalCrs) 
+	: AbstractRepresentationTest(epcDocPath, uuid, title, xyzPointCountOfAllPatches, xyzPointsOfAllPatchesInLocalCrs) {
 }
 
-AbstractSurfaceRepresentationTest::AbstractSurfaceRepresentationTest(COMMON_NS::EpcDocument* epcDoc, const string & uuid, const string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInGlobalCrs)
-	: AbstractRepresentationTest(epcDoc, uuid, title, xyzPointCountOfAllPatches, xyzPointsOfAllPatchesInGlobalCrs) {
+AbstractSurfaceRepresentationTest::AbstractSurfaceRepresentationTest(COMMON_NS::EpcDocument* epcDoc, const string & uuid, const string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInLocalCrs)
+	: AbstractRepresentationTest(epcDoc, uuid, title, xyzPointCountOfAllPatches, xyzPointsOfAllPatchesInLocalCrs) {
 }
 

--- a/test/resqml2_0_1test/AbstractSurfaceRepresentationTest.h
+++ b/test/resqml2_0_1test/AbstractSurfaceRepresentationTest.h
@@ -28,8 +28,8 @@ namespace COMMON_NS {
 namespace resqml2_0_1test {
 	class AbstractSurfaceRepresentationTest : public AbstractRepresentationTest {
 	public:
-		AbstractSurfaceRepresentationTest(const std::string & epcDocPath, const std::string & uuid, const std::string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInGlobalCrs);
-		AbstractSurfaceRepresentationTest(COMMON_NS::EpcDocument* epcDoc, const std::string & uuid, const std::string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInGlobalCrs);
+		AbstractSurfaceRepresentationTest(const std::string & epcDocPath, const std::string & uuid, const std::string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInLocalCrs);
+		AbstractSurfaceRepresentationTest(COMMON_NS::EpcDocument* epcDoc, const std::string & uuid, const std::string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInLocalCrs);
 	};
 }
 

--- a/test/resqml2_0_1test/BigIjkGridExplicitRepresentationTest.cpp
+++ b/test/resqml2_0_1test/BigIjkGridExplicitRepresentationTest.cpp
@@ -70,7 +70,7 @@ void BigIjkGridExplicitRepresentationTest::initEpcDocHandler() {
 	unsigned int * splitCoordinateLineColumnCumulativeCount = new unsigned int[faultCount * (jCount + 1)];
 	unsigned int * splitCoordinateLineColumns = new unsigned int[(faultCount * (jCount + 1)) + (faultCount * (jCount - 1))];
 	initSplitCoordinateLine(pillarOfCoordinateLine, splitCoordinateLineColumnCumulativeCount, splitCoordinateLineColumns);
-	ijkGrid->setGeometryAsCoordinateLineNodes(gsoap_resqml2_0_1::resqml2__PillarShape__vertical, gsoap_resqml2_0_1::resqml2__KDirection__down, false, this->xyzPointsOfAllPatchesInGlobalCrs, hdfProxy,
+	ijkGrid->setGeometryAsCoordinateLineNodes(gsoap_resqml2_0_1::resqml2__PillarShape__vertical, gsoap_resqml2_0_1::resqml2__KDirection__down, false, this->xyzPointsOfAllPatchesInLocalCrs, hdfProxy,
 		faultCount * (jCount + 1), pillarOfCoordinateLine, splitCoordinateLineColumnCumulativeCount, splitCoordinateLineColumns);
 
 	// adding a discrete property

--- a/test/resqml2_0_1test/FaultSinglePatchTriangulatedSetRepresentationTest.cpp
+++ b/test/resqml2_0_1test/FaultSinglePatchTriangulatedSetRepresentationTest.cpp
@@ -40,28 +40,26 @@ FaultSinglePatchTriangulatedSetRepresentationTest::FaultSinglePatchTriangulatedS
 	: TriangulatedSetRepresentationTest(epcDocument, uuidFaultSinglePatchTriangulatedSetRepresentation, titleFaultSinglePatchTriangulatedSetRepresentation, nodesCountFaultSinglePatchTriangulatedSetRepresentation, nodesFaultSinglePatchTriangulatedSetRepresentation)
 {
 	if (init)
-		this->initEpcDoc();
+		initEpcDoc();
 	else
-		this->readEpcDoc();
+		readEpcDoc();
 }
 
 void FaultSinglePatchTriangulatedSetRepresentationTest::initEpcDocHandler()
 {
-	FaultInterpretation * interp = static_cast<FaultInterpretation*>(this->epcDoc->getDataObjectByUuid(uuidFaultInterpretation));
+	FaultInterpretation * interp = epcDoc->getDataObjectByUuid<FaultInterpretation>(uuidFaultInterpretation);
 	if (interp == nullptr) {
-		FaultInterpretationTest * interpTest = new FaultInterpretationTest(this->epcDoc, true);
-		interp = static_cast<FaultInterpretation*>(this->epcDoc->getDataObjectByUuid(uuidFaultInterpretation));
-		delete interpTest;
+		FaultInterpretationTest interpTest(epcDoc, true);
+		interp = epcDoc->getDataObjectByUuid<FaultInterpretation>(uuidFaultInterpretation);
 	}
 
-	LocalDepth3dCrs * crs = static_cast<LocalDepth3dCrs *>(this->epcDoc->getDataObjectByUuid(LocalDepth3dCrsTest::defaultUuid));
+	LocalDepth3dCrs * crs = epcDoc->getDataObjectByUuid<LocalDepth3dCrs>(LocalDepth3dCrsTest::defaultUuid);
 	if (crs == nullptr) {
-		LocalDepth3dCrsTest * crsTest = new LocalDepth3dCrsTest(this->epcDoc, true);
-		crs = static_cast<LocalDepth3dCrs *>(this->epcDoc->getDataObjectByUuid(LocalDepth3dCrsTest::defaultUuid));
-		delete crsTest;
+		LocalDepth3dCrsTest crsTest(epcDoc, true);
+		crs = epcDoc->getDataObjectByUuid<LocalDepth3dCrs>(LocalDepth3dCrsTest::defaultUuid);
 	}
 
-	TriangulatedSetRepresentation* rep = this->epcDoc->createTriangulatedSetRepresentation(interp, crs, this->uuid, this->title);
+	TriangulatedSetRepresentation* rep = epcDoc->createTriangulatedSetRepresentation(interp, crs, uuid, title);
 	REQUIRE( rep != nullptr );
 
 	unsigned int triangleNodeIndexFault[60] = {0,4,3, 0,1,4, 1,2,4, 2,5,4,
@@ -69,17 +67,16 @@ void FaultSinglePatchTriangulatedSetRepresentationTest::initEpcDocHandler()
 		6,10,9, 6,7,10, 7,8,10, 8,11,10,
 		9,13,12, 9,10,13, 10,11,13, 11,14,13,
 		12,16,15, 12,13,16, 13,14,16, 14,17,16 };
-	rep->pushBackTrianglePatch(18, this->xyzPointsOfAllPatchesInGlobalCrs, 20, triangleNodeIndexFault, this->epcDoc->getHdfProxySet()[0]);
+	rep->pushBackTrianglePatch(18, xyzPointsOfAllPatchesInLocalCrs, 20, triangleNodeIndexFault, epcDoc->getHdfProxySet()[0]);
 }
 
 void FaultSinglePatchTriangulatedSetRepresentationTest::readEpcDocHandler()
 {
 	// reading dependencies
-	FaultInterpretationTest * interpTest = new FaultInterpretationTest(this->epcDoc, false);
-	LocalDepth3dCrsTest * crsTest = new LocalDepth3dCrsTest(this->epcDoc, false);
+	FaultInterpretationTest * interpTest = new FaultInterpretationTest(epcDoc, false);
+	LocalDepth3dCrsTest * crsTest = new LocalDepth3dCrsTest(epcDoc, false);
 
 	// cleaning
 	delete interpTest;
 	delete crsTest;
 }
-

--- a/test/resqml2_0_1test/Grid2dRepresentationTest.cpp
+++ b/test/resqml2_0_1test/Grid2dRepresentationTest.cpp
@@ -1,0 +1,117 @@
+/*-----------------------------------------------------------------------
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"; you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-----------------------------------------------------------------------*/
+#include "resqml2_0_1test/Grid2dRepresentationTest.h"
+#include "../catch.hpp"
+#include "../config.h" 
+#include "resqml2_0_1/Horizon.h"
+#include "resqml2_0_1/HorizonInterpretation.h"
+#include "resqml2_0_1/Grid2dRepresentation.h"
+#include "resqml2_0_1/LocalDepth3dCrs.h"
+#include "common/HdfProxy.h"
+#include "resqml2_0_1test/SeismicLatticeRepresentationTest.h"
+#include "resqml2_0_1test/LocalDepth3dCrsTest.h"
+
+using namespace std;
+using namespace resqml2_0_1test;
+using namespace COMMON_NS;
+using namespace RESQML2_0_1_NS;
+
+const char* Grid2dRepresentationTest::defaultUuidFeature = "25ecaf5e-90f2-482f-a3cc-9707b772f62d";
+const char* Grid2dRepresentationTest::defaultTitleFeature = "Horizon Feature";
+const char* Grid2dRepresentationTest::defaultUuidInterp = "d058e544-2946-4bb4-a0e4-ed19e9cbc84e";
+const char* Grid2dRepresentationTest::defaultTitleInterp = "Horizon Interp";
+const char* Grid2dRepresentationTest::defaultUuid = "6cbfb84d-f5c8-4595-9e7f-b003d0fe81c2";
+const char* Grid2dRepresentationTest::defaultTitle = "Grid 2d Representation";
+
+Grid2dRepresentationTest::Grid2dRepresentationTest(const string & epcDocPath)
+	: AbstractSurfaceRepresentationTest(epcDocPath, defaultUuid, defaultTitle, 8, nullptr)
+{
+}
+
+Grid2dRepresentationTest::Grid2dRepresentationTest(EpcDocument * epcDocument, bool init)
+	: AbstractSurfaceRepresentationTest(epcDocument, defaultUuid, defaultTitle, 8, nullptr)
+{
+	if (init)
+		initEpcDoc();
+	else
+		readEpcDoc();
+}
+
+void Grid2dRepresentationTest::initEpcDocHandler()
+{
+	LocalDepth3dCrs * crs = epcDoc->getDataObjectByUuid<LocalDepth3dCrs>(LocalDepth3dCrsTest::defaultUuid);
+	if (crs == nullptr) {
+		LocalDepth3dCrsTest crsTest(epcDoc, true);
+		crs = epcDoc->getDataObjectByUuid<LocalDepth3dCrs>(LocalDepth3dCrsTest::defaultUuid);
+	}
+
+	Horizon* feature = epcDoc->createHorizon(defaultUuidFeature, defaultTitleFeature);
+	HorizonInterpretation* interp = epcDoc->createHorizonInterpretation(feature, defaultUuidInterp, defaultTitleInterp);
+	Grid2dRepresentation* rep = epcDoc->createGrid2dRepresentation(interp, crs, uuid, title);
+
+	Grid2dRepresentation* supportingRep = epcDoc->getDataObjectByUuid<Grid2dRepresentation>(SeismicLatticeRepresentationTest::defaultUuid);
+	if (supportingRep == nullptr) {
+		SeismicLatticeRepresentationTest seisTest(epcDoc, true);
+		supportingRep = epcDoc->getDataObjectByUuid<Grid2dRepresentation>(SeismicLatticeRepresentationTest::defaultUuid);
+	}
+
+	double zValues[8] = { 300, 300, 350, 350, 300, 300, 350, 350 };
+	rep->setGeometryAsArray2dOfExplicitZ(zValues, 4, 2, epcDoc->getHdfProxySet()[0], supportingRep);
+}
+
+void Grid2dRepresentationTest::readEpcDocHandler()
+{
+	// Grid 2D
+	RESQML2_0_1_NS::Grid2dRepresentation* rep = epcDoc->getDataObjectByUuid<RESQML2_0_1_NS::Grid2dRepresentation>(defaultUuid);
+	REQUIRE(rep->getSupportingRepresentation() != nullptr);
+	REQUIRE(rep->getSeismicSupportOfPatch(0) == nullptr);
+	REQUIRE((rep->isISpacingConstant() && rep->isJSpacingConstant()));
+	REQUIRE(rep->getXOrigin() == .0);
+	REQUIRE(rep->getXOriginInGlobalCrs() == 1000);
+	REQUIRE(rep->getYOrigin() == .0);
+	REQUIRE(rep->getYOriginInGlobalCrs() == 2000);
+	REQUIRE(rep->getNodeCountAlongIAxis() == 4);
+	REQUIRE(rep->getNodeCountAlongJAxis() == 2);
+	REQUIRE(rep->getISpacing() == 250.0);
+	REQUIRE(rep->getJSpacing() == 200.0);
+	REQUIRE(rep->getIndexOriginOnSupportingRepresentation() == 0);
+	REQUIRE(rep->getIndexOffsetOnSupportingRepresentation(0) == 1);
+	REQUIRE(rep->getNodeCountOnSupportingRepresentation(1) == 4);
+
+	double* zValues = new double[8];
+	rep->getZValues(zValues);
+	REQUIRE(zValues[0] == 300);
+	REQUIRE(zValues[1] == 300);
+	REQUIRE(zValues[2] == 350);
+	REQUIRE(zValues[3] == 350);
+	REQUIRE(zValues[4] == 300);
+	REQUIRE(zValues[5] == 300);
+	REQUIRE(zValues[6] == 350);
+	REQUIRE(zValues[7] == 350);
+	rep->getZValuesInGlobalCrs(zValues);
+	REQUIRE(zValues[0] == 3300);
+	REQUIRE(zValues[1] == 3300);
+	REQUIRE(zValues[2] == 3350);
+	REQUIRE(zValues[3] == 3350);
+	REQUIRE(zValues[4] == 3300);
+	REQUIRE(zValues[5] == 3300);
+	REQUIRE(zValues[6] == 3350);
+	REQUIRE(zValues[7] == 3350);
+	delete[] zValues;
+}

--- a/test/resqml2_0_1test/Grid2dRepresentationTest.h
+++ b/test/resqml2_0_1test/Grid2dRepresentationTest.h
@@ -18,21 +18,41 @@ under the License.
 -----------------------------------------------------------------------*/
 #pragma once
 
-#include "AbstractGridRepresentationTest.h"
-#include <iostream>
+#include "AbstractSurfaceRepresentationTest.h"
+#include <string>
 
 namespace COMMON_NS {
 	class EpcDocument;
 }
 
 namespace resqml2_0_1test {
-	class UnstructuredGridRepresentationTest : public AbstractGridRepresentationTest {
+	class Grid2dRepresentationTest : public AbstractSurfaceRepresentationTest {
 	public:
+		static const char* defaultUuidFeature;
+		static const char* defaultTitleFeature;
+		static const char* defaultUuidInterp;
+		static const char* defaultTitleInterp;
 		static const char* defaultUuid;
 		static const char* defaultTitle;
 
-		UnstructuredGridRepresentationTest(const std::string & epcDocPath, const std::string & uuid, const std::string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInLocalCrs);
-		UnstructuredGridRepresentationTest(COMMON_NS::EpcDocument * epcDoc, const std::string & uuid, const std::string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInLocalCrs);
+		/**
+		* Creation of a testing object from an EPC document path. At serialize() call,
+		* exising .epc file will be erased. 
+		* @param epcDocPath the path of the .epc file (including .epc extension)
+		*/
+		Grid2dRepresentationTest(const std::string & epcDocPath);
+
+		/**
+		* Creation of a testing object from an existing EPC document.
+		* @param epcDoc an existing EPC document
+		* @param init true if this object is created for initialization purpose else false if it is 
+		* created for reading purpose. According to init value a iniEpcDoc() or readEpcDoc() is called.
+		*/
+		Grid2dRepresentationTest(COMMON_NS::EpcDocument * epcDocument, bool init);
+	protected:
+		void initEpcDocHandler();
+		void readEpcDocHandler();
 	};
 }
+
 

--- a/test/resqml2_0_1test/IjkGridExplicitRepresentationTest.cpp
+++ b/test/resqml2_0_1test/IjkGridExplicitRepresentationTest.cpp
@@ -60,7 +60,7 @@ void IjkGridExplicitRepresentationTest::initEpcDocHandler() {
 	unsigned int pillarOfCoordinateLine[2] = {1,4};
 	unsigned int splitCoordinateLineColumnCumulativeCount[2] = {1,2};
 	unsigned int splitCoordinateLineColumns[2] = {1,1};
-	ijkGrid->setGeometryAsCoordinateLineNodes(gsoap_resqml2_0_1::resqml2__PillarShape__vertical, gsoap_resqml2_0_1::resqml2__KDirection__down, false, this->xyzPointsOfAllPatchesInGlobalCrs, hdfProxy,
+	ijkGrid->setGeometryAsCoordinateLineNodes(gsoap_resqml2_0_1::resqml2__PillarShape__vertical, gsoap_resqml2_0_1::resqml2__KDirection__down, false, this->xyzPointsOfAllPatchesInLocalCrs, hdfProxy,
 		2, pillarOfCoordinateLine, splitCoordinateLineColumnCumulativeCount, splitCoordinateLineColumns);
 
 	// cleaning

--- a/test/resqml2_0_1test/LgrOnRightHanded4x3x2ExplicitIjkGrid.cpp
+++ b/test/resqml2_0_1test/LgrOnRightHanded4x3x2ExplicitIjkGrid.cpp
@@ -81,7 +81,7 @@ void LgrOnRightHanded4x3x2ExplicitIjkGrid::initEpcDocHandler() {
 
 	// creating the child ijk grid
 	RESQML2_0_1_NS::IjkGridExplicitRepresentation* childGrid = epcDoc->createIjkGridExplicitRepresentation(crs, uuid, title, 3, 1, 4);
-	childGrid->setGeometryAsCoordinateLineNodes(gsoap_resqml2_0_1::resqml2__PillarShape__vertical, gsoap_resqml2_0_1::resqml2__KDirection__down, false, xyzPointsOfAllPatchesInGlobalCrs, hdfProxy);
+	childGrid->setGeometryAsCoordinateLineNodes(gsoap_resqml2_0_1::resqml2__PillarShape__vertical, gsoap_resqml2_0_1::resqml2__KDirection__down, false, xyzPointsOfAllPatchesInLocalCrs, hdfProxy);
 	childGrid->setParentWindow(
 		0, 3, 1, 1,
 		0, 1, 1, 1,

--- a/test/resqml2_0_1test/LocalDepth3dCrsTest.cpp
+++ b/test/resqml2_0_1test/LocalDepth3dCrsTest.cpp
@@ -21,9 +21,12 @@ under the License.
 #include "common/EpcDocument.h"
 #include "../catch.hpp"
 
+#include "resqml2_0_1/LocalDepth3dCrs.h"
+
 using namespace resqml2_0_1test;
 using namespace COMMON_NS;
 using namespace std;
+using namespace RESQML2_0_1_NS;
 
 const char* LocalDepth3dCrsTest::defaultUuid = "a8effb2c-c94f-4d88-ae76-581ff14a4b96";
 const char* LocalDepth3dCrsTest::defaultTitle = "Local Depth 3d Crs Test";
@@ -37,18 +40,26 @@ LocalDepth3dCrsTest::LocalDepth3dCrsTest(EpcDocument* epcDoc, bool init)
 	: AbstractLocal3dCrsTest(epcDoc, defaultUuid, defaultTitle)
 {
 	if (init)
-		this->initEpcDoc();
+		initEpcDoc();
 	else
-		this->readEpcDoc();
+		readEpcDoc();
 }
 
 void LocalDepth3dCrsTest::initEpcDocHandler()
 {
-	this->epcDoc->createLocalDepth3dCrs(uuid, title, .0, .0, .0, .0, gsoap_resqml2_0_1::eml20__LengthUom__m, 23031, gsoap_resqml2_0_1::eml20__LengthUom__m, "Unknown", false);
+	epcDoc->createLocalDepth3dCrs(uuid, title, 1000, 2000, 3000, .0, gsoap_resqml2_0_1::eml20__LengthUom__m, 23031, gsoap_resqml2_0_1::eml20__LengthUom__ft, "Unknown", false);
 }
 
 void LocalDepth3dCrsTest::readEpcDocHandler()
 {
 	REQUIRE( epcDoc->getLocalDepth3dCrsSet().size() == 1 );
+	LocalDepth3dCrs* crs = epcDoc->getDataObjectByUuid<LocalDepth3dCrs>(uuid);
+	REQUIRE(crs->getOriginOrdinal1() == 1000);
+	REQUIRE(crs->getOriginOrdinal2() == 2000);
+	REQUIRE(crs->getOriginDepthOrElevation() == 3000);
+	REQUIRE(crs->getProjectedCrsEpsgCode() == 23031);
+	REQUIRE(crs->isVerticalCrsUnknown());
+	REQUIRE(crs->getProjectedCrsUnit() == gsoap_resqml2_0_1::eml20__LengthUom__m);
+	REQUIRE(crs->getVerticalCrsUnit() == gsoap_resqml2_0_1::eml20__LengthUom__ft);
+	REQUIRE(crs->isDepthOriented());
 }
-

--- a/test/resqml2_0_1test/OneTetrahedronUnstructuredGridRepresentationTest.cpp
+++ b/test/resqml2_0_1test/OneTetrahedronUnstructuredGridRepresentationTest.cpp
@@ -56,7 +56,7 @@ void OneTetrahedronUnstructuredGridRepresentationTest::initEpcDocHandler() {
 	unsigned char faceRightHandness[4] = { 0, 0, 1, 1 };
 	ULONG64 faceIndicesPerCell[4] = { 0, 1, 2, 3 };
 	ULONG64 nodeIndicesPerCell[12] = { 0, 1, 2, 1, 2, 3, 0, 1, 3, 0, 2, 3 };
-	tetraGrid->setTetrahedraOnlyGeometry(faceRightHandness, this->xyzPointsOfAllPatchesInGlobalCrs, 4, 4, hdfProxy, faceIndicesPerCell, nodeIndicesPerCell);
+	tetraGrid->setTetrahedraOnlyGeometry(faceRightHandness, this->xyzPointsOfAllPatchesInLocalCrs, 4, 4, hdfProxy, faceIndicesPerCell, nodeIndicesPerCell);
 
 	// cleaning
 	delete crsTest;

--- a/test/resqml2_0_1test/RightHanded4x3x2ExplicitIjkGrid.cpp
+++ b/test/resqml2_0_1test/RightHanded4x3x2ExplicitIjkGrid.cpp
@@ -79,7 +79,7 @@ void RightHanded4x3x2ExplicitIjkGrid::initEpcDocHandler() {
 	unsigned int pillarOfCoordinateLine[4] = { 17, 12, 7, 2 };
 	unsigned int splitCoordinateLineColumnCumulativeCount[4] = { 1, 3, 5, 6 };
 	unsigned int splitCoordinateLineColumns[6] = { 10, 10, 6, 6, 2, 2 };
-	ijkGrid->setGeometryAsCoordinateLineNodes(gsoap_resqml2_0_1::resqml2__PillarShape__vertical, gsoap_resqml2_0_1::resqml2__KDirection__down, false, this->xyzPointsOfAllPatchesInGlobalCrs, hdfProxy,
+	ijkGrid->setGeometryAsCoordinateLineNodes(gsoap_resqml2_0_1::resqml2__PillarShape__vertical, gsoap_resqml2_0_1::resqml2__KDirection__down, false, this->xyzPointsOfAllPatchesInLocalCrs, hdfProxy,
 		4, pillarOfCoordinateLine, splitCoordinateLineColumnCumulativeCount, splitCoordinateLineColumns);
 
 	// Enabling cell

--- a/test/resqml2_0_1test/SeismicLatticeRepresentationTest.cpp
+++ b/test/resqml2_0_1test/SeismicLatticeRepresentationTest.cpp
@@ -48,14 +48,18 @@ SeismicLatticeRepresentationTest::SeismicLatticeRepresentationTest(EpcDocument *
 	: AbstractSurfaceRepresentationTest(epcDocument, defaultUuid, defaultTitle, 8, nullptr)
 {
 	if (init)
-		this->initEpcDoc();
+		initEpcDoc();
 	else
-		this->readEpcDoc();
+		readEpcDoc();
 }
 
 void SeismicLatticeRepresentationTest::initEpcDocHandler()
 {
 	LocalDepth3dCrs * crs = epcDoc->getDataObjectByUuid<LocalDepth3dCrs>(LocalDepth3dCrsTest::defaultUuid);
+	if (crs == nullptr) {
+		LocalDepth3dCrsTest crsTest(epcDoc, true);
+		crs = epcDoc->getDataObjectByUuid<LocalDepth3dCrs>(LocalDepth3dCrsTest::defaultUuid);
+	}
 
 	SeismicLatticeFeature* seismicLattice = epcDoc->createSeismicLattice(defaultUuidFeature, defaultTitleFeature, 2, 2, 150, 152, 4, 2);
 	GenericFeatureInterpretation* seismicLatticeInterp = epcDoc->createGenericFeatureInterpretation(seismicLattice, defaultUuidInterp, defaultTitleInterp);
@@ -75,20 +79,17 @@ void SeismicLatticeRepresentationTest::readEpcDocHandler()
 	// Grid 2D
 	RESQML2_0_1_NS::Grid2dRepresentation* rep = epcDoc->getDataObjectByUuid<RESQML2_0_1_NS::Grid2dRepresentation>(defaultUuid);
 	REQUIRE(rep->getSupportingRepresentation() == nullptr);
-	REQUIRE_THROWS(rep->getSeismicSupportOfPatch(0));
+	REQUIRE(rep->getSeismicSupportOfPatch(0) == nullptr);
 	REQUIRE((rep->isISpacingConstant() && rep->isJSpacingConstant()));
 	REQUIRE(rep->getXOrigin() == .0);
+	REQUIRE(rep->getXOriginInGlobalCrs() == 1000);
 	REQUIRE(rep->getYOrigin() == .0);
+	REQUIRE(rep->getYOriginInGlobalCrs() == 2000);
 	REQUIRE(rep->getNodeCountAlongIAxis() == 4);
 	REQUIRE(rep->getNodeCountAlongJAxis() == 2);
-	REQUIRE(rep->getXIOffset() == 1.0);
-	REQUIRE(rep->getYIOffset() == 0.0);
-	REQUIRE(rep->getXIOffset() == 0.0);
-	REQUIRE(rep->getYIOffset() == 1.0);
 	REQUIRE(rep->getISpacing() == 250.0);
 	REQUIRE(rep->getJSpacing() == 200.0);
 	REQUIRE_THROWS(rep->getIndexOriginOnSupportingRepresentation());
 	REQUIRE_THROWS(rep->getIndexOffsetOnSupportingRepresentation(0));
 	REQUIRE_THROWS(rep->getNodeCountOnSupportingRepresentation(1));
 }
-

--- a/test/resqml2_0_1test/TriangulatedSetRepresentationTest.cpp
+++ b/test/resqml2_0_1test/TriangulatedSetRepresentationTest.cpp
@@ -21,11 +21,11 @@ under the License.
 using namespace std;
 using namespace resqml2_0_1test;
 
-TriangulatedSetRepresentationTest::TriangulatedSetRepresentationTest(const std::string & epcDocPath, const string & uuid, const string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInGlobalCrs) 
-	: AbstractSurfaceRepresentationTest(epcDocPath, uuid, title, xyzPointCountOfAllPatches, xyzPointsOfAllPatchesInGlobalCrs) {
+TriangulatedSetRepresentationTest::TriangulatedSetRepresentationTest(const std::string & epcDocPath, const string & uuid, const string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInLocalCrs) 
+	: AbstractSurfaceRepresentationTest(epcDocPath, uuid, title, xyzPointCountOfAllPatches, xyzPointsOfAllPatchesInLocalCrs) {
 }
 
-TriangulatedSetRepresentationTest::TriangulatedSetRepresentationTest(COMMON_NS::EpcDocument* epcDoc, const string & uuid, const string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInGlobalCrs)
-	: AbstractSurfaceRepresentationTest(epcDoc, uuid, title, xyzPointCountOfAllPatches, xyzPointsOfAllPatchesInGlobalCrs) {
+TriangulatedSetRepresentationTest::TriangulatedSetRepresentationTest(COMMON_NS::EpcDocument* epcDoc, const string & uuid, const string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInLocalCrs)
+	: AbstractSurfaceRepresentationTest(epcDoc, uuid, title, xyzPointCountOfAllPatches, xyzPointsOfAllPatchesInLocalCrs) {
 }
 

--- a/test/resqml2_0_1test/TriangulatedSetRepresentationTest.h
+++ b/test/resqml2_0_1test/TriangulatedSetRepresentationTest.h
@@ -27,8 +27,8 @@ namespace COMMON_NS {
 namespace resqml2_0_1test {
 	class TriangulatedSetRepresentationTest : public AbstractSurfaceRepresentationTest {
 	public:
-		TriangulatedSetRepresentationTest(const std::string & epcDocPath, const std::string & uuid, const std::string & title, const ULONG64 & xyzPointCountOfAllPatches = 0, double * xyzPointsOfAllPatchesInGlobalCrs = nullptr);
-		TriangulatedSetRepresentationTest(COMMON_NS::EpcDocument* epcDoc, const std::string & uuid, const std::string & title, const ULONG64 & xyzPointCountOfAllPatches = 0, double * xyzPointsOfAllPatchesInGlobalCrs = nullptr);
+		TriangulatedSetRepresentationTest(const std::string & epcDocPath, const std::string & uuid, const std::string & title, const ULONG64 & xyzPointCountOfAllPatches = 0, double * xyzPointsOfAllPatchesInLocalCrs = nullptr);
+		TriangulatedSetRepresentationTest(COMMON_NS::EpcDocument* epcDoc, const std::string & uuid, const std::string & title, const ULONG64 & xyzPointCountOfAllPatches = 0, double * xyzPointsOfAllPatchesInLocalCrs = nullptr);
 	};
 }
 

--- a/test/resqml2_0_1test/UnstructuredGridRepresentationTest.cpp
+++ b/test/resqml2_0_1test/UnstructuredGridRepresentationTest.cpp
@@ -25,11 +25,11 @@ using namespace resqml2_0_1test;
 const char* UnstructuredGridRepresentationTest::defaultUuid = "d084eef4-137a-423f-a41c-8064868bcfa0";
 const char* UnstructuredGridRepresentationTest::defaultTitle = "Unstructured Grid Representation";
 
-UnstructuredGridRepresentationTest::UnstructuredGridRepresentationTest(const string & epcDocPath, const string & uuid, const string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInGlobalCrs)
-	: AbstractGridRepresentationTest(epcDocPath, uuid, title, xyzPointCountOfAllPatches, xyzPointsOfAllPatchesInGlobalCrs) {
+UnstructuredGridRepresentationTest::UnstructuredGridRepresentationTest(const string & epcDocPath, const string & uuid, const string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInLocalCrs)
+	: AbstractGridRepresentationTest(epcDocPath, uuid, title, xyzPointCountOfAllPatches, xyzPointsOfAllPatchesInLocalCrs) {
 }
 
-UnstructuredGridRepresentationTest::UnstructuredGridRepresentationTest(EpcDocument * epcDoc, const string & uuid, const string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInGlobalCrs)
-	: AbstractGridRepresentationTest(epcDoc, uuid, title, xyzPointCountOfAllPatches, xyzPointsOfAllPatchesInGlobalCrs) {
+UnstructuredGridRepresentationTest::UnstructuredGridRepresentationTest(EpcDocument * epcDoc, const string & uuid, const string & title, const ULONG64 & xyzPointCountOfAllPatches, double * xyzPointsOfAllPatchesInLocalCrs)
+	: AbstractGridRepresentationTest(epcDoc, uuid, title, xyzPointCountOfAllPatches, xyzPointsOfAllPatchesInLocalCrs) {
 }
 

--- a/test/unitTest.cpp
+++ b/test/unitTest.cpp
@@ -47,6 +47,8 @@ under the License.
 #include "resqml2_0_1test/WellboreFrameRepresentationTest.h"
 #include "resqml2_0_1test/WellboreRegularFrameRepresentationTest.h"
 #include "resqml2_0_1test/DiscretePropertyUsingLocalKindOnWellFrameTest.h"
+#include "resqml2_0_1test/SeismicLatticeRepresentationTest.h"
+#include "resqml2_0_1test/Grid2dRepresentationTest.h"
 #include "resqml2_0_1test/HorizonOnSeismicLine.h"
 #include "resqml2_0_1test/RightHanded4x3x2ExplicitIjkGrid.h"
 #include "resqml2_0_1test/BigIjkGridExplicitRepresentationTest.h"
@@ -63,17 +65,15 @@ using namespace witsml2_0test;
 
 #define FESAPI_TEST(name, tags, classTest)  TEST_CASE(name, tags)\
 {\
-	classTest* test = new classTest("../../" #classTest ".epc");\
-	test->serialize();\
-	test->deserialize();\
-	delete test;\
+	classTest test("../../" #classTest ".epc");\
+	test.serialize();\
+	test.deserialize();\
 }
 /*
 TEST_CASE( "Deserialize an EPC document", "[epc]")
 {
-	EpcDocumentTest* test = new EpcDocumentTest("../../testingPackageCpp.epc");
-	test->deserialize();
-	delete test;
+	EpcDocumentTest test("../../testingPackageCpp.epc");
+	test.deserialize();
 }
 */
 FESAPI_TEST("Export and import a local depth 3d crs", "[crs]", LocalDepth3dCrsTest)
@@ -137,8 +137,9 @@ FESAPI_TEST("Export and import a wellbore frame (irregular md spacings) with a s
 
 FESAPI_TEST("Export and import a wellbore frame (irregular md spacings) with a single discrete property on node using a local property kind", "[well][property]", DiscretePropertyUsingLocalKindOnWellFrameTest)
 
+FESAPI_TEST("Export and import a seismic lattice feature", "[seismic]", SeismicLatticeRepresentationTest)
+FESAPI_TEST("Export and import a seismic horizon grid 2d rep", "[seismic]", Grid2dRepresentationTest)
 FESAPI_TEST("Export and import an horizon on a seismic line", "[seismic]", HorizonOnSeismicLine)
 
 FESAPI_TEST("Export and import a Witsml well", "[well]", WellTest)
 FESAPI_TEST("Export and import a Witsml trajectory", "[well]", Trajectory)
-


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------
The origin and zValues of a grid 2d representation were always returned in local CRS even if "inGlobalCrs" was explicitely asked.

Does this close any currently open issues?
------------------------------------------
Fix #121 

Any other comments?
-------------------
The bug reason looks to be that offset of a 2d grid do not need to be "displaced" even when asked in global CRS compared to origin point of this same 2D grid.
The code was wrongly too much generic and ignored potential displacement even for origin.
Some unit test have been also developed to automatically potential regression about this point.

Where has this been tested?
---------------------------
**Operating System:** Win 10 64 bits

**Platform:** VS2015 60
