### PR TITLE
WITSML 2.0 perforation improvment, fix cs example

### DIFF
--- a/cmake/Program.cs
+++ b/cmake/Program.cs
@@ -13,7 +13,7 @@ namespace example
     {
         private static void serialize()
         {
-            using (EpcDocument epc_file = new EpcDocument("../../../TestingPackageCs"))
+            using (EpcDocument epc_file = new EpcDocument("../../../TestingPackageCs.epc"))
             {
                 LocalDepth3dCrs crs = epc_file.createLocalDepth3dCrs(Guid.NewGuid().ToString(), "UTF8 Crs title : éàç : олег1", 0.0, 0.0, 0.0, 0.0, eml20__LengthUom.eml20__LengthUom__m, 5215, eml20__LengthUom.eml20__LengthUom__m, "Unknown", false);
                 System.Console.WriteLine("Serialize : CRS title is " + crs.getTitle());
@@ -26,7 +26,7 @@ namespace example
 
         private static void deserialize()
         {
-            using (EpcDocument epc_file = new EpcDocument("../../../TestingPackageCs"))
+            using (EpcDocument epc_file = new EpcDocument("../../../TestingPackageCs.epc"))
             {
                 string status = epc_file.deserialize();
                 if (status.Length > 0) {
@@ -34,7 +34,7 @@ namespace example
 				}
                 LocalDepth3dCrsVector crs_set = epc_file.getLocalDepth3dCrsSet();
                 System.Console.WriteLine("Deserialize : CRS title is " + crs_set[0].getTitle());
-				Well well = epc_file.getResqmlAbstractObjectByUuid("1425632e-3c22-4845-b431-ecd36da0671e") as Well;
+				Well well = epc_file.getDataObjectByUuid("1425632e-3c22-4845-b431-ecd36da0671e") as Well;
                 System.Console.WriteLine("Deserialize : Well title is " + well.getTitle());
             }
         }

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -184,10 +184,10 @@ void serializePerforations(COMMON_NS::EpcDocument * pck)
 
 	wellboreCompletion->pushBackPerforation("Mean Sea Level", gsoap_eml2_1::eml21__LengthUom__m, 1970, 1980);
 	wellboreCompletion->pushBackPerforation("Mean Sea Level", gsoap_eml2_1::eml21__LengthUom__m, 1990, 2000);
-	wellboreCompletion->pushBackPerforationHistoryEntry("0", gsoap_eml2_1::witsml2__PerforationStatus__open, "Mean Sea Level", gsoap_eml2_1::eml21__LengthUom__m, 1970, 1980, 407568645, 1514764800);
-	wellboreCompletion->pushBackPerforationHistoryEntry("0", gsoap_eml2_1::witsml2__PerforationStatus__squeezed, "Mean Sea Level", gsoap_eml2_1::eml21__LengthUom__m, 1970, 1980, 1514764800);
-	wellboreCompletion->pushBackPerforationHistoryEntry("1", gsoap_eml2_1::witsml2__PerforationStatus__open, "Mean Sea Level", gsoap_eml2_1::eml21__LengthUom__m, 1990, 2000, 410104800);
-	wellboreCompletion->pushBackPerforationHistoryEntry("1", gsoap_eml2_1::witsml2__PerforationStatus__squeezed, "Mean Sea Level", gsoap_eml2_1::eml21__LengthUom__m, 1990, 1995, 1514764800);
+	wellboreCompletion->pushBackPerforationHistory(0, gsoap_eml2_1::witsml2__PerforationStatus__open, "Mean Sea Level", gsoap_eml2_1::eml21__LengthUom__m, 1970, 1980, 407568645, 1514764800);
+	wellboreCompletion->pushBackPerforationHistory(0, gsoap_eml2_1::witsml2__PerforationStatus__squeezed, "Mean Sea Level", gsoap_eml2_1::eml21__LengthUom__m, 1970, 1980, 1514764800);
+	wellboreCompletion->pushBackPerforationHistory(1, gsoap_eml2_1::witsml2__PerforationStatus__open, "Mean Sea Level", gsoap_eml2_1::eml21__LengthUom__m, 1990, 2000, 410104800);
+	wellboreCompletion->pushBackPerforationHistory(1, gsoap_eml2_1::witsml2__PerforationStatus__squeezed, "Mean Sea Level", gsoap_eml2_1::eml21__LengthUom__m, 1990, 1995, 1514764800);
 }
 
 void serializeStratigraphicModel(COMMON_NS::EpcDocument * pck, COMMON_NS::AbstractHdfProxy* hdfProxy)
@@ -3122,58 +3122,54 @@ void deserializePerforations(COMMON_NS::EpcDocument & pck)
 	
 	for (unsigned int perforationIndex = 0; perforationIndex < wellboreCompletion->getPerforationCount(); ++perforationIndex)
 	{
-		std::string perforationUid = std::to_string(perforationIndex);
-
-		cout << std::endl << "perforation " + perforationUid << ":" << std::endl;
-		if (wellboreCompletion->hasPerforationMdDatum(perforationUid))
+		cout << std::endl << "perforation " + perforationIndex << ":" << std::endl;
+		if (wellboreCompletion->hasPerforationMdDatum(perforationIndex))
 		{
-			cout << "datum: " << wellboreCompletion->getPerforationMdDatum(perforationUid) << std::endl;
+			cout << "datum: " << wellboreCompletion->getPerforationMdDatum(perforationIndex) << std::endl;
 		}
-		if (wellboreCompletion->hasPerforationMdUnit(perforationUid))
+		if (wellboreCompletion->hasPerforationMdUnit(perforationIndex))
 		{
-			cout << "md unit: " << pck.lengthUomToString(wellboreCompletion->getPerforationMdUnit(perforationUid)) << std::endl;
+			cout << "md unit: " << pck.lengthUomToString(wellboreCompletion->getPerforationMdUnit(perforationIndex)) << std::endl;
 		}
-		if (wellboreCompletion->hasPerforationTopMd(perforationUid))
+		if (wellboreCompletion->hasPerforationTopMd(perforationIndex))
 		{
-			cout << "top md: " << wellboreCompletion->getPerforationTopMd(perforationUid) << std::endl;
+			cout << "top md: " << wellboreCompletion->getPerforationTopMd(perforationIndex) << std::endl;
 		}
-		if (wellboreCompletion->hasPerforationBaseMd(perforationUid))
+		if (wellboreCompletion->hasPerforationBaseMd(perforationIndex))
 		{
-			cout << "base md: " << wellboreCompletion->getPerforationBaseMd(perforationUid) << std::endl;
+			cout << "base md: " << wellboreCompletion->getPerforationBaseMd(perforationIndex) << std::endl;
 		}
 
-		for (unsigned int historyEntryIndex = 0; historyEntryIndex < wellboreCompletion->getHistoryEntryCount(perforationUid); ++historyEntryIndex)
+		for (unsigned int historyIndex = 0; historyIndex < wellboreCompletion->getPerforationHistoryCount(perforationIndex); ++historyIndex)
 		{
-			std::string historyEntryUid = std::to_string(historyEntryIndex);
-
-			cout << "history entry " << historyEntryUid << ":" << std::endl;
-			if (wellboreCompletion->hasPerforationHistoryEntryStatus(historyEntryUid, perforationUid))
+			cout << "history entry " << historyIndex << ":" << std::endl;
+			if (wellboreCompletion->hasPerforationHistoryStatus(historyIndex, perforationIndex))
 			{
-				cout << "\tstatus: " << wellboreCompletion->getPerforationHistoryEntryStatusToString(historyEntryUid, perforationUid) << std::endl;
+				cout << "\tstatus: " << wellboreCompletion->getPerforationHistoryStatusToString(historyIndex, perforationIndex) << std::endl;
 			}
-			if (wellboreCompletion->hasPerforationHistoryEntryStartDate(historyEntryUid, perforationUid))
+			if (wellboreCompletion->hasPerforationHistoryStartDate(historyIndex, perforationIndex))
 			{
-				cout << "\tstart date: " << wellboreCompletion->getPerforationHistoryEntryStartDate(historyEntryUid, perforationUid) << std::endl;
+				cout << "\tstart date: " << wellboreCompletion->getPerforationHistoryStartDate(historyIndex, perforationIndex) << std::endl;
 			}
-			if (wellboreCompletion->hasPerforationHistoryEntryEndDate(historyEntryUid, perforationUid))
+			if (wellboreCompletion->hasPerforationHistoryEndDate(historyIndex, perforationIndex))
 			{
-				cout << "\tend date: " << wellboreCompletion->getPerforationHistoryEntryEndDate(historyEntryUid, perforationUid) << std::endl;
+				cout << "\tend date: " << wellboreCompletion->getPerforationHistoryEndDate(historyIndex, perforationIndex) << std::endl;
 			}
-			if (wellboreCompletion->hasPerforationHistoryEntryMdDatum(historyEntryUid, perforationUid))
+			if (wellboreCompletion->hasPerforationHistoryMdDatum(historyIndex, perforationIndex))
 			{
-				cout << "\tend datum: " << wellboreCompletion->getPerforationHistoryEntryMdDatum(historyEntryUid, perforationUid) << std::endl;
+				cout << "\tend datum: " << wellboreCompletion->getPerforationHistoryMdDatum(historyIndex, perforationIndex) << std::endl;
 			}
-			if (wellboreCompletion->hasPerforationHistoryEntryMdUnit(historyEntryUid, perforationUid))
+			if (wellboreCompletion->hasPerforationHistoryMdUnit(historyIndex, perforationIndex))
 			{
-				cout << "\tend md unit: " << pck.lengthUomToString(wellboreCompletion->getPerforationHistoryEntryMdUnit(historyEntryUid, perforationUid)) << std::endl;
+				cout << "\tend md unit: " << pck.lengthUomToString(wellboreCompletion->getPerforationHistoryMdUnit(historyIndex, perforationIndex)) << std::endl;
 			}
-			if (wellboreCompletion->hasPerforationHistoryEntryTopMd(historyEntryUid, perforationUid))
+			if (wellboreCompletion->hasPerforationHistoryTopMd(historyIndex, perforationIndex))
 			{
-				cout << "\tend top md: " << wellboreCompletion->getPerforationHistoryEntryTopMd(historyEntryUid, perforationUid) << std::endl;
+				cout << "\tend top md: " << wellboreCompletion->getPerforationHistoryTopMd(historyIndex, perforationIndex) << std::endl;
 			}
-			if (wellboreCompletion->hasPerforationHistoryEntryBaseMd(historyEntryUid, perforationUid))
+			if (wellboreCompletion->hasPerforationHistoryBaseMd(historyIndex, perforationIndex))
 			{
-				cout << "\tend base md: " << wellboreCompletion->getPerforationHistoryEntryBaseMd(historyEntryUid, perforationUid) << std::endl;
+				cout << "\tend base md: " << wellboreCompletion->getPerforationHistoryBaseMd(historyIndex, perforationIndex) << std::endl;
 			}
 		}
 	}

--- a/src/witsml2_0/WellboreCompletion.cpp
+++ b/src/witsml2_0/WellboreCompletion.cpp
@@ -134,7 +134,7 @@ void WellboreCompletion::pushBackPerforation(const string & datum,
 	wellboreCompletion->ContactIntervalSet->PerforationSetInterval.push_back(perforationSetInterval);
 }
 
-void WellboreCompletion::pushBackPerforationHistoryEntry(const std::string & perforationGuid,
+void WellboreCompletion::pushBackPerforationHistory(unsigned int index,
 	gsoap_eml2_1::witsml2__PerforationStatus perforationStatus,
 	const string & datum,
 	gsoap_eml2_1::eml21__LengthUom MdUnit,
@@ -145,11 +145,7 @@ void WellboreCompletion::pushBackPerforationHistoryEntry(const std::string & per
 	const string & guid
 )
 {
-	witsml2__PerforationSetInterval * perforationSetInterval = getPerforation(perforationGuid);
-	if (perforationSetInterval == nullptr)
-	{
-		throw invalid_argument("The perforation guid is invalid.");
-	}
+	witsml2__PerforationSetInterval * perforationSetInterval = getPerforation(index);
 
 	witsml2__PerforationStatusHistory* perforationStatusHistory = soap_new_witsml2__PerforationStatusHistory(gsoapProxy2_1->soap, 1);
 
@@ -201,35 +197,24 @@ unsigned int WellboreCompletion::getPerforationCount() const
 	return wellboreCompletion->ContactIntervalSet->PerforationSetInterval.size();
 }
 
-bool WellboreCompletion::hasPerforationMdDatum(const std::string & guid) const
+bool WellboreCompletion::hasPerforationMdDatum(unsigned int index) const
 {
-	witsml2__PerforationSetInterval * perforationSetInterval = getPerforation(guid);
-	if (perforationSetInterval == nullptr)
-	{
-		return false;
-	}
-
-	return (perforationSetInterval->PerforationSetMdInterval != nullptr);
+	return (getPerforation(index)->PerforationSetMdInterval != nullptr);
 }
 
-string WellboreCompletion::getPerforationMdDatum(const string & guid) const
+string WellboreCompletion::getPerforationMdDatum(unsigned int index) const
 {
-	if (!hasPerforationMdDatum(guid))
+	if (!hasPerforationMdDatum(index))
 	{
 		throw invalid_argument("No perforation md datum is defined.");
 	}
 
-	witsml2__PerforationSetInterval * perforationSetInterval = getPerforation(guid);
-	return perforationSetInterval->PerforationSetMdInterval->datum;
+	return getPerforation(index)->PerforationSetMdInterval->datum;
 }
 
-bool WellboreCompletion::hasPerforationMdUnit(const std::string & guid) const
+bool WellboreCompletion::hasPerforationMdUnit(unsigned int index) const
 {
-	witsml2__PerforationSetInterval * perforationSetInterval = getPerforation(guid);
-	if (perforationSetInterval == nullptr)
-	{
-		return false;
-	}
+	witsml2__PerforationSetInterval * perforationSetInterval = getPerforation(index);
 
 	if (perforationSetInterval->PerforationSetMdInterval == nullptr)
 	{
@@ -240,14 +225,15 @@ bool WellboreCompletion::hasPerforationMdUnit(const std::string & guid) const
 		perforationSetInterval->PerforationSetMdInterval->MdTop != nullptr;
 }
 
-eml21__LengthUom WellboreCompletion::getPerforationMdUnit(const string & guid) const
+eml21__LengthUom WellboreCompletion::getPerforationMdUnit(unsigned int index) const
 {
-	if (!hasPerforationMdUnit(guid))
+	if (!hasPerforationMdUnit(index))
 	{
 		throw invalid_argument("No perforation md unit is defined.");
 	}
 
-	witsml2__PerforationSetInterval * perforationSetInterval = getPerforation(guid);	
+	witsml2__PerforationSetInterval * perforationSetInterval = getPerforation(index);
+
 	if (perforationSetInterval->PerforationSetMdInterval->MdBase != nullptr)
 	{
 		return perforationSetInterval->PerforationSetMdInterval->MdBase->uom;
@@ -258,13 +244,9 @@ eml21__LengthUom WellboreCompletion::getPerforationMdUnit(const string & guid) c
 	}
 }
 
-bool WellboreCompletion::hasPerforationTopMd(const std::string & guid) const
+bool WellboreCompletion::hasPerforationTopMd(unsigned int index) const
 {
-	witsml2__PerforationSetInterval * perforationSetInterval = getPerforation(guid);
-	if (perforationSetInterval == nullptr)
-	{
-		return false;
-	}
+	witsml2__PerforationSetInterval * perforationSetInterval = getPerforation(index);
 
 	if (perforationSetInterval->PerforationSetMdInterval == nullptr)
 	{
@@ -274,24 +256,19 @@ bool WellboreCompletion::hasPerforationTopMd(const std::string & guid) const
 	return (perforationSetInterval->PerforationSetMdInterval->MdTop != nullptr);
 }
 
-double WellboreCompletion::getPerforationTopMd(const string & guid) const
+double WellboreCompletion::getPerforationTopMd(unsigned int index) const
 {
-	if (!hasPerforationTopMd(guid))
+	if (!hasPerforationTopMd(index))
 	{
 		throw invalid_argument("No perforation top md is defined.");
 	}
 
-	witsml2__PerforationSetInterval * perforationSetInterval = getPerforation(guid);
-	return perforationSetInterval->PerforationSetMdInterval->MdTop->__item;
+	return getPerforation(index)->PerforationSetMdInterval->MdTop->__item;
 }
 
-bool WellboreCompletion::hasPerforationBaseMd(const std::string & guid) const
+bool WellboreCompletion::hasPerforationBaseMd(unsigned int index) const
 {
-	witsml2__PerforationSetInterval * perforationSetInterval = getPerforation(guid);
-	if (perforationSetInterval == nullptr)
-	{
-		return false;
-	}
+	witsml2__PerforationSetInterval * perforationSetInterval = getPerforation(index);
 
 	if (perforationSetInterval->PerforationSetMdInterval == nullptr)
 	{
@@ -301,138 +278,103 @@ bool WellboreCompletion::hasPerforationBaseMd(const std::string & guid) const
 	return (perforationSetInterval->PerforationSetMdInterval->MdBase != nullptr);
 }
 
-double WellboreCompletion::getPerforationBaseMd(const string & guid) const
+double WellboreCompletion::getPerforationBaseMd(unsigned int index) const
 {
-	if (!hasPerforationBaseMd(guid))
+	if (!hasPerforationBaseMd(index))
 	{
 		throw invalid_argument("No perforation base md is defined.");
 	}
 
-	witsml2__PerforationSetInterval * perforationSetInterval = getPerforation(guid);
-	return perforationSetInterval->PerforationSetMdInterval->MdBase->__item;
+	return getPerforation(index)->PerforationSetMdInterval->MdBase->__item;
 }
 
-unsigned int WellboreCompletion::getHistoryEntryCount(const std::string & perforationGuid) const
+unsigned int WellboreCompletion::getPerforationHistoryCount(unsigned int index) const
 {
-	witsml2__PerforationSetInterval * perforation = getPerforation(perforationGuid);
-
-	return perforation->PerforationStatusHistory.size();
+	return getPerforation(index)->PerforationStatusHistory.size();
 }
 
-bool WellboreCompletion::hasPerforationHistoryEntryStatus(const std::string & guid,
-	const std::string & perforationGuid) const
+bool WellboreCompletion::hasPerforationHistoryStatus(unsigned int historyIndex,
+	unsigned int perforationIndex) const
 {
-	witsml2__PerforationStatusHistory* perforationStatusHistory = getPerforationHistoryEntry(guid, perforationGuid);
-	if (perforationStatusHistory == nullptr)
-	{
-		return false;
-	}
-
-	return perforationStatusHistory->PerforationStatus != nullptr;
+	return getPerforationHistoryEntry(historyIndex, perforationIndex)->PerforationStatus != nullptr;
 }
 
-witsml2__PerforationStatus WellboreCompletion::getPerforationHistoryEntryStatus(const string & guid,
-	const string & perforationGuid) const
+witsml2__PerforationStatus WellboreCompletion::getPerforationHistoryStatus(unsigned int historyIndex,
+	unsigned int perforationIndex) const
 {
-	if (!hasPerforationHistoryEntryStatus(guid, perforationGuid))
+	if (!hasPerforationHistoryStatus(historyIndex, perforationIndex))
 	{
 		throw invalid_argument("No perforation history entry is defined.");
 	}
 
-	witsml2__PerforationStatusHistory* perforationStatusHistory = getPerforationHistoryEntry(guid, perforationGuid);
-	return *perforationStatusHistory->PerforationStatus;
+	return *getPerforationHistoryEntry(historyIndex, perforationIndex)->PerforationStatus;
 }
 
-string WellboreCompletion::getPerforationHistoryEntryStatusToString(const string & guid,
-	const string & perforationGuid) const
+string WellboreCompletion::getPerforationHistoryStatusToString(unsigned int historyIndex,
+	unsigned int perforationIndex) const
 {
-	return gsoap_eml2_1::soap_witsml2__PerforationStatus2s(gsoapProxy2_1->soap, getPerforationHistoryEntryStatus(guid, perforationGuid));
+	return gsoap_eml2_1::soap_witsml2__PerforationStatus2s(gsoapProxy2_1->soap, getPerforationHistoryStatus(historyIndex, perforationIndex));
 }
 
-bool WellboreCompletion::hasPerforationHistoryEntryStartDate(const std::string & guid,
-	const std::string & perforationGuid) const
+bool WellboreCompletion::hasPerforationHistoryStartDate(unsigned int historyIndex,
+	unsigned int perforationIndex) const
 {
-	witsml2__PerforationStatusHistory* perforationStatusHistory = getPerforationHistoryEntry(guid, perforationGuid);
-	if (perforationStatusHistory == nullptr)
-	{
-		return false;
-	}
-
-	return perforationStatusHistory->StartDate != nullptr;
+	return getPerforationHistoryEntry(historyIndex, perforationIndex)->StartDate != nullptr;
 }
 
-time_t WellboreCompletion::getPerforationHistoryEntryStartDate(const string & guid,
-	const string & perforationGuid) const
+time_t WellboreCompletion::getPerforationHistoryStartDate(unsigned int historyIndex,
+	unsigned int perforationIndex) const
 {
-	if (!hasPerforationHistoryEntryStartDate(guid, perforationGuid))
+	if (!hasPerforationHistoryStartDate(historyIndex, perforationIndex))
 	{
 		throw invalid_argument("No perforation history entry start date is defined.");
 	}
 
-	witsml2__PerforationStatusHistory* perforationStatusHistory = getPerforationHistoryEntry(guid, perforationGuid);
-	string startDate = *perforationStatusHistory->StartDate;
+	string startDate = *getPerforationHistoryEntry(historyIndex, perforationIndex)->StartDate;
 
 	return timeTools::convertIsoToUnixTimestamp(startDate);
 }
 
-bool WellboreCompletion::hasPerforationHistoryEntryEndDate(const std::string & guid,
-	const std::string & perforationGuid) const
+bool WellboreCompletion::hasPerforationHistoryEndDate(unsigned int historyIndex,
+	unsigned int perforationIndex) const
 {
-	witsml2__PerforationStatusHistory* perforationStatusHistory = getPerforationHistoryEntry(guid, perforationGuid);
-	if (perforationStatusHistory == nullptr)
-	{
-		return false;
-	}
-
-	return perforationStatusHistory->EndDate != nullptr;
+	return getPerforationHistoryEntry(historyIndex, perforationIndex)->EndDate != nullptr;
 }
 
-time_t WellboreCompletion::getPerforationHistoryEntryEndDate(const string & guid,
-	const string & perforationGuid) const
+time_t WellboreCompletion::getPerforationHistoryEndDate(unsigned int historyIndex,
+	unsigned int perforationIndex) const
 {
-	if (!hasPerforationHistoryEntryEndDate(guid, perforationGuid))
+	if (!hasPerforationHistoryEndDate(historyIndex, perforationIndex))
 	{
 		throw invalid_argument("No perforation history entry end date is defined.");
 	}
 
-	witsml2__PerforationStatusHistory* perforationStatusHistory = getPerforationHistoryEntry(guid, perforationGuid);
-	string endDate = *perforationStatusHistory->EndDate;
+	string endDate = *getPerforationHistoryEntry(historyIndex, perforationIndex)->EndDate;
 
 	return timeTools::convertIsoToUnixTimestamp(endDate);
 }
 
-bool WellboreCompletion::hasPerforationHistoryEntryMdDatum(const std::string & guid,
-	const std::string & perforationGuid) const
+bool WellboreCompletion::hasPerforationHistoryMdDatum(unsigned int historyIndex,
+	unsigned int perforationIndex) const
 {
-	witsml2__PerforationStatusHistory* perforationStatusHistory = getPerforationHistoryEntry(guid, perforationGuid);
-	if (perforationStatusHistory == nullptr)
-	{
-		return false;
-	}
-
-	return (perforationStatusHistory->PerforationMdInterval != nullptr);
+	return (getPerforationHistoryEntry(historyIndex, perforationIndex)->PerforationMdInterval != nullptr);
 }
 
-string WellboreCompletion::getPerforationHistoryEntryMdDatum(const string & guid,
-	const string & perforationGuid) const
+string WellboreCompletion::getPerforationHistoryMdDatum(unsigned int historyIndex,
+	unsigned int perforationIndex) const
 {
-	if (!hasPerforationHistoryEntryMdDatum(guid, perforationGuid))
+	if (!hasPerforationHistoryMdDatum(historyIndex, perforationIndex))
 	{
 		throw invalid_argument("No perforation history entry md datum is defined.");
 	}
 
-	witsml2__PerforationStatusHistory* perforationStatusHistory = getPerforationHistoryEntry(guid, perforationGuid);
-	return perforationStatusHistory->PerforationMdInterval->datum;
+	return getPerforationHistoryEntry(historyIndex, perforationIndex)->PerforationMdInterval->datum;
 }
 
-bool WellboreCompletion::hasPerforationHistoryEntryMdUnit(const std::string & guid,
-	const std::string & perforationGuid) const
+bool WellboreCompletion::hasPerforationHistoryMdUnit(unsigned int historyIndex,
+	unsigned int perforationIndex) const
 {
-	witsml2__PerforationStatusHistory* perforationStatusHistory = getPerforationHistoryEntry(guid, perforationGuid);
-	if (perforationStatusHistory == nullptr)
-	{
-		return false;
-	}
+	witsml2__PerforationStatusHistory* perforationStatusHistory = getPerforationHistoryEntry(historyIndex, perforationIndex);
 
 	if (perforationStatusHistory->PerforationMdInterval == nullptr)
 	{
@@ -443,29 +385,23 @@ bool WellboreCompletion::hasPerforationHistoryEntryMdUnit(const std::string & gu
 		perforationStatusHistory->PerforationMdInterval->MdTop != nullptr;
 }
 
-eml21__LengthUom WellboreCompletion::getPerforationHistoryEntryMdUnit(const std::string & guid,
-	const std::string & perforationGuid) const
+eml21__LengthUom WellboreCompletion::getPerforationHistoryMdUnit(unsigned int historyIndex,
+	unsigned int perforationIndex) const
 {
-	if (!hasPerforationHistoryEntryMdUnit(guid, perforationGuid))
+	if (!hasPerforationHistoryMdUnit(historyIndex, perforationIndex))
 	{
 		throw invalid_argument("No perforation history entry md unit is defined.");
 	}
 
-	witsml2__PerforationStatusHistory* perforationStatusHistory = getPerforationHistoryEntry(guid, perforationGuid);
-	if (perforationStatusHistory->PerforationMdInterval->MdBase != nullptr)
-	{
-		return perforationStatusHistory->PerforationMdInterval->MdBase->uom;
-	}
-	else
-	{
-		return perforationStatusHistory->PerforationMdInterval->MdTop->uom;
-	}
+	witsml2__PerforationStatusHistory* perforationStatusHistory = getPerforationHistoryEntry(historyIndex, perforationIndex);
+
+	return perforationStatusHistory->PerforationMdInterval->MdBase != nullptr ? perforationStatusHistory->PerforationMdInterval->MdBase->uom : perforationStatusHistory->PerforationMdInterval->MdTop->uom;
 }
 
-bool WellboreCompletion::hasPerforationHistoryEntryTopMd(const std::string & guid,
-	const std::string & perforationGuid) const
+bool WellboreCompletion::hasPerforationHistoryTopMd(unsigned int historyIndex,
+	unsigned int perforationIndex) const
 {
-	witsml2__PerforationStatusHistory* perforationStatusHistory = getPerforationHistoryEntry(guid, perforationGuid);
+	witsml2__PerforationStatusHistory* perforationStatusHistory = getPerforationHistoryEntry(historyIndex, perforationIndex);
 	if (perforationStatusHistory == nullptr)
 	{
 		return false;
@@ -479,22 +415,21 @@ bool WellboreCompletion::hasPerforationHistoryEntryTopMd(const std::string & gui
 	return perforationStatusHistory->PerforationMdInterval->MdTop != nullptr;
 }
 
-double WellboreCompletion::getPerforationHistoryEntryTopMd(const std::string & guid,
-	const std::string & perforationGuid) const
+double WellboreCompletion::getPerforationHistoryTopMd(unsigned int historyIndex,
+	unsigned int perforationIndex) const
 {
-	if (!hasPerforationHistoryEntryTopMd(guid, perforationGuid))
+	if (!hasPerforationHistoryTopMd(historyIndex, perforationIndex))
 	{
 		throw invalid_argument("No perforation history entry top md is defined.");
 	}
 
-	witsml2__PerforationStatusHistory* perforationStatusHistory = getPerforationHistoryEntry(guid, perforationGuid);
-	return perforationStatusHistory->PerforationMdInterval->MdTop->__item;
+	return getPerforationHistoryEntry(historyIndex, perforationIndex)->PerforationMdInterval->MdTop->__item;
 }
 
-bool WellboreCompletion::hasPerforationHistoryEntryBaseMd(const std::string & guid,
-	const std::string & perforationGuid) const
+bool WellboreCompletion::hasPerforationHistoryBaseMd(unsigned int historyIndex,
+	unsigned int perforationIndex) const
 {
-	witsml2__PerforationStatusHistory* perforationStatusHistory = getPerforationHistoryEntry(guid, perforationGuid);
+	witsml2__PerforationStatusHistory* perforationStatusHistory = getPerforationHistoryEntry(historyIndex, perforationIndex);
 	if (perforationStatusHistory == nullptr)
 	{
 		return false;
@@ -508,16 +443,15 @@ bool WellboreCompletion::hasPerforationHistoryEntryBaseMd(const std::string & gu
 	return perforationStatusHistory->PerforationMdInterval->MdBase != nullptr;
 }
 
-double WellboreCompletion::getPerforationHistoryEntryBaseMd(const std::string & guid,
-	const std::string & perforationGuid) const
+double WellboreCompletion::getPerforationHistoryBaseMd(unsigned int historyIndex,
+	unsigned int perforationIndex) const
 {
-	if (!hasPerforationHistoryEntryBaseMd(guid, perforationGuid))
+	if (!hasPerforationHistoryBaseMd(historyIndex, perforationIndex))
 	{
 		throw invalid_argument("No perforation history entry base md is defined.");
 	}
 
-	witsml2__PerforationStatusHistory* perforationStatusHistory = getPerforationHistoryEntry(guid, perforationGuid);
-	return perforationStatusHistory->PerforationMdInterval->MdBase->__item;
+	return getPerforationHistoryEntry(historyIndex, perforationIndex)->PerforationMdInterval->MdBase->__item;
 }
 
 void WellboreCompletion::importRelationshipSetFromEpc(COMMON_NS::EpcDocument* epcDoc)
@@ -526,7 +460,7 @@ void WellboreCompletion::importRelationshipSetFromEpc(COMMON_NS::EpcDocument* ep
 
 	gsoap_eml2_1::eml21__DataObjectReference* dor = getWellCompletionDor();
 	WellCompletion* wellCompletion = epcDoc->getDataObjectByUuid<WellCompletion>(dor->Uuid);
-	
+
 	if (wellCompletion == nullptr) {
 		throw invalid_argument("The DOR looks invalid.");
 	}
@@ -549,7 +483,7 @@ vector<Relationship> WellboreCompletion::getAllEpcRelationships() const
 	return result;
 }
 
-witsml2__PerforationSetInterval * WellboreCompletion::getPerforation(const string & guid) const
+gsoap_eml2_1::witsml2__PerforationSetInterval* WellboreCompletion::getPerforation(unsigned int index) const
 {
 	witsml2__WellboreCompletion* wellboreCompletion = static_cast<witsml2__WellboreCompletion*>(gsoapProxy2_1);
 
@@ -558,35 +492,23 @@ witsml2__PerforationSetInterval * WellboreCompletion::getPerforation(const strin
 		throw invalid_argument("No contact interval exists.");
 	}
 
-	for (unsigned int perforationIndex = 0; perforationIndex < wellboreCompletion->ContactIntervalSet->PerforationSetInterval.size(); ++perforationIndex)
+	if (index >= wellboreCompletion->ContactIntervalSet->PerforationSetInterval.size())
 	{
-		if (wellboreCompletion->ContactIntervalSet->PerforationSetInterval[perforationIndex]->uid == guid)
-		{
-			return wellboreCompletion->ContactIntervalSet->PerforationSetInterval[perforationIndex];
-
-		}
+		throw invalid_argument("Perforation index out of range.");
 	}
 
-	return nullptr;
+	return wellboreCompletion->ContactIntervalSet->PerforationSetInterval[index];
 }
 
-witsml2__PerforationStatusHistory* WellboreCompletion::getPerforationHistoryEntry(const string & guid, 
-	const string & perforationGuid) const
+gsoap_eml2_1::witsml2__PerforationStatusHistory* WellboreCompletion::getPerforationHistoryEntry(unsigned int index,
+	unsigned int perforationIndex) const
 {
-	witsml2__PerforationSetInterval* perforationSetInterval = getPerforation(perforationGuid);
+	witsml2__PerforationSetInterval* perforationSetInterval = getPerforation(perforationIndex);
 
-	if (perforationSetInterval == nullptr)
+	if (index >= perforationSetInterval->PerforationStatusHistory.size())
 	{
-		throw invalid_argument("The perforation guid is invalid.");
+		throw invalid_argument("History index out of range.");
 	}
 
-	for (unsigned int perforationStatusHistoryIndex = 0; perforationStatusHistoryIndex < perforationSetInterval->PerforationStatusHistory.size(); ++perforationStatusHistoryIndex)
-	{
-		if (perforationSetInterval->PerforationStatusHistory[perforationStatusHistoryIndex]->uid == guid)
-		{
-			return perforationSetInterval->PerforationStatusHistory[perforationStatusHistoryIndex];
-		}
-	}
-
-	return nullptr;
+	return perforationSetInterval->PerforationStatusHistory[index];
 }

--- a/src/witsml2_0/WellboreCompletion.h
+++ b/src/witsml2_0/WellboreCompletion.h
@@ -57,7 +57,7 @@ namespace WITSML2_0_NS
 			const double & BaseMd, 
 			const std::string & guid = "");
 
-		DLL_IMPORT_OR_EXPORT void pushBackPerforationHistoryEntry(const std::string & perforationGuid,
+		DLL_IMPORT_OR_EXPORT void pushBackPerforationHistory(unsigned int index,
 			gsoap_eml2_1::witsml2__PerforationStatus perforationStatus,
 			const std::string & datum,
 			gsoap_eml2_1::eml21__LengthUom MdUnit,
@@ -69,68 +69,68 @@ namespace WITSML2_0_NS
 
 		DLL_IMPORT_OR_EXPORT unsigned int getPerforationCount() const;
 
-		DLL_IMPORT_OR_EXPORT bool hasPerforationMdDatum(const std::string & guid) const;
+		DLL_IMPORT_OR_EXPORT bool hasPerforationMdDatum(unsigned int index) const;
+	
+		DLL_IMPORT_OR_EXPORT std::string getPerforationMdDatum(unsigned int index) const;
 		
-		DLL_IMPORT_OR_EXPORT std::string getPerforationMdDatum(const std::string & guid) const;
+		DLL_IMPORT_OR_EXPORT bool hasPerforationMdUnit(unsigned int index) const;
 		
-		DLL_IMPORT_OR_EXPORT bool hasPerforationMdUnit(const std::string & guid) const;
+		DLL_IMPORT_OR_EXPORT gsoap_eml2_1::eml21__LengthUom getPerforationMdUnit(unsigned int index) const;
 		
-		DLL_IMPORT_OR_EXPORT gsoap_eml2_1::eml21__LengthUom getPerforationMdUnit(const std::string & guid) const;
+		DLL_IMPORT_OR_EXPORT bool hasPerforationTopMd(unsigned int index) const;
 		
-		DLL_IMPORT_OR_EXPORT bool hasPerforationTopMd(const std::string & guid) const;
+		DLL_IMPORT_OR_EXPORT double getPerforationTopMd(unsigned int index) const;
+
+		DLL_IMPORT_OR_EXPORT bool hasPerforationBaseMd(unsigned int index) const;
+
+		DLL_IMPORT_OR_EXPORT double getPerforationBaseMd(unsigned int index) const;
+
+		DLL_IMPORT_OR_EXPORT unsigned int getPerforationHistoryCount(unsigned int index) const;
+
+		DLL_IMPORT_OR_EXPORT bool hasPerforationHistoryStatus(unsigned int historyIndex,
+			unsigned int perforationIndex) const;
+
+		DLL_IMPORT_OR_EXPORT gsoap_eml2_1::witsml2__PerforationStatus getPerforationHistoryStatus(unsigned int historyIndex,
+			unsigned int perforationIndex) const;
+
+		DLL_IMPORT_OR_EXPORT std::string getPerforationHistoryStatusToString(unsigned int historyIndex,
+			unsigned int perforationIndex) const;
+
+		DLL_IMPORT_OR_EXPORT bool hasPerforationHistoryStartDate(unsigned int historyIndex,
+			unsigned int perforationIndex) const;
+
+		DLL_IMPORT_OR_EXPORT time_t getPerforationHistoryStartDate(unsigned int historyIndex,
+			unsigned int perforationIndex) const;
+
+		DLL_IMPORT_OR_EXPORT bool hasPerforationHistoryEndDate(unsigned int historyIndex,
+			unsigned int perforationIndex) const;
+
+		DLL_IMPORT_OR_EXPORT time_t getPerforationHistoryEndDate(unsigned int historyIndex,
+			unsigned int perforationIndex) const;
 		
-		DLL_IMPORT_OR_EXPORT double getPerforationTopMd(const std::string & guid) const;
-
-		DLL_IMPORT_OR_EXPORT bool hasPerforationBaseMd(const std::string & guid) const;
-
-		DLL_IMPORT_OR_EXPORT double getPerforationBaseMd(const std::string & guid) const;
-
-		DLL_IMPORT_OR_EXPORT unsigned int getHistoryEntryCount(const std::string & perforationGuid) const;
-
-		DLL_IMPORT_OR_EXPORT bool hasPerforationHistoryEntryStatus(const std::string & guid,
-			const std::string & perforationGuid) const;
-
-		DLL_IMPORT_OR_EXPORT gsoap_eml2_1::witsml2__PerforationStatus getPerforationHistoryEntryStatus(const std::string & guid,
-			const std::string & perforationGuid) const;
-
-		DLL_IMPORT_OR_EXPORT std::string getPerforationHistoryEntryStatusToString(const std::string & guid,
-			const std::string & perforationGuid) const;
-
-		DLL_IMPORT_OR_EXPORT bool hasPerforationHistoryEntryStartDate(const std::string & guid,
-			const std::string & perforationGuid) const;
-
-		DLL_IMPORT_OR_EXPORT time_t getPerforationHistoryEntryStartDate(const std::string & guid,
-			const std::string & perforationGuid) const;
-
-		DLL_IMPORT_OR_EXPORT bool hasPerforationHistoryEntryEndDate(const std::string & guid,
-			const std::string & perforationGuid) const;
-
-		DLL_IMPORT_OR_EXPORT time_t getPerforationHistoryEntryEndDate(const std::string & guid,
-			const std::string & perforationGuid) const;
+		DLL_IMPORT_OR_EXPORT bool hasPerforationHistoryMdDatum(unsigned int historyIndex,
+			unsigned int perforationIndex) const;
 		
-		DLL_IMPORT_OR_EXPORT bool hasPerforationHistoryEntryMdDatum(const std::string & guid,
-			const std::string & perforationGuid) const;
+		DLL_IMPORT_OR_EXPORT std::string getPerforationHistoryMdDatum(unsigned int historyIndex,
+			unsigned int perforationIndex) const;
 		
-		DLL_IMPORT_OR_EXPORT std::string getPerforationHistoryEntryMdDatum(const std::string & guid,
-			const std::string & perforationGuid) const;
+		DLL_IMPORT_OR_EXPORT bool hasPerforationHistoryMdUnit(unsigned int historyIndex,
+			unsigned int perforationIndex) const;
+
+		DLL_IMPORT_OR_EXPORT gsoap_eml2_1::eml21__LengthUom getPerforationHistoryMdUnit(unsigned int historyIndex,
+			unsigned int perforationIndex) const;
+
+		DLL_IMPORT_OR_EXPORT bool hasPerforationHistoryTopMd(unsigned int historyIndex,
+			unsigned int perforationIndex) const;
+
+		DLL_IMPORT_OR_EXPORT double getPerforationHistoryTopMd(unsigned int historyIndex,
+			unsigned int perforationIndex) const;
 		
-		DLL_IMPORT_OR_EXPORT bool hasPerforationHistoryEntryMdUnit(const std::string & guid,
-			const std::string & perforationGuid) const;
+		DLL_IMPORT_OR_EXPORT bool hasPerforationHistoryBaseMd(unsigned int historyIndex,
+			unsigned int perforationIndex) const;
 
-		DLL_IMPORT_OR_EXPORT gsoap_eml2_1::eml21__LengthUom getPerforationHistoryEntryMdUnit(const std::string & guid,
-			const std::string & perforationGuid) const;
-
-		DLL_IMPORT_OR_EXPORT bool hasPerforationHistoryEntryTopMd(const std::string & guid,
-			const std::string & perforationGuid) const;
-
-		DLL_IMPORT_OR_EXPORT double getPerforationHistoryEntryTopMd(const std::string & guid,
-			const std::string & perforationGuid) const;
-		
-		DLL_IMPORT_OR_EXPORT bool hasPerforationHistoryEntryBaseMd(const std::string & guid,
-			const std::string & perforationGuid) const;
-
-		DLL_IMPORT_OR_EXPORT double getPerforationHistoryEntryBaseMd(const std::string & guid,
-			const std::string & perforationGuid) const;
+		DLL_IMPORT_OR_EXPORT double getPerforationHistoryBaseMd(unsigned int historyIndex,
+			unsigned int perforationIndex) const;
 
 		/**
 		* Resolve all relationships of the object in an epc document.
@@ -143,9 +143,9 @@ namespace WITSML2_0_NS
 		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const { return XML_TAG; }
 
 	private:
-		gsoap_eml2_1::witsml2__PerforationSetInterval* getPerforation(const std::string & guid) const;
+		gsoap_eml2_1::witsml2__PerforationSetInterval* getPerforation(unsigned int index) const;
 
-		gsoap_eml2_1::witsml2__PerforationStatusHistory* getPerforationHistoryEntry(const std::string & guid, 
-			const std::string & perforationGuid) const;
+		gsoap_eml2_1::witsml2__PerforationStatusHistory* getPerforationHistoryEntry(unsigned int index,
+			unsigned int perforationIndex) const;	
 	};
 }

--- a/swig/swigWitsml2_0Include.i
+++ b/swig/swigWitsml2_0Include.i
@@ -61,9 +61,12 @@ namespace gsoap_eml2_1
 //#endif
 #if defined(SWIGJAVA) || defined(SWIGCSHARP)
 	%nspace WITSML2_0_NS::AbstractObject;
+	
 	%nspace WITSML2_0_NS::Well;
-	%nspace WITSML2_0_NS::Wellbore;
 	%nspace WITSML2_0_NS::WellCompletion;
+	
+	%nspace WITSML2_0_NS::Wellbore;
+	%nspace WITSML2_0_NS::WellboreObject;
 	%nspace WITSML2_0_NS::WellboreCompletion;
 #endif
 
@@ -172,7 +175,7 @@ namespace WITSML2_0_NS
 			const double & BaseMd, 
 			const std::string & guid = "");
 
-		void pushBackPerforationHistoryEntry(const std::string & perforationGuid,
+		void pushBackPerforationHistory(unsigned int index,
 			gsoap_eml2_1::witsml2__PerforationStatus perforationStatus,
 			const std::string & datum,
 			gsoap_eml2_1::eml21__LengthUom MdUnit,
@@ -184,74 +187,73 @@ namespace WITSML2_0_NS
 
 		unsigned int getPerforationCount() const;
 
-		bool hasPerforationMdDatum(const std::string & guid) const;
+		bool hasPerforationMdDatum(unsigned int index) const;
+	
+		std::string getPerforationMdDatum(unsigned int index) const;
 		
-		std::string getPerforationMdDatum(const std::string & guid) const;
+		bool hasPerforationMdUnit(unsigned int index) const;
 		
-		bool hasPerforationMdUnit(const std::string & guid) const;
+		gsoap_eml2_1::eml21__LengthUom getPerforationMdUnit(unsigned int index) const;
 		
-		gsoap_eml2_1::eml21__LengthUom getPerforationMdUnit(const std::string & guid) const;
+		bool hasPerforationTopMd(unsigned int index) const;
 		
-		bool hasPerforationTopMd(const std::string & guid) const;
+		double getPerforationTopMd(unsigned int index) const;
+
+		bool hasPerforationBaseMd(unsigned int index) const;
+
+		double getPerforationBaseMd(unsigned int index) const;
+
+		unsigned int getPerforationHistoryCount(unsigned int index) const;
+
+		bool hasPerforationHistoryStatus(unsigned int historyIndex,
+			unsigned int perforationIndex) const;
+
+		gsoap_eml2_1::witsml2__PerforationStatus getPerforationHistoryStatus(unsigned int historyIndex,
+			unsigned int perforationIndex) const;
+
+		std::string getPerforationHistoryStatusToString(unsigned int historyIndex,
+			unsigned int perforationIndex) const;
+
+		bool hasPerforationHistoryStartDate(unsigned int historyIndex,
+			unsigned int perforationIndex) const;
+
+		time_t getPerforationHistoryStartDate(unsigned int historyIndex,
+			unsigned int perforationIndex) const;
+
+		bool hasPerforationHistoryEndDate(unsigned int historyIndex,
+			unsigned int perforationIndex) const;
+
+		time_t getPerforationHistoryEndDate(unsigned int historyIndex,
+			unsigned int perforationIndex) const;
 		
-		double getPerforationTopMd(const std::string & guid) const;
-
-		bool hasPerforationBaseMd(const std::string & guid) const;
-
-		double getPerforationBaseMd(const std::string & guid) const;
-
-		unsigned int getHistoryEntryCount(const std::string & perforationGuid) const;
-
-		bool hasPerforationHistoryEntryStatus(const std::string & guid,
-			const std::string & perforationGuid) const;
-
-		gsoap_eml2_1::witsml2__PerforationStatus getPerforationHistoryEntryStatus(const std::string & guid,
-			const std::string & perforationGuid) const;
-
-		std::string getPerforationHistoryEntryStatusToString(const std::string & guid,
-			const std::string & perforationGuid) const;
-
-		bool hasPerforationHistoryEntryStartDate(const std::string & guid,
-			const std::string & perforationGuid) const;
-
-		time_t getPerforationHistoryEntryStartDate(const std::string & guid,
-			const std::string & perforationGuid) const;
-
-		bool hasPerforationHistoryEntryEndDate(const std::string & guid,
-			const std::string & perforationGuid) const;
-
-		time_t getPerforationHistoryEntryEndDate(const std::string & guid,
-			const std::string & perforationGuid) const;
+		bool hasPerforationHistoryMdDatum(unsigned int historyIndex,
+			unsigned int perforationIndex) const;
 		
-		bool hasPerforationHistoryEntryMdDatum(const std::string & guid,
-			const std::string & perforationGuid) const;
+		std::string getPerforationHistoryMdDatum(unsigned int historyIndex,
+			unsigned int perforationIndex) const;
 		
-		std::string getPerforationHistoryEntryMdDatum(const std::string & guid,
-			const std::string & perforationGuid) const;
+		bool hasPerforationHistoryMdUnit(unsigned int historyIndex,
+			unsigned int perforationIndex) const;
+
+		gsoap_eml2_1::eml21__LengthUom getPerforationHistoryMdUnit(unsigned int historyIndex,
+			unsigned int perforationIndex) const;
+
+		bool hasPerforationHistoryTopMd(unsigned int historyIndex,
+			unsigned int perforationIndex) const;
+
+		double getPerforationHistoryTopMd(unsigned int historyIndex,
+			unsigned int perforationIndex) const;
 		
-		bool hasPerforationHistoryEntryMdUnit(const std::string & guid,
-			const std::string & perforationGuid) const;
+		bool hasPerforationHistoryBaseMd(unsigned int historyIndex,
+			unsigned int perforationIndex) const;
 
-		gsoap_eml2_1::eml21__LengthUom getPerforationHistoryEntryMdUnit(const std::string & guid,
-			const std::string & perforationGuid) const;
-
-		bool hasPerforationHistoryEntryTopMd(const std::string & guid,
-			const std::string & perforationGuid) const;
-
-		double getPerforationHistoryEntryTopMd(const std::string & guid,
-			const std::string & perforationGuid) const;
-		
-		bool hasPerforationHistoryEntryBaseMd(const std::string & guid,
-			const std::string & perforationGuid) const;
-
-		double getPerforationHistoryEntryBaseMd(const std::string & guid,
-			const std::string & perforationGuid) const;
+		double getPerforationHistoryBaseMd(unsigned int historyIndex,
+			unsigned int perforationIndex) const;
 	};
 	
 	class Trajectory : public WellboreObject
 	{
 	public:
 	};
-}
 }
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- WITSML 2.0 perforation and their history can be get thanks to index instead of uid
- cs example have been fixed
- WellboreObject have been fixed in swigWitsml2_0Include.i

Does this close any currently open issues?
------------------------------------------
No

Where has this been tested?
---------------------------
**Operating System:** Windows 10 64bits

**Platform:** Microsoft Visual Studio Community 2015
