### PR TITLE
Remove Compiler Warning C4251

### DIFF
--- a/example/example.cpp
+++ b/example/example.cpp
@@ -3519,7 +3519,7 @@ void deserialize(const string & inputFile)
 		{
 			for (size_t k = 0; k < wellboreSet[i]->getInterpretationSet()[j]->getRepresentationSet().size(); k++)
 			{
-				if (wellboreSet[i]->getInterpretationSet()[j]->getRepresentationSet()[k]->getGsoapType() == SOAP_TYPE_gsoap_resqml2_0_1_resqml2__obj_USCOREWellboreMarkerFrameRepresentation)
+				if (wellboreSet[i]->getInterpretationSet()[j]->getRepresentationSet()[k]->getXmlTag() == WellboreMarkerFrameRepresentation::XML_TAG)
 				{
 					WellboreMarkerFrameRepresentation* wmf = static_cast<WellboreMarkerFrameRepresentation*>(wellboreSet[i]->getInterpretationSet()[j]->getRepresentationSet()[k]);
 					vector<WellboreMarker*> marketSet = wmf->getWellboreMarkerSet();
@@ -3533,7 +3533,7 @@ void deserialize(const string & inputFile)
 
 					for (size_t l = 0; l < wmf->getPropertySet().size(); ++l)
 					{
-						if (wmf->getPropertySet()[l]->getGsoapType() == SOAP_TYPE_gsoap_resqml2_0_1_resqml2__obj_USCORECategoricalProperty)
+						if (wmf->getPropertySet()[l]->getXmlTag() == CategoricalProperty::XML_TAG)
 						{
 							CategoricalProperty* catVal = static_cast<CategoricalProperty*>(wmf->getPropertySet()[l]);
 							if (catVal->getValuesHdfDatatype() == RESQML2_NS::AbstractValuesProperty::LONG)
@@ -3791,7 +3791,7 @@ void deserialize(const string & inputFile)
 		if (ijkGrid->getParentGrid() != NULL)
 		{
 			std::cout << "\t PARENT WINDOW" << std::endl;
-			if (ijkGrid->getParentGrid()->getGsoapType() == SOAP_TYPE_gsoap_resqml2_0_1_resqml2__obj_USCOREIjkGridRepresentation)
+			if (ijkGrid->getParentGrid()->getXmlTag() == AbstractIjkGridRepresentation::XML_TAG)
 			{
 				for (char dimension = 'i'; dimension < 'l'; ++dimension) {
 					std::cout << "\t\t DIMENSION :" << dimension << std::endl;
@@ -3810,12 +3810,12 @@ void deserialize(const string & inputFile)
 						std::cout << "\t\t Non constant child cell count per interval" << std::endl;
 					}
 				}
-			}
-			else if (ijkGrid->getParentGrid()->getGsoapType() == SOAP_TYPE_gsoap_resqml2_0_1_resqml2__obj_USCOREUnstructuredColumnLayerGridRepresentation)
+			}/*
+			else if (ijkGrid->getParentGrid()->getXmlTag() == UnstructuredColumnLayerGridRepresentation::XML_TAG)
 			{
 				std::cout << "\t\t Refined columns count :" << ijkGrid->getParentColumnIndexCount() << std::endl;
-			}
-			else if (ijkGrid->getParentGrid()->getGsoapType() == SOAP_TYPE_gsoap_resqml2_0_1_resqml2__obj_USCOREUnstructuredGridRepresentation)
+			}*/
+			else if (ijkGrid->getParentGrid()->getXmlTag() == UnstructuredGridRepresentation::XML_TAG)
 			{
 				std::cout << "\t\t Refined cells count :" << ijkGrid->getParentCellIndexCount() << std::endl;
 			}

--- a/src/common/AbstractHdfProxy.h
+++ b/src/common/AbstractHdfProxy.h
@@ -26,7 +26,7 @@ under the License.
 
 namespace COMMON_NS
 {
-	class DLL_IMPORT_OR_EXPORT AbstractHdfProxy : public EpcExternalPartReference
+	class AbstractHdfProxy : public EpcExternalPartReference
 	{
 	protected:
 
@@ -59,7 +59,7 @@ namespace COMMON_NS
 		/**
 		 * Check if the Hdf file is open or not
 		 */
-		virtual bool isOpened() const = 0;
+		DLL_IMPORT_OR_EXPORT virtual bool isOpened() const = 0;
 
 		/**
 		 * Close the file
@@ -115,7 +115,7 @@ namespace COMMON_NS
 		 * Set the new compression level which will be used for all data to be written
 		 * @param compressionLevel				Lower compression levels are faster but result in less compression. Range [0..9] is allowed.
 		 */
-		virtual void setCompressionLevel(const unsigned int & newCompressionLevel) = 0;
+		DLL_IMPORT_OR_EXPORT virtual void setCompressionLevel(const unsigned int & newCompressionLevel) = 0;
 
 		virtual void writeArrayNdOfFloatValues(const std::string & groupName,
 		  const std::string & name,
@@ -536,4 +536,3 @@ namespace COMMON_NS
 
 	};
 }
-

--- a/src/common/AbstractObject.h
+++ b/src/common/AbstractObject.h
@@ -24,7 +24,7 @@ under the License.
 
 namespace COMMON_NS
 {
-	class DLL_IMPORT_OR_EXPORT AbstractObject
+	class AbstractObject
 	{
 	private:
 		static char citationFormat[];
@@ -157,41 +157,41 @@ namespace COMMON_NS
 		* A partial object just contains a mime type, an uuid and a title as a minimum amount of information.
 		* A partial object is never explicit in an EPC document : it is not a file.
 		*/
-		bool isPartial() const {return partialObject != nullptr;}
+		DLL_IMPORT_OR_EXPORT bool isPartial() const {return partialObject != nullptr;}
 
-		std::string getUuid() const;
-		std::string getTitle() const;
-		std::string getEditor() const;
-		time_t getCreation() const;
+		DLL_IMPORT_OR_EXPORT std::string getUuid() const;
+		DLL_IMPORT_OR_EXPORT std::string getTitle() const;
+		DLL_IMPORT_OR_EXPORT std::string getEditor() const;
+		DLL_IMPORT_OR_EXPORT time_t getCreation() const;
 		/**
 		* Use this method if you want to read some dates out of range of time_t
 		*/
-		tm getCreationAsTimeStructure() const;
-		std::string getOriginator() const;
-		std::string getDescription() const;
-		time_t getLastUpdate() const;
+		DLL_IMPORT_OR_EXPORT tm getCreationAsTimeStructure() const;
+		DLL_IMPORT_OR_EXPORT std::string getOriginator() const;
+		DLL_IMPORT_OR_EXPORT std::string getDescription() const;
+		DLL_IMPORT_OR_EXPORT time_t getLastUpdate() const;
 		/**
 		* Use this method if you want to read some dates out of range of time_t
 		*/
-		tm getLastUpdateAsTimeStructure() const;
-		std::string getFormat() const;
-		std::string getDescriptiveKeywords() const;
-		std::string getVersionString() const;
+		DLL_IMPORT_OR_EXPORT tm getLastUpdateAsTimeStructure() const;
+		DLL_IMPORT_OR_EXPORT std::string getFormat() const;
+		DLL_IMPORT_OR_EXPORT std::string getDescriptiveKeywords() const;
+		DLL_IMPORT_OR_EXPORT std::string getVersionString() const;
 
-		void setTitle(const std::string & title);
-		void setEditor(const std::string & editor);
-		void setCreation(const time_t & creation);
+		DLL_IMPORT_OR_EXPORT void setTitle(const std::string & title);
+		DLL_IMPORT_OR_EXPORT void setEditor(const std::string & editor);
+		DLL_IMPORT_OR_EXPORT void setCreation(const time_t & creation);
 		/**
 		* Use this method if you want to set some dates out of range of time_t
 		*/
-		void setCreation(const tm & creation);
-		void setOriginator(const std::string & originator);
-		void setDescription(const std::string & description);
-		void setLastUpdate(const time_t & lastUpdate);
+		DLL_IMPORT_OR_EXPORT void setCreation(const tm & creation);
+		DLL_IMPORT_OR_EXPORT void setOriginator(const std::string & originator);
+		DLL_IMPORT_OR_EXPORT void setDescription(const std::string & description);
+		DLL_IMPORT_OR_EXPORT void setLastUpdate(const time_t & lastUpdate);
 		/**
 		* Use this method if you want to set some dates out of range of time_t
 		*/
-		void setLastUpdate(const tm & lastUpdate);
+		DLL_IMPORT_OR_EXPORT void setLastUpdate(const tm & lastUpdate);
 		
 		/**
 		* Set the default citation format which is going to be written in each created object.
@@ -200,23 +200,23 @@ namespace COMMON_NS
 		* @param applicationName The application name which is exporting the RESQML objects
 		* @param applicationVersionNumber The application version number which is exporting the RESQML objects
 		*/
-		static void setFormat(const std::string & vendor, const std::string & applicationName, const std::string & applicationVersionNumber);
+		DLL_IMPORT_OR_EXPORT static void setFormat(const std::string & vendor, const std::string & applicationName, const std::string & applicationVersionNumber);
 
-		void setDescriptiveKeywords(const std::string & descriptiveKeywords);
-		void setVersionString(const std::string & versionString);
+		DLL_IMPORT_OR_EXPORT void setDescriptiveKeywords(const std::string & descriptiveKeywords);
+		DLL_IMPORT_OR_EXPORT void setVersionString(const std::string & versionString);
 
 		/**
 		* Set a title and other common metadata for the resqml instance. Set to empty string or zero if you don't want to use.
 		* @param title				The title to set to the resqml instance. Set to empty string if you don't want to set it.
 		*/
-		void setMetadata(const std::string & title, const std::string & editor, const time_t & creation, const std::string & originator,
+		DLL_IMPORT_OR_EXPORT void setMetadata(const std::string & title, const std::string & editor, const time_t & creation, const std::string & originator,
 			const std::string & description, const time_t & lastUpdate, const std::string & descriptiveKeywords);
 
 		/**
 		* Serialize the instance into a stream.
 		* @param stream	The stream must be opened for writing and won't be closed.
 		*/
-		void serializeIntoStream(std::ostream * stream);
+		DLL_IMPORT_OR_EXPORT void serializeIntoStream(std::ostream * stream);
 
 		/**
 		* Get the gsoap proxy which is wrapped by this entity
@@ -241,7 +241,7 @@ namespace COMMON_NS
 		/**
 		 * Return the EPC document which contains this gsoap wrapper.
 		 */
-		COMMON_NS::EpcDocument* getEpcDocument() const {return epcDocument;}
+		DLL_IMPORT_OR_EXPORT COMMON_NS::EpcDocument* getEpcDocument() const {return epcDocument;}
 
 		/**
 		* Get the XML namespace for the tags for the XML serialization of this instance
@@ -251,7 +251,7 @@ namespace COMMON_NS
 		/**
 		* Get the XML tag for the XML serialization of this instance
 		*/
-		virtual std::string getXmlTag() const = 0;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const = 0;
 
 		/**
 		* Get the XML tag for the XML serialization of this instance
@@ -261,7 +261,7 @@ namespace COMMON_NS
 		/**
 		* Get the content type of the instance according to EPC recommendation
 		*/
-		virtual std::string getContentType() const;
+		DLL_IMPORT_OR_EXPORT virtual std::string getContentType() const;
 		
 		/**
 		* Get part name of this XML top level instance in the EPC document
@@ -271,53 +271,53 @@ namespace COMMON_NS
 		/**
 		* Serialize the gsoap proxy into a string
 		*/
-		std::string serializeIntoString();	
+		DLL_IMPORT_OR_EXPORT std::string serializeIntoString();
 
 		/**
 		* Add an alias for this object
 		*/
-		void addAlias(const std::string & authority, const std::string & title);
+		DLL_IMPORT_OR_EXPORT void addAlias(const std::string & authority, const std::string & title);
 
 		/**
 		* Get the count of aliases in the instance.
 		*/
-		unsigned int getAliasCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getAliasCount() const;
 
 		/**
 		* Get the alias authority at a particular index in the aliases set.
 		*/
-		std::string getAliasAuthorityAtIndex(unsigned int index) const;
+		DLL_IMPORT_OR_EXPORT std::string getAliasAuthorityAtIndex(unsigned int index) const;
 
 		/**
 		* Get the alias title at a particular index in the aliases set.
 		*/
-		std::string getAliasTitleAtIndex(unsigned int index) const;
+		DLL_IMPORT_OR_EXPORT std::string getAliasTitleAtIndex(unsigned int index) const;
 
 		/**
 		* Get all the activities where the instance is involved.
 		*/
-		const std::vector<RESQML2_NS::Activity*> & getActivitySet() const;
+		DLL_IMPORT_OR_EXPORT const std::vector<RESQML2_NS::Activity*> & getActivitySet() const;
 
 		/**
 		* Get the count of associated activities.
 		*/
-		unsigned int getActivityCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getActivityCount() const;
 
 		/**
 		* Get the associated activity at a particular index.
 		*/
-		RESQML2_NS::Activity* getActivity(unsigned int index) const;
+		DLL_IMPORT_OR_EXPORT RESQML2_NS::Activity* getActivity(unsigned int index) const;
 
 		/**
 		* Push back an extra metadata (not a standard one)
 		*/
-		void pushBackExtraMetadata(const std::string & key, const std::string & value);
+		DLL_IMPORT_OR_EXPORT void pushBackExtraMetadata(const std::string & key, const std::string & value);
 
 		/**
 		* Getter (in read only mode) of all the extra metadata
 		*/
 #if (defined(_WIN32) && _MSC_VER >= 1600) || defined(__APPLE__)
-		std::unordered_map< std::string, std::string > getExtraMetadataSet() const;
+		DLL_IMPORT_OR_EXPORT std::unordered_map< std::string, std::string > getExtraMetadataSet() const;
 #else
 		std::tr1::unordered_map< std::string, std::string > getExtraMetadataSet() const;
 #endif
@@ -326,25 +326,24 @@ namespace COMMON_NS
 		* Get an extra metadata according its key.
 		* @return An empty vector if the extra metadata does not exist. Or the extra metadata value set if it exists.
 		*/
-		std::vector<std::string> getExtraMetadata(const std::string & key) const;
+		DLL_IMPORT_OR_EXPORT std::vector<std::string> getExtraMetadata(const std::string & key) const;
 
 		/**
 		* Get the count of extra metadata in the instance.
 		*/
-		unsigned int getExtraMetadataCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getExtraMetadataCount() const;
 
 		/**
 		* Get the key of a string value pair at a particular index in the extra metadata set
 		*/
-		std::string getExtraMetadataKeyAtIndex(unsigned int index) const;
+		DLL_IMPORT_OR_EXPORT std::string getExtraMetadataKeyAtIndex(unsigned int index) const;
 
 		/**
 		* Get the string value of a string value pair at a particular index in the extra metadata set
 		*/
-		std::string getExtraMetadataStringValueAtIndex(unsigned int index) const;
+		DLL_IMPORT_OR_EXPORT std::string getExtraMetadataStringValueAtIndex(unsigned int index) const;
 
 		static const char* RESQML_2_0_CONTENT_TYPE_PREFIX;
 		static const char* RESQML_2_0_1_CONTENT_TYPE_PREFIX;
 	};
 }
-

--- a/src/common/EpcDocument.cpp
+++ b/src/common/EpcDocument.cpp
@@ -176,6 +176,11 @@ EpcDocument::EpcDocument(const std::string & fileName, const std::string & prope
 	}
 }
 
+EpcDocument::~EpcDocument()
+{
+	close();
+}
+
 std::string EpcDocument::generateRandomUuidAsString()
 {
 	return GuidTools::generateUidAsString();

--- a/src/common/EpcDocument.h
+++ b/src/common/EpcDocument.h
@@ -149,7 +149,7 @@ namespace COMMON_NS
 	/**
 	* This class allows an access to a memory package representing an EPC document.
 	*/
-	class DLL_IMPORT_OR_EXPORT EpcDocument
+	class EpcDocument
 	{
 	private :
 
@@ -162,13 +162,13 @@ namespace COMMON_NS
 
 		enum openingMode { READ_ONLY = 0, READ_WRITE = 1, OVERWRITE = 2 };
 
-		EpcDocument(const std::string & fileName, const openingMode & hdf5PermissionAccess = READ_ONLY);
-		EpcDocument(const std::string & fileName, const std::string & propertyKindMappingFilesDirectory, const openingMode & hdf5PermissionAccess = READ_ONLY);
+		DLL_IMPORT_OR_EXPORT EpcDocument(const std::string & fileName, const openingMode & hdf5PermissionAccess = READ_ONLY);
+		DLL_IMPORT_OR_EXPORT EpcDocument(const std::string & fileName, const std::string & propertyKindMappingFilesDirectory, const openingMode & hdf5PermissionAccess = READ_ONLY);
 
 		/**
 		* The destructor frees all allocated ressources.
 		*/
-		virtual ~EpcDocument() { close(); }
+		DLL_IMPORT_OR_EXPORT virtual ~EpcDocument();
 
 		// A function pointer definition which allows to build an abstract hdf proxy in writing mode of an epc document
 		typedef COMMON_NS::AbstractHdfProxy* (HdfProxyBuilder)(soap* soapContext, const std::string & guid, const std::string & title, const std::string & packageDirAbsolutePath, const std::string & externalFilePath);
@@ -177,39 +177,39 @@ namespace COMMON_NS
 
 		// Allows a fesapi user to set a different builder of Hdf Proxy than the default one in writing mode of an epc document
 		// This is especially useful when the fesapi users wants to use its own builder for example.
-		void set_hdf_proxy_builder(HdfProxyBuilder builder);
-		void set_hdf_proxy_builder(HdfProxyBuilderFromGsoapProxy2_0_1 builder);
+		DLL_IMPORT_OR_EXPORT void set_hdf_proxy_builder(HdfProxyBuilder builder);
+		DLL_IMPORT_OR_EXPORT void set_hdf_proxy_builder(HdfProxyBuilderFromGsoapProxy2_0_1 builder);
 
 		/**
 		* Open an epc document.
 		* If already opened, the epc document must be closed before to open a new one.
 		* Don't forget to call close() before to destroy this object.
 		*/
-		void open(const std::string & fileName, const openingMode & hdf5PermissionAccess = READ_ONLY);
+		DLL_IMPORT_OR_EXPORT void open(const std::string & fileName, const openingMode & hdf5PermissionAccess = READ_ONLY);
 	
 		/**
 		 * Free all ressources contained in this package.
 		 */
-		void close();
+		DLL_IMPORT_OR_EXPORT void close();
 
-		const openingMode & getHdf5PermissionAccess() const;
+		DLL_IMPORT_OR_EXPORT const openingMode & getHdf5PermissionAccess() const;
 
 		/**
 		 * Set the file path which will be used for future serialization and deserialization
 		 * Will add the standard epc extension to the filePath is not already present.
 		 */
-		void setFilePath(const std::string & filePath);
+		DLL_IMPORT_OR_EXPORT void setFilePath(const std::string & filePath);
 
 		/**
 		* Serialize the package by serializing all the gsoap wrappers and by zipping the package.
 		*/
-		virtual void serialize(bool useZip64 = false);
+		DLL_IMPORT_OR_EXPORT virtual void serialize(bool useZip64 = false);
 
 		/**
 		* Unzip the package and get all contained elements with their relationships
 		* @return			An empty string if everything's ok otherwise the error string.
 		*/
-		virtual std::string deserialize();
+		DLL_IMPORT_OR_EXPORT virtual std::string deserialize();
 
 		/**
 		* Get the soap context of the epc document.
@@ -225,67 +225,67 @@ namespace COMMON_NS
 		 * Get the property kind mapper of this epc document if given at EPC document construction time.
 		 * Else return NULL.
 		 */
-		RESQML2_0_1_NS::PropertyKindMapper* getPropertyKindMapper() const;
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::PropertyKindMapper* getPropertyKindMapper() const;
 
 		/**
 		* Get the name of the energistics property kind as a string based on the enumerated property kind.
 		* @return The empty string if no correspondence is found
 		*/
-		std::string getEnergisticsPropertyKindName(const gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind & energisticsPropertyKind) const;
+		DLL_IMPORT_OR_EXPORT std::string getEnergisticsPropertyKindName(const gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind & energisticsPropertyKind) const;
 
 		/**
 		* Get the Energistics property kind enumerated value from the name (string) of the property kind.
 		* @return The most abstract energistics property kind if no correspondance is found with the property kind string/name.
 		*/
-		gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind getEnergisticsPropertyKind(const std::string & energisticsPropertyKindName) const;
+		DLL_IMPORT_OR_EXPORT gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind getEnergisticsPropertyKind(const std::string & energisticsPropertyKindName) const;
 
 		/**
 		* Get the name of the resqml standard property type as a string based on the enumerated property kind.
 		* @return The empty string if no correspondence is found
 		*/
-		std::string getEnergisticsUnitOfMeasureName(const gsoap_resqml2_0_1::resqml2__ResqmlUom & energisticsUom) const;
+		DLL_IMPORT_OR_EXPORT std::string getEnergisticsUnitOfMeasureName(const gsoap_resqml2_0_1::resqml2__ResqmlUom & energisticsUom) const;
 
 		/**
 		* Get the Energistics unit of measure enumerated value from the name (string) of the uom.
 		* @return The Euclidian (no uom) energistics uom if no correspondance is found with the uom string/name.
 		*/
-		gsoap_resqml2_0_1::resqml2__ResqmlUom getEnergisticsUnitOfMeasure(const std::string & energisticsUomName) const;
+		DLL_IMPORT_OR_EXPORT gsoap_resqml2_0_1::resqml2__ResqmlUom getEnergisticsUnitOfMeasure(const std::string & energisticsUomName) const;
 
 		/**
 		* Get the name of the resqml facet as a string based on the enumerated facet.
 		* @return The empty string if no correspondence is found
 		*/
-		std::string getFacet(const gsoap_resqml2_0_1::resqml2__Facet & facet) const;
+		DLL_IMPORT_OR_EXPORT std::string getFacet(const gsoap_resqml2_0_1::resqml2__Facet & facet) const;
 
 		/**
 		* Get the facet enumerated value from the name (string) of the facet.
 		* @return The what facet if no correspondance is found with the facet string/name.
 		*/
-		gsoap_resqml2_0_1::resqml2__Facet getFacet(const std::string & facet) const;
+		DLL_IMPORT_OR_EXPORT gsoap_resqml2_0_1::resqml2__Facet getFacet(const std::string & facet) const;
 
 		/**
 		* Get the name (string) of the witsml uom as a string based on the enumerated uom.
 		* @return The empty string if no correspondence is found
 		*/
-		std::string lengthUomToString(const gsoap_eml2_1::eml21__LengthUom & witsmlUom) const;
+		DLL_IMPORT_OR_EXPORT std::string lengthUomToString(const gsoap_eml2_1::eml21__LengthUom & witsmlUom) const;
 
 		/**
 		* Get the name (string) of the witsml uom as a string based on the enumerated uom.
 		* @return The empty string if no correspondence is found
 		*/
-		std::string verticalCoordinateUomToString(const gsoap_eml2_1::eml21__VerticalCoordinateUom & witsmlUom) const;
+		DLL_IMPORT_OR_EXPORT std::string verticalCoordinateUomToString(const gsoap_eml2_1::eml21__VerticalCoordinateUom & witsmlUom) const;
 
 		/**
 		* Get the name (string) of the witsml uom as a string based on the enumerated uom.
 		* @return The empty string if no correspondence is found
 		*/
-		std::string planeAngleUomToString(const gsoap_eml2_1::eml21__PlaneAngleUom & witsmlUom) const;
+		DLL_IMPORT_OR_EXPORT std::string planeAngleUomToString(const gsoap_eml2_1::eml21__PlaneAngleUom & witsmlUom) const;
 
 		/**
 		* Get all the resqml gsoap wrappers from the epc document
 		*/
 #if (defined(_WIN32) && _MSC_VER >= 1600) || defined(__APPLE__)
-		const std::unordered_map< std::string, COMMON_NS::AbstractObject* > & getDataObjectSet() const;
+		DLL_IMPORT_OR_EXPORT const std::unordered_map< std::string, COMMON_NS::AbstractObject* > & getDataObjectSet() const;
 #else
 		const std::tr1::unordered_map< std::string, COMMON_NS::AbstractObject* > & getDataObjectSet() const;
 #endif
@@ -295,7 +295,7 @@ namespace COMMON_NS
 		* @return A map where the key is a content type and where the value is the collection of Data objects of this content type
 		*/
 #if (defined(_WIN32) && _MSC_VER >= 1600) || defined(__APPLE__)
-		std::unordered_map< std::string, std::vector<COMMON_NS::AbstractObject*> > getDataObjectsGroupedByContentType() const;
+		DLL_IMPORT_OR_EXPORT std::unordered_map< std::string, std::vector<COMMON_NS::AbstractObject*> > getDataObjectsGroupedByContentType() const;
 #else
 		std::tr1::unordered_map< std::string, std::vector<COMMON_NS::AbstractObject*> > getDataObjectsGroupedByContentType() const;
 #endif
@@ -304,7 +304,7 @@ namespace COMMON_NS
 		* Get Data objects which honor this content type
 		* @return The vector of Data objects in this EPC Document which honor the content type
 		*/
-		std::vector<COMMON_NS::AbstractObject*> getDataObjectsByContentType(const std::string & contentType) const;
+		DLL_IMPORT_OR_EXPORT std::vector<COMMON_NS::AbstractObject*> getDataObjectsByContentType(const std::string & contentType) const;
 
 		/**
 		* Get RESQML2.0 objects which honor a particular XML tag.
@@ -313,7 +313,7 @@ namespace COMMON_NS
 		*
 		* @return The vector of RESQML2.0.1 objects in this EPC Document which honor the XML tag
 		*/
-		std::vector<COMMON_NS::AbstractObject*> getResqml2_0ObjectsByXmlTag(const std::string & xmlTag) const;
+		DLL_IMPORT_OR_EXPORT std::vector<COMMON_NS::AbstractObject*> getResqml2_0ObjectsByXmlTag(const std::string & xmlTag) const;
 
 		/**
 		* Get all data objects of a particular type indicated by means of the template class.
@@ -341,17 +341,17 @@ namespace COMMON_NS
 		/**
 		* Get all UUIDs of the objects contained in the EPC document
 		*/
-		std::vector<std::string> getAllUuids() const;
+		DLL_IMPORT_OR_EXPORT std::vector<std::string> getAllUuids() const;
 
 		/**
 		* Get the Gsoap type by means of its uuid
 		*/
-		COMMON_NS::AbstractObject* getDataObjectByUuid(const std::string & uuid, int & gsoapType) const;
+		DLL_IMPORT_OR_EXPORT COMMON_NS::AbstractObject* getDataObjectByUuid(const std::string & uuid, int & gsoapType) const;
 
 		/**
 		* Get a gsoap wrapper from the epc document by means of its uuid
 		*/
-		COMMON_NS::AbstractObject* getDataObjectByUuid(const std::string & uuid) const;
+		DLL_IMPORT_OR_EXPORT COMMON_NS::AbstractObject* getDataObjectByUuid(const std::string & uuid) const;
 
 		/**
 		* Get a gsoap wrapper from the epc document by means of its uuid
@@ -376,227 +376,227 @@ namespace COMMON_NS
 		/**
 		* Get all the local 3d depth crs contained into the EPC document
 		*/
-		const std::vector<RESQML2_0_1_NS::LocalDepth3dCrs*> & getLocalDepth3dCrsSet() const;
+		DLL_IMPORT_OR_EXPORT const std::vector<RESQML2_0_1_NS::LocalDepth3dCrs*> & getLocalDepth3dCrsSet() const;
 
 		/**
 		* Get all the local 3d time crs contained into the EPC document
 		*/
-		const std::vector<RESQML2_0_1_NS::LocalTime3dCrs*> & getLocalTime3dCrsSet() const;
+		DLL_IMPORT_OR_EXPORT const std::vector<RESQML2_0_1_NS::LocalTime3dCrs*> & getLocalTime3dCrsSet() const;
 
 		/**
 		* Get all the stratigraphic columns contained into the EPC document
 		*/
-		const std::vector<RESQML2_0_1_NS::StratigraphicColumn*> & getStratigraphicColumnSet() const;
+		DLL_IMPORT_OR_EXPORT const std::vector<RESQML2_0_1_NS::StratigraphicColumn*> & getStratigraphicColumnSet() const;
 
 		/**
 		* Get all the faults contained into the EPC document
 		*/
-		const std::vector<RESQML2_0_1_NS::TectonicBoundaryFeature*> & getFaultSet() const;
+		DLL_IMPORT_OR_EXPORT const std::vector<RESQML2_0_1_NS::TectonicBoundaryFeature*> & getFaultSet() const;
 
 		/**
 		* Get all the fractures contained into the EPC document
 		*/
-		const std::vector<RESQML2_0_1_NS::TectonicBoundaryFeature*> & getFractureSet() const;
+		DLL_IMPORT_OR_EXPORT const std::vector<RESQML2_0_1_NS::TectonicBoundaryFeature*> & getFractureSet() const;
 
 		/**
 		* Get all the individual representations of faults which are associated to a polyline topology
 		*/
-		std::vector<RESQML2_0_1_NS::PolylineSetRepresentation*> getFaultPolylineSetRepSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::PolylineSetRepresentation*> getFaultPolylineSetRepSet() const;
 
 		/**
 		* Get all the individual representations of fractures which are associated to a polyline topology
 		*/
-		std::vector<RESQML2_0_1_NS::PolylineSetRepresentation*> getFracturePolylineSetRepSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::PolylineSetRepresentation*> getFracturePolylineSetRepSet() const;
 
 		/**
 		* Get all the individual representations of frontiers which are associated to a polyline set topology
 		*/
-		std::vector<RESQML2_0_1_NS::PolylineSetRepresentation*> getFrontierPolylineSetRepSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::PolylineSetRepresentation*> getFrontierPolylineSetRepSet() const;
 
 		/**
 		* Get all the individual representations of faults which are associated to a triangulation set topology
 		*/
-		std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation*> getFaultTriangulatedSetRepSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation*> getFaultTriangulatedSetRepSet() const;
 
         /**
 		* Get all the individual representations of fractures which are associated to a triangulation set topology
 		*/
-		std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation*> getFractureTriangulatedSetRepSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation*> getFractureTriangulatedSetRepSet() const;
 
 		/**
 		* Get all the horizons contained into the EPC document
 		*/
-		std::vector<RESQML2_0_1_NS::Horizon*> getHorizonSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::Horizon*> getHorizonSet() const;
 
 		/**
 		* Get all the geobody boundaries contained into the EPC document
 		*/
-		std::vector<RESQML2_0_1_NS::GeneticBoundaryFeature*> getGeobodyBoundarySet() const;
-		unsigned int getGeobodyBoundaryCount() const;
-		RESQML2_0_1_NS::GeneticBoundaryFeature* getGeobodyBoundary(unsigned int index) const;
+		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::GeneticBoundaryFeature*> getGeobodyBoundarySet() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getGeobodyBoundaryCount() const;
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::GeneticBoundaryFeature* getGeobodyBoundary(unsigned int index) const;
 
 		/**
 		* Get all the geobodies contained into the EPC document
 		*/
-		const std::vector<RESQML2_0_1_NS::GeobodyFeature*> & getGeobodySet() const;
+		DLL_IMPORT_OR_EXPORT const std::vector<RESQML2_0_1_NS::GeobodyFeature*> & getGeobodySet() const;
         
 		/**
 		* Get all the individual representations of horizons which are associated to grid 2d set topology
 		*/
-		std::vector<RESQML2_0_1_NS::Grid2dRepresentation*> getHorizonGrid2dRepSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::Grid2dRepresentation*> getHorizonGrid2dRepSet() const;
         
 		/**
 		* Get all the single polyline representations of all the horizons
 		*/
-		std::vector<RESQML2_0_1_NS::PolylineRepresentation*> getHorizonPolylineRepSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::PolylineRepresentation*> getHorizonPolylineRepSet() const;
         
 		/**
 		* Get all the single polyline representations of all the horizons
 		*/
-		std::vector<RESQML2_0_1_NS::PolylineSetRepresentation*> getHorizonPolylineSetRepSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::PolylineSetRepresentation*> getHorizonPolylineSetRepSet() const;
         
         /**
 		* Get all the triangulated set representations of all the horizons
 		*/
-		std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation*> getHorizonTriangulatedSetRepSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation*> getHorizonTriangulatedSetRepSet() const;
 
 		/**
 		* Get all the triangulated set representations of the EPC document
 		*/
-		const std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation*> & getAllTriangulatedSetRepSet() const;
+		DLL_IMPORT_OR_EXPORT const std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation*> & getAllTriangulatedSetRepSet() const;
 
 		/**
 		* Get all the grid 2d representations of the EPC document
 		*/
-		const std::vector<RESQML2_0_1_NS::Grid2dRepresentation*> & getAllGrid2dRepresentationSet() const;
+		DLL_IMPORT_OR_EXPORT const std::vector<RESQML2_0_1_NS::Grid2dRepresentation*> & getAllGrid2dRepresentationSet() const;
 
 		/**
 		* Get all the polyline set representations of the EPC document
 		*/
-		const std::vector<RESQML2_0_1_NS::PolylineSetRepresentation*> & getAllPolylineSetRepSet() const;
+		DLL_IMPORT_OR_EXPORT const std::vector<RESQML2_0_1_NS::PolylineSetRepresentation*> & getAllPolylineSetRepSet() const;
 
 		/**
 		* Get all the triangulated set representations of the EPC document which are not horizon and fault neither.
 		*/
-		std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation*> getUnclassifiedTriangulatedSetRepSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation*> getUnclassifiedTriangulatedSetRepSet() const;
 
 		/**
 		* Get all the seismic line contained into the EPC document
 		*/
-		const std::vector<RESQML2_0_1_NS::SeismicLineFeature*> & getSeismicLineSet() const;
+		DLL_IMPORT_OR_EXPORT const std::vector<RESQML2_0_1_NS::SeismicLineFeature*> & getSeismicLineSet() const;
 
 		/**
 		* Get all the wellbores contained into the EPC document
 		*/
-		const std::vector<RESQML2_0_1_NS::WellboreFeature*> & getWellboreSet() const;
+		DLL_IMPORT_OR_EXPORT const std::vector<RESQML2_0_1_NS::WellboreFeature*> & getWellboreSet() const;
 
 		/**
 		* Get all the trajectory representations of all wellbores.
 		*/
-		std::vector<RESQML2_0_1_NS::WellboreTrajectoryRepresentation*> getWellboreTrajectoryRepresentationSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::WellboreTrajectoryRepresentation*> getWellboreTrajectoryRepresentationSet() const;
 
 		/**
 		* Get all the devaition survey of all wellbores.
 		*/
-		std::vector<RESQML2_0_1_NS::DeviationSurveyRepresentation*> getDeviationSurveyRepresentationSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::DeviationSurveyRepresentation*> getDeviationSurveyRepresentationSet() const;
 
 		/**
 		* Get all the representationset representations contained into the EPC document
 		*/
-		const std::vector<RESQML2_NS::RepresentationSetRepresentation*> & getRepresentationSetRepresentationSet() const;
+		DLL_IMPORT_OR_EXPORT const std::vector<RESQML2_NS::RepresentationSetRepresentation*> & getRepresentationSetRepresentationSet() const;
 
 		/**
 		* Get the representationset representations count of this EPC document
 		*/
-		unsigned int getRepresentationSetRepresentationCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getRepresentationSetRepresentationCount() const;
 
 		/**
 		* Get the representationset representations at a particular index of this EPC document
 		*/
-		RESQML2_NS::RepresentationSetRepresentation* getRepresentationSetRepresentation(const unsigned int & index) const;
+		DLL_IMPORT_OR_EXPORT RESQML2_NS::RepresentationSetRepresentation* getRepresentationSetRepresentation(const unsigned int & index) const;
 
 		/**
 		* Get all the polyline representations contained into the EPC document.
 		*/
-		const std::vector<RESQML2_0_1_NS::PolylineRepresentation*> & getAllPolylineRepresentationSet() const;
+		DLL_IMPORT_OR_EXPORT const std::vector<RESQML2_0_1_NS::PolylineRepresentation*> & getAllPolylineRepresentationSet() const;
 
 		/**
 		* Get all the single polyline representations contained into the EPC document which correspond to a seismic line.
 		*/
-		std::vector<RESQML2_0_1_NS::PolylineRepresentation*> getSeismicLinePolylineRepSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::PolylineRepresentation*> getSeismicLinePolylineRepSet() const;
 
 		/**
 		* Get all the ijk grid contained into the EPC document.
 		*/
-		const std::vector<RESQML2_0_1_NS::AbstractIjkGridRepresentation*> & getIjkGridRepresentationSet() const;
-		unsigned int getIjkGridRepresentationCount() const;
-		RESQML2_0_1_NS::AbstractIjkGridRepresentation* getIjkGridRepresentation(const unsigned int & i) const;
+		DLL_IMPORT_OR_EXPORT const std::vector<RESQML2_0_1_NS::AbstractIjkGridRepresentation*> & getIjkGridRepresentationSet() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getIjkGridRepresentationCount() const;
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::AbstractIjkGridRepresentation* getIjkGridRepresentation(const unsigned int & i) const;
 
 		/**
 		* Get all the ijk grid contained into the EPC document which have a parametric geometry.
 		*/
-		std::vector<RESQML2_0_1_NS::IjkGridParametricRepresentation*> getIjkGridParametricRepresentationSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::IjkGridParametricRepresentation*> getIjkGridParametricRepresentationSet() const;
 
 		/**
 		* Get all the ijk grid contained into the EPC document which have an explicit geometry.
 		*/
-		std::vector<RESQML2_0_1_NS::IjkGridExplicitRepresentation*> getIjkGridExplicitRepresentationSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::IjkGridExplicitRepresentation*> getIjkGridExplicitRepresentationSet() const;
 
 		/**
 		* Get all the ijk grid contained into the EPC document which correspond to a seismic cube.
 		*/
-		std::vector<RESQML2_0_1_NS::IjkGridLatticeRepresentation*> getIjkSeismicCubeGridRepresentationSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::IjkGridLatticeRepresentation*> getIjkSeismicCubeGridRepresentationSet() const;
 
 		/**
 		* Get all the unstructured grid contained into the EPC document
 		*/
-		const std::vector<RESQML2_0_1_NS::UnstructuredGridRepresentation*> & getUnstructuredGridRepresentationSet() const;
+		DLL_IMPORT_OR_EXPORT const std::vector<RESQML2_0_1_NS::UnstructuredGridRepresentation*> & getUnstructuredGridRepresentationSet() const;
 
 		/**
 		* Get all the frontier features contained into the EPC document
 		*/
-		const std::vector<RESQML2_0_1_NS::FrontierFeature*> & getFrontierSet() const;
+		DLL_IMPORT_OR_EXPORT const std::vector<RESQML2_0_1_NS::FrontierFeature*> & getFrontierSet() const;
 
 		/**
 		 * Get all the organization features contained into the EPC document
 		 */
-		const std::vector<RESQML2_0_1_NS::OrganizationFeature*> & getOrganizationSet() const;
+		DLL_IMPORT_OR_EXPORT const std::vector<RESQML2_0_1_NS::OrganizationFeature*> & getOrganizationSet() const;
 
 		/**
 		 * Get all the time series contained into the EPC document
 		 */
-		const std::vector<RESQML2_NS::TimeSeries*> & getTimeSeriesSet() const;
+		DLL_IMPORT_OR_EXPORT const std::vector<RESQML2_NS::TimeSeries*> & getTimeSeriesSet() const;
 
 		/**
 		 * Get all the subrepresentations contained into the EPC document
 		 */
-		const std::vector<RESQML2_NS::SubRepresentation*> & getSubRepresentationSet() const;
-		unsigned int getSubRepresentationCount() const;
-		RESQML2_NS::SubRepresentation* getSubRepresentation(const unsigned int & index) const;
+		DLL_IMPORT_OR_EXPORT const std::vector<RESQML2_NS::SubRepresentation*> & getSubRepresentationSet() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getSubRepresentationCount() const;
+		DLL_IMPORT_OR_EXPORT RESQML2_NS::SubRepresentation* getSubRepresentation(const unsigned int & index) const;
 
 		/**
 		* Get all the point set representations contained into the EPC document
 		*/
-		const std::vector<RESQML2_0_1_NS::PointSetRepresentation*> & getPointSetRepresentationSet() const;
-		unsigned int getPointSetRepresentationCount() const;
-		RESQML2_0_1_NS::PointSetRepresentation* getPointSetRepresentation(const unsigned int & index) const;
+		DLL_IMPORT_OR_EXPORT const std::vector<RESQML2_0_1_NS::PointSetRepresentation*> & getPointSetRepresentationSet() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getPointSetRepresentationCount() const;
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::PointSetRepresentation* getPointSetRepresentation(const unsigned int & index) const;
 
 		/**
 		* Get all the Hdf proxies used with this EPC document
 		*/
-		const std::vector<COMMON_NS::AbstractHdfProxy*> & getHdfProxySet() const;
-		unsigned int getHdfProxyCount() const;
-		COMMON_NS::AbstractHdfProxy* getHdfProxy(const unsigned int & index) const;
+		DLL_IMPORT_OR_EXPORT const std::vector<COMMON_NS::AbstractHdfProxy*> & getHdfProxySet() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getHdfProxyCount() const;
+		DLL_IMPORT_OR_EXPORT COMMON_NS::AbstractHdfProxy* getHdfProxy(const unsigned int & index) const;
 
 		/**
 		* Get the absolute path of the directory where the epc document is stored.
 		*/
-		std::string getStorageDirectory() const;
+		DLL_IMPORT_OR_EXPORT std::string getStorageDirectory() const;
 
 		/**
 		* Get the name of the epc document.
 		*/
-		std::string getName() const;
+		DLL_IMPORT_OR_EXPORT std::string getName() const;
 
 		/**
 		* Try to resolve in memory all the relationshsips which are serialized into Resqml objects of the EPC document
@@ -604,18 +604,18 @@ namespace COMMON_NS
 		void updateAllRelationships();
 
 #if (defined(_WIN32) && _MSC_VER >= 1600) || defined(__APPLE__)
-		std::unordered_map< std::string, std::string > & getExtendedCoreProperty();
+		DLL_IMPORT_OR_EXPORT std::unordered_map< std::string, std::string > & getExtendedCoreProperty();
 #else
 		std::tr1::unordered_map< std::string, std::string > & getExtendedCoreProperty();
 #endif
 
-		void setExtendedCoreProperty(const std::string & key, const std::string & value);
+		DLL_IMPORT_OR_EXPORT void setExtendedCoreProperty(const std::string & key, const std::string & value);
 
 		/**
 		* Get an extended core property value according its key.
 		* @return An empty string if the extended core property does not exist. Or the extended core property value if it exists
 		*/
-		std::string getExtendedCoreProperty(const std::string & key);
+		DLL_IMPORT_OR_EXPORT std::string getExtendedCoreProperty(const std::string & key);
 
 		/**
 		* Create a partial object in this EpcDocument based on a Data Object Reference
@@ -641,7 +641,7 @@ namespace COMMON_NS
 		//************ HDF *******************
 		//************************************
 
-		virtual COMMON_NS::AbstractHdfProxy* createHdfProxy(const std::string & guid, const std::string & title, const std::string & packageDirAbsolutePath, const std::string & externalFilePath);
+		DLL_IMPORT_OR_EXPORT virtual COMMON_NS::AbstractHdfProxy* createHdfProxy(const std::string & guid, const std::string & title, const std::string & packageDirAbsolutePath, const std::string & externalFilePath);
 
 		//************************************
 		//************ CRS *******************
@@ -661,7 +661,7 @@ namespace COMMON_NS
 		* @param verticalEpsgCode	The epsg code of the associated vertical CRS.
 		* @param isUpOriented		If true, indicates that this depth CRS is actually an elevation CRS.
 		*/
-		RESQML2_0_1_NS::LocalDepth3dCrs* createLocalDepth3dCrs(const std::string & guid, const std::string & title,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::LocalDepth3dCrs* createLocalDepth3dCrs(const std::string & guid, const std::string & title,
 			const double & originOrdinal1, const double & originOrdinal2, const double & originOrdinal3,
 			const double & arealRotation,
 			const gsoap_resqml2_0_1::eml20__LengthUom & projectedUom, const unsigned long & projectedEpsgCode,
@@ -681,7 +681,7 @@ namespace COMMON_NS
 		* @param verticalUnknownReason	Indicates why the vertical CRS cannot be provided using EPSG or GML.
 		* @param isUpOriented			If true, indicates that this depth CRS is actually an elevation CRS.
 		*/
-		RESQML2_0_1_NS::LocalDepth3dCrs* createLocalDepth3dCrs(const std::string & guid, const std::string & title,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::LocalDepth3dCrs* createLocalDepth3dCrs(const std::string & guid, const std::string & title,
 			const double & originOrdinal1, const double & originOrdinal2, const double & originOrdinal3,
 			const double & arealRotation,
 			const gsoap_resqml2_0_1::eml20__LengthUom & projectedUom, const std::string & projectedUnknownReason,
@@ -701,7 +701,7 @@ namespace COMMON_NS
 		* @param verticalUnknownReason	Indicates why the vertical CRS cannot be provided using EPSG or GML.
 		* @param isUpOriented			If true, indicates that this depth CRS is actually an elevation CRS.
 		*/
-		RESQML2_0_1_NS::LocalDepth3dCrs* createLocalDepth3dCrs(const std::string & guid, const std::string & title,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::LocalDepth3dCrs* createLocalDepth3dCrs(const std::string & guid, const std::string & title,
 			const double & originOrdinal1, const double & originOrdinal2, const double & originOrdinal3,
 			const double & arealRotation,
 			const gsoap_resqml2_0_1::eml20__LengthUom & projectedUom, const unsigned long & projectedEpsgCode,
@@ -721,7 +721,7 @@ namespace COMMON_NS
 		* @param verticalEpsgCode		The epsg code of the associated vertical CRS.
 		* @param isUpOriented			If true, indicates that this depth CRS is actually an elevation CRS.
 		*/
-		RESQML2_0_1_NS::LocalDepth3dCrs* createLocalDepth3dCrs(const std::string & guid, const std::string & title,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::LocalDepth3dCrs* createLocalDepth3dCrs(const std::string & guid, const std::string & title,
 			const double & originOrdinal1, const double & originOrdinal2, const double & originOrdinal3,
 			const double & arealRotation,
 			const gsoap_resqml2_0_1::eml20__LengthUom & projectedUom, const std::string & projectedUnknownReason,
@@ -742,7 +742,7 @@ namespace COMMON_NS
 		* @param verticalEpsgCode	The epsg code of the associated vertical CRS.
 		* @param isUpOriented		If true, indicates that the Z offset if an elevation when positive. If false, the Z offset if a depth when positive.
 		*/
-		RESQML2_0_1_NS::LocalTime3dCrs* createLocalTime3dCrs(const std::string & guid, const std::string & title,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::LocalTime3dCrs* createLocalTime3dCrs(const std::string & guid, const std::string & title,
 			const double & originOrdinal1, const double & originOrdinal2, const double & originOrdinal3,
 			const double & arealRotation,
 			const gsoap_resqml2_0_1::eml20__LengthUom & projectedUom, const unsigned long & projectedEpsgCode,
@@ -764,7 +764,7 @@ namespace COMMON_NS
 		* @param verticalUnknownReason	Indicates why the vertical CRS cannot be provided using EPSG or GML.
 		* @param isUpOriented			If true, indicates that the Z offset if an elevation when positive. If false, the Z offset if a depth when positive.
 		*/
-		RESQML2_0_1_NS::LocalTime3dCrs* createLocalTime3dCrs(const std::string & guid, const std::string & title,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::LocalTime3dCrs* createLocalTime3dCrs(const std::string & guid, const std::string & title,
 			const double & originOrdinal1, const double & originOrdinal2, const double & originOrdinal3,
 			const double & arealRotation,
 			const gsoap_resqml2_0_1::eml20__LengthUom & projectedUom, const std::string & projectedUnknownReason,
@@ -786,7 +786,7 @@ namespace COMMON_NS
 		* @param verticalUnknownReason	Indicates why the vertical CRS cannot be provided using EPSG or GML.
 		* @param isUpOriented			If true, indicates that the Z offset if an elevation when positive. If false, the Z offset if a depth when positive.
 		*/
-		RESQML2_0_1_NS::LocalTime3dCrs* createLocalTime3dCrs(const std::string & guid, const std::string & title,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::LocalTime3dCrs* createLocalTime3dCrs(const std::string & guid, const std::string & title,
 			const double & originOrdinal1, const double & originOrdinal2, const double & originOrdinal3,
 			const double & arealRotation,
 			const gsoap_resqml2_0_1::eml20__LengthUom & projectedUom, const unsigned long & projectedEpsgCode,
@@ -808,14 +808,14 @@ namespace COMMON_NS
 		* @param verticalEpsgCode		The epsg code of the associated vertical CRS.
 		* @param isUpOriented			If true, indicates that the Z offset if an elevation when positive. If false, the Z offset if a depth when positive.
 		*/
-		RESQML2_0_1_NS::LocalTime3dCrs* createLocalTime3dCrs(const std::string & guid, const std::string & title,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::LocalTime3dCrs* createLocalTime3dCrs(const std::string & guid, const std::string & title,
 			const double & originOrdinal1, const double & originOrdinal2, const double & originOrdinal3,
 			const double & arealRotation,
 			const gsoap_resqml2_0_1::eml20__LengthUom & projectedUom, const std::string & projectedUnknownReason,
 			const gsoap_resqml2_0_1::eml20__TimeUom & timeUom,
 			const gsoap_resqml2_0_1::eml20__LengthUom & verticalUom, const unsigned int & verticalEpsgCode, const bool & isUpOriented);
 
-		RESQML2_NS::MdDatum* createMdDatum(const std::string & guid, const std::string & title,
+		DLL_IMPORT_OR_EXPORT RESQML2_NS::MdDatum* createMdDatum(const std::string & guid, const std::string & title,
 			RESQML2_NS::AbstractLocal3dCrs * locCrs, const gsoap_resqml2_0_1::resqml2__MdReference & originKind,
 			const double & referenceLocationOrdinal1, const double & referenceLocationOrdinal2, const double & referenceLocationOrdinal3);
 
@@ -823,291 +823,291 @@ namespace COMMON_NS
 		//************ FEATURE ***************
 		//************************************
 
-		RESQML2_0_1_NS::BoundaryFeature* createBoundaryFeature(const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::BoundaryFeature* createBoundaryFeature(const std::string & guid, const std::string & title);
 
-		RESQML2_0_1_NS::Horizon* createHorizon(const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::Horizon* createHorizon(const std::string & guid, const std::string & title);
 
-		RESQML2_0_1_NS::GeneticBoundaryFeature* createGeobodyBoundaryFeature(const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::GeneticBoundaryFeature* createGeobodyBoundaryFeature(const std::string & guid, const std::string & title);
 
-		RESQML2_0_1_NS::GeobodyFeature* createGeobodyFeature(const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::GeobodyFeature* createGeobodyFeature(const std::string & guid, const std::string & title);
 
-		RESQML2_0_1_NS::TectonicBoundaryFeature* createFault(const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::TectonicBoundaryFeature* createFault(const std::string & guid, const std::string & title);
 
-		RESQML2_0_1_NS::TectonicBoundaryFeature* createFracture(const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::TectonicBoundaryFeature* createFracture(const std::string & guid, const std::string & title);
 
-		RESQML2_0_1_NS::WellboreFeature* createWellboreFeature(const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::WellboreFeature* createWellboreFeature(const std::string & guid, const std::string & title);
 
-		RESQML2_0_1_NS::SeismicLatticeFeature* createSeismicLattice(const std::string & guid, const std::string & title,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::SeismicLatticeFeature* createSeismicLattice(const std::string & guid, const std::string & title,
 			const int & inlineIncrement, const int & crosslineIncrement,
 			const unsigned int & originInline, const unsigned int & originCrossline,
 			const unsigned int & inlineCount, const unsigned int & crosslineCount);
 
-		RESQML2_0_1_NS::SeismicLineFeature* createSeismicLine(const std::string & guid, const std::string & title,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::SeismicLineFeature* createSeismicLine(const std::string & guid, const std::string & title,
 			const int & traceIndexIncrement, const unsigned int & firstTraceIndex, const unsigned int & traceCount);
 
-		RESQML2_0_1_NS::SeismicLineSetFeature* createSeismicLineSet(const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::SeismicLineSetFeature* createSeismicLineSet(const std::string & guid, const std::string & title);
 
-		RESQML2_0_1_NS::FrontierFeature* createFrontier(const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::FrontierFeature* createFrontier(const std::string & guid, const std::string & title);
 
-		RESQML2_0_1_NS::StratigraphicUnitFeature* createStratigraphicUnit(const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::StratigraphicUnitFeature* createStratigraphicUnit(const std::string & guid, const std::string & title);
 
-		RESQML2_0_1_NS::OrganizationFeature* createStructuralModel(const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::OrganizationFeature* createStructuralModel(const std::string & guid, const std::string & title);
 
-		RESQML2_0_1_NS::OrganizationFeature* createStratigraphicModel(const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::OrganizationFeature* createStratigraphicModel(const std::string & guid, const std::string & title);
 
-		RESQML2_0_1_NS::OrganizationFeature* createRockFluidModel(const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::OrganizationFeature* createRockFluidModel(const std::string & guid, const std::string & title);
 
-        RESQML2_0_1_NS::OrganizationFeature* createEarthModel(const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::OrganizationFeature* createEarthModel(const std::string & guid, const std::string & title);
 		
-		RESQML2_0_1_NS::FluidBoundaryFeature* createFluidBoundaryFeature(const std::string & guid, const std::string & title, const gsoap_resqml2_0_1::resqml2__FluidContact & fluidContact);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::FluidBoundaryFeature* createFluidBoundaryFeature(const std::string & guid, const std::string & title, const gsoap_resqml2_0_1::resqml2__FluidContact & fluidContact);
 
-		RESQML2_0_1_NS::RockFluidUnitFeature* createRockFluidUnit(const std::string & guid, const std::string & title, gsoap_resqml2_0_1::resqml2__Phase phase, RESQML2_0_1_NS::FluidBoundaryFeature* fluidBoundaryTop, RESQML2_0_1_NS::FluidBoundaryFeature* fluidBoundaryBottom);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::RockFluidUnitFeature* createRockFluidUnit(const std::string & guid, const std::string & title, gsoap_resqml2_0_1::resqml2__Phase phase, RESQML2_0_1_NS::FluidBoundaryFeature* fluidBoundaryTop, RESQML2_0_1_NS::FluidBoundaryFeature* fluidBoundaryBottom);
 
 
 		//************************************
 		//************ INTERPRETATION ********
 		//************************************
 
-		RESQML2_0_1_NS::GenericFeatureInterpretation* createGenericFeatureInterpretation(RESQML2_NS::AbstractFeature * feature, const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::GenericFeatureInterpretation* createGenericFeatureInterpretation(RESQML2_NS::AbstractFeature * feature, const std::string & guid, const std::string & title);
 		
-		RESQML2_0_1_NS::BoundaryFeatureInterpretation* createBoundaryFeatureInterpretation(RESQML2_0_1_NS::BoundaryFeature * feature, const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::BoundaryFeatureInterpretation* createBoundaryFeatureInterpretation(RESQML2_0_1_NS::BoundaryFeature * feature, const std::string & guid, const std::string & title);
 
-		RESQML2_0_1_NS::HorizonInterpretation* createPartialHorizonInterpretation(const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::HorizonInterpretation* createPartialHorizonInterpretation(const std::string & guid, const std::string & title);
 
-		RESQML2_0_1_NS::HorizonInterpretation* createHorizonInterpretation(RESQML2_0_1_NS::Horizon * horizon, const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::HorizonInterpretation* createHorizonInterpretation(RESQML2_0_1_NS::Horizon * horizon, const std::string & guid, const std::string & title);
 
-		RESQML2_0_1_NS::GeobodyBoundaryInterpretation* createGeobodyBoundaryInterpretation(RESQML2_0_1_NS::GeneticBoundaryFeature * geobodyBoundary, const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::GeobodyBoundaryInterpretation* createGeobodyBoundaryInterpretation(RESQML2_0_1_NS::GeneticBoundaryFeature * geobodyBoundary, const std::string & guid, const std::string & title);
 
-		RESQML2_0_1_NS::FaultInterpretation* createFaultInterpretation(RESQML2_0_1_NS::TectonicBoundaryFeature * fault, const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::FaultInterpretation* createFaultInterpretation(RESQML2_0_1_NS::TectonicBoundaryFeature * fault, const std::string & guid, const std::string & title);
 
-		RESQML2_0_1_NS::WellboreInterpretation* createWellboreInterpretation(RESQML2_0_1_NS::WellboreFeature * wellbore, const std::string & guid, const std::string & title, bool isDrilled);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::WellboreInterpretation* createWellboreInterpretation(RESQML2_0_1_NS::WellboreFeature * wellbore, const std::string & guid, const std::string & title, bool isDrilled);
                 
-		RESQML2_0_1_NS::EarthModelInterpretation* createEarthModelInterpretation(RESQML2_0_1_NS::OrganizationFeature * orgFeat, const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::EarthModelInterpretation* createEarthModelInterpretation(RESQML2_0_1_NS::OrganizationFeature * orgFeat, const std::string & guid, const std::string & title);
 		
-		RESQML2_0_1_NS::StructuralOrganizationInterpretation* createStructuralOrganizationInterpretationInAge(RESQML2_0_1_NS::OrganizationFeature * orgFeat, const std::string & guid, const std::string & title);
-		RESQML2_0_1_NS::StructuralOrganizationInterpretation* createStructuralOrganizationInterpretationInApparentDepth(RESQML2_0_1_NS::OrganizationFeature * orgFeat, const std::string & guid, const std::string & title);
-		RESQML2_0_1_NS::StructuralOrganizationInterpretation* createStructuralOrganizationInterpretationInMeasuredDepth(RESQML2_0_1_NS::OrganizationFeature * orgFeat, const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::StructuralOrganizationInterpretation* createStructuralOrganizationInterpretationInAge(RESQML2_0_1_NS::OrganizationFeature * orgFeat, const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::StructuralOrganizationInterpretation* createStructuralOrganizationInterpretationInApparentDepth(RESQML2_0_1_NS::OrganizationFeature * orgFeat, const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::StructuralOrganizationInterpretation* createStructuralOrganizationInterpretationInMeasuredDepth(RESQML2_0_1_NS::OrganizationFeature * orgFeat, const std::string & guid, const std::string & title);
 		
-		RESQML2_0_1_NS::RockFluidOrganizationInterpretation* createRockFluidOrganizationInterpretation(RESQML2_0_1_NS::OrganizationFeature * orgFeat, const std::string & guid, const std::string & title, RESQML2_0_1_NS::RockFluidUnitInterpretation * rockFluidUnitInterp);
-		RESQML2_0_1_NS::RockFluidUnitInterpretation* createRockFluidUnitInterpretation(RESQML2_0_1_NS::RockFluidUnitFeature * rockFluidUnitFeature, const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::RockFluidOrganizationInterpretation* createRockFluidOrganizationInterpretation(RESQML2_0_1_NS::OrganizationFeature * orgFeat, const std::string & guid, const std::string & title, RESQML2_0_1_NS::RockFluidUnitInterpretation * rockFluidUnitInterp);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::RockFluidUnitInterpretation* createRockFluidUnitInterpretation(RESQML2_0_1_NS::RockFluidUnitFeature * rockFluidUnitFeature, const std::string & guid, const std::string & title);
 
-		RESQML2_0_1_NS::GeobodyInterpretation* createGeobodyInterpretation(RESQML2_0_1_NS::GeobodyFeature * geobody, const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::GeobodyInterpretation* createGeobodyInterpretation(RESQML2_0_1_NS::GeobodyFeature * geobody, const std::string & guid, const std::string & title);
 
-		RESQML2_0_1_NS::StratigraphicUnitInterpretation* createStratigraphicUnitInterpretation(RESQML2_0_1_NS::StratigraphicUnitFeature * stratiUnitFeature, const std::string & guid, const std::string & title);
-		RESQML2_0_1_NS::StratigraphicColumn* createStratigraphicColumn(const std::string & guid, const std::string & title);
-		RESQML2_0_1_NS::StratigraphicColumnRankInterpretation* createStratigraphicColumnRankInterpretationInAge(RESQML2_0_1_NS::OrganizationFeature * orgFeat, const std::string & guid, const std::string & title, const unsigned long & rank);
-		RESQML2_0_1_NS::StratigraphicColumnRankInterpretation* createStratigraphicColumnRankInterpretationInApparentDepth(RESQML2_0_1_NS::OrganizationFeature * orgFeat, const std::string & guid, const std::string & title, const unsigned long & rank);
-		RESQML2_0_1_NS::StratigraphicOccurrenceInterpretation* createStratigraphicOccurrenceInterpretationInAge(RESQML2_0_1_NS::OrganizationFeature * orgFeat, const std::string & guid, const std::string & title);
-		RESQML2_0_1_NS::StratigraphicOccurrenceInterpretation* createStratigraphicOccurrenceInterpretationInApparentDepth(RESQML2_0_1_NS::OrganizationFeature * orgFeat, const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::StratigraphicUnitInterpretation* createStratigraphicUnitInterpretation(RESQML2_0_1_NS::StratigraphicUnitFeature * stratiUnitFeature, const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::StratigraphicColumn* createStratigraphicColumn(const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::StratigraphicColumnRankInterpretation* createStratigraphicColumnRankInterpretationInAge(RESQML2_0_1_NS::OrganizationFeature * orgFeat, const std::string & guid, const std::string & title, const unsigned long & rank);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::StratigraphicColumnRankInterpretation* createStratigraphicColumnRankInterpretationInApparentDepth(RESQML2_0_1_NS::OrganizationFeature * orgFeat, const std::string & guid, const std::string & title, const unsigned long & rank);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::StratigraphicOccurrenceInterpretation* createStratigraphicOccurrenceInterpretationInAge(RESQML2_0_1_NS::OrganizationFeature * orgFeat, const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::StratigraphicOccurrenceInterpretation* createStratigraphicOccurrenceInterpretationInApparentDepth(RESQML2_0_1_NS::OrganizationFeature * orgFeat, const std::string & guid, const std::string & title);
 
 		//************************************
 		//************ REPRESENTATION ********
 		//************************************
 
-		RESQML2_0_1_NS::TriangulatedSetRepresentation* createTriangulatedSetRepresentation(RESQML2_NS::AbstractFeatureInterpretation* interp, RESQML2_NS::AbstractLocal3dCrs * crs,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::TriangulatedSetRepresentation* createTriangulatedSetRepresentation(RESQML2_NS::AbstractFeatureInterpretation* interp, RESQML2_NS::AbstractLocal3dCrs * crs,
 			const std::string & guid, const std::string & title);
 
-		RESQML2_0_1_NS::PolylineSetRepresentation* createPolylineSetRepresentation(RESQML2_NS::AbstractLocal3dCrs * crs,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::PolylineSetRepresentation* createPolylineSetRepresentation(RESQML2_NS::AbstractLocal3dCrs * crs,
 			const std::string & guid, const std::string & title);
 
-		RESQML2_0_1_NS::PolylineSetRepresentation* createPolylineSetRepresentation(RESQML2_NS::AbstractFeatureInterpretation* interp, RESQML2_NS::AbstractLocal3dCrs * crs,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::PolylineSetRepresentation* createPolylineSetRepresentation(RESQML2_NS::AbstractFeatureInterpretation* interp, RESQML2_NS::AbstractLocal3dCrs * crs,
 			const std::string & guid, const std::string & title);
 
-		RESQML2_0_1_NS::PolylineSetRepresentation* createPolylineSetRepresentation(RESQML2_NS::AbstractFeatureInterpretation* interp, RESQML2_NS::AbstractLocal3dCrs * crs,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::PolylineSetRepresentation* createPolylineSetRepresentation(RESQML2_NS::AbstractFeatureInterpretation* interp, RESQML2_NS::AbstractLocal3dCrs * crs,
 			const std::string & guid, const std::string & title, const gsoap_resqml2_0_1::resqml2__LineRole & roleKind);
 
-		RESQML2_0_1_NS::PointSetRepresentation* createPointSetRepresentation(RESQML2_NS::AbstractFeatureInterpretation* interp, RESQML2_NS::AbstractLocal3dCrs * crs,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::PointSetRepresentation* createPointSetRepresentation(RESQML2_NS::AbstractFeatureInterpretation* interp, RESQML2_NS::AbstractLocal3dCrs * crs,
 			const std::string & guid, const std::string & title);
 
-		RESQML2_0_1_NS::PlaneSetRepresentation* createPlaneSetRepresentation(RESQML2_NS::AbstractFeatureInterpretation* interp, RESQML2_NS::AbstractLocal3dCrs * crs,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::PlaneSetRepresentation* createPlaneSetRepresentation(RESQML2_NS::AbstractFeatureInterpretation* interp, RESQML2_NS::AbstractLocal3dCrs * crs,
 			const std::string & guid, const std::string & title);
 
-		RESQML2_0_1_NS::PolylineRepresentation* createPolylineRepresentation(RESQML2_NS::AbstractLocal3dCrs * crs,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::PolylineRepresentation* createPolylineRepresentation(RESQML2_NS::AbstractLocal3dCrs * crs,
 			const std::string & guid, const std::string & title, bool isClosed = false);
 
-		RESQML2_0_1_NS::PolylineRepresentation* createPolylineRepresentation(RESQML2_NS::AbstractFeatureInterpretation* interp, RESQML2_NS::AbstractLocal3dCrs * crs,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::PolylineRepresentation* createPolylineRepresentation(RESQML2_NS::AbstractFeatureInterpretation* interp, RESQML2_NS::AbstractLocal3dCrs * crs,
 			const std::string & guid, const std::string & title, bool isClosed = false);
 
-		RESQML2_0_1_NS::PolylineRepresentation* createPolylineRepresentation(RESQML2_NS::AbstractFeatureInterpretation* interp, RESQML2_NS::AbstractLocal3dCrs * crs,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::PolylineRepresentation* createPolylineRepresentation(RESQML2_NS::AbstractFeatureInterpretation* interp, RESQML2_NS::AbstractLocal3dCrs * crs,
 			const std::string & guid, const std::string & title, const gsoap_resqml2_0_1::resqml2__LineRole & roleKind, bool isClosed = false);
 
-		RESQML2_0_1_NS::Grid2dRepresentation* createGrid2dRepresentation(RESQML2_NS::AbstractFeatureInterpretation* interp, RESQML2_NS::AbstractLocal3dCrs * crs,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::Grid2dRepresentation* createGrid2dRepresentation(RESQML2_NS::AbstractFeatureInterpretation* interp, RESQML2_NS::AbstractLocal3dCrs * crs,
 			const std::string & guid, const std::string & title);
 
-		RESQML2_0_1_NS::WellboreTrajectoryRepresentation* createWellboreTrajectoryRepresentation(RESQML2_0_1_NS::WellboreInterpretation* interp, const std::string & guid, const std::string & title, RESQML2_NS::MdDatum * mdInfo);
-		RESQML2_0_1_NS::WellboreTrajectoryRepresentation* createWellboreTrajectoryRepresentation(RESQML2_0_1_NS::WellboreInterpretation* interp, const std::string & guid, const std::string & title, RESQML2_0_1_NS::DeviationSurveyRepresentation* deviationSurvey);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::WellboreTrajectoryRepresentation* createWellboreTrajectoryRepresentation(RESQML2_0_1_NS::WellboreInterpretation* interp, const std::string & guid, const std::string & title, RESQML2_NS::MdDatum * mdInfo);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::WellboreTrajectoryRepresentation* createWellboreTrajectoryRepresentation(RESQML2_0_1_NS::WellboreInterpretation* interp, const std::string & guid, const std::string & title, RESQML2_0_1_NS::DeviationSurveyRepresentation* deviationSurvey);
 
-		RESQML2_0_1_NS::DeviationSurveyRepresentation* createDeviationSurveyRepresentation(RESQML2_0_1_NS::WellboreInterpretation* interp, const std::string & guid, const std::string & title, const bool & isFinal, RESQML2_NS::MdDatum * mdInfo);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::DeviationSurveyRepresentation* createDeviationSurveyRepresentation(RESQML2_0_1_NS::WellboreInterpretation* interp, const std::string & guid, const std::string & title, const bool & isFinal, RESQML2_NS::MdDatum * mdInfo);
 
-		RESQML2_0_1_NS::WellboreFrameRepresentation* createWellboreFrameRepresentation(RESQML2_0_1_NS::WellboreInterpretation* interp, const std::string & guid, const std::string & title, RESQML2_0_1_NS::WellboreTrajectoryRepresentation * traj);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::WellboreFrameRepresentation* createWellboreFrameRepresentation(RESQML2_0_1_NS::WellboreInterpretation* interp, const std::string & guid, const std::string & title, RESQML2_0_1_NS::WellboreTrajectoryRepresentation * traj);
 
-		RESQML2_0_1_NS::WellboreMarkerFrameRepresentation* createWellboreMarkerFrameRepresentation(RESQML2_0_1_NS::WellboreInterpretation* interp, const std::string & guid, const std::string & title, RESQML2_0_1_NS::WellboreTrajectoryRepresentation * traj);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::WellboreMarkerFrameRepresentation* createWellboreMarkerFrameRepresentation(RESQML2_0_1_NS::WellboreInterpretation* interp, const std::string & guid, const std::string & title, RESQML2_0_1_NS::WellboreTrajectoryRepresentation * traj);
 
-		RESQML2_0_1_NS::BlockedWellboreRepresentation* createBlockedWellboreRepresentation(RESQML2_0_1_NS::WellboreInterpretation* interp,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::BlockedWellboreRepresentation* createBlockedWellboreRepresentation(RESQML2_0_1_NS::WellboreInterpretation* interp,
 			const std::string & guid, const std::string & title, RESQML2_0_1_NS::WellboreTrajectoryRepresentation * traj);
 
-		RESQML2_NS::RepresentationSetRepresentation* createRepresentationSetRepresentation(
+		DLL_IMPORT_OR_EXPORT RESQML2_NS::RepresentationSetRepresentation* createRepresentationSetRepresentation(
                 RESQML2_0_1_NS::AbstractOrganizationInterpretation* interp,
                 const std::string & guid,
 				const std::string & title);
 
-		RESQML2_NS::RepresentationSetRepresentation* createRepresentationSetRepresentation(
+		DLL_IMPORT_OR_EXPORT RESQML2_NS::RepresentationSetRepresentation* createRepresentationSetRepresentation(
 			const std::string & guid,
 			const std::string & title);
 
-		RESQML2_NS::RepresentationSetRepresentation* createPartialRepresentationSetRepresentation(const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_NS::RepresentationSetRepresentation* createPartialRepresentationSetRepresentation(const std::string & guid, const std::string & title);
                 
-        RESQML2_0_1_NS::NonSealedSurfaceFrameworkRepresentation* createNonSealedSurfaceFrameworkRepresentation(
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::NonSealedSurfaceFrameworkRepresentation* createNonSealedSurfaceFrameworkRepresentation(
                 RESQML2_0_1_NS::StructuralOrganizationInterpretation* interp, 
                 const std::string & guid, 
                 const std::string & title);
 
-        RESQML2_0_1_NS::SealedSurfaceFrameworkRepresentation* createSealedSurfaceFrameworkRepresentation(
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::SealedSurfaceFrameworkRepresentation* createSealedSurfaceFrameworkRepresentation(
                 RESQML2_0_1_NS::StructuralOrganizationInterpretation* interp,
                 const std::string & guid,
                 const std::string & title);
 
-		RESQML2_0_1_NS::SealedVolumeFrameworkRepresentation* createSealedVolumeFrameworkRepresentation(
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::SealedVolumeFrameworkRepresentation* createSealedVolumeFrameworkRepresentation(
 			RESQML2_0_1_NS::StratigraphicColumnRankInterpretation* interp,
 			const std::string & guid,
 			const std::string & title,
 			RESQML2_0_1_NS::SealedSurfaceFrameworkRepresentation* ssf);
 
-		RESQML2_0_1_NS::AbstractIjkGridRepresentation* createPartialIjkGridRepresentation(const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::AbstractIjkGridRepresentation* createPartialIjkGridRepresentation(const std::string & guid, const std::string & title);
 
-		RESQML2_0_1_NS::AbstractIjkGridRepresentation* createPartialTruncatedIjkGridRepresentation(const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::AbstractIjkGridRepresentation* createPartialTruncatedIjkGridRepresentation(const std::string & guid, const std::string & title);
 
-		RESQML2_0_1_NS::IjkGridExplicitRepresentation* createIjkGridExplicitRepresentation(RESQML2_NS::AbstractLocal3dCrs * crs,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::IjkGridExplicitRepresentation* createIjkGridExplicitRepresentation(RESQML2_NS::AbstractLocal3dCrs * crs,
 			const std::string & guid, const std::string & title,
 			const unsigned int & iCount, const unsigned int & jCount, const unsigned int & kCount);
 
-		RESQML2_0_1_NS::IjkGridExplicitRepresentation* createIjkGridExplicitRepresentation(RESQML2_NS::AbstractFeatureInterpretation* interp, RESQML2_NS::AbstractLocal3dCrs * crs,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::IjkGridExplicitRepresentation* createIjkGridExplicitRepresentation(RESQML2_NS::AbstractFeatureInterpretation* interp, RESQML2_NS::AbstractLocal3dCrs * crs,
 			const std::string & guid, const std::string & title,
 			const unsigned int & iCount, const unsigned int & jCount, const unsigned int & kCount);
 
-		RESQML2_0_1_NS::IjkGridParametricRepresentation* createIjkGridParametricRepresentation(RESQML2_NS::AbstractLocal3dCrs * crs,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::IjkGridParametricRepresentation* createIjkGridParametricRepresentation(RESQML2_NS::AbstractLocal3dCrs * crs,
 			const std::string & guid, const std::string & title,
 			const unsigned int & iCount, const unsigned int & jCount, const unsigned int & kCount);
 
-		RESQML2_0_1_NS::IjkGridParametricRepresentation* createIjkGridParametricRepresentation(RESQML2_NS::AbstractFeatureInterpretation* interp, RESQML2_NS::AbstractLocal3dCrs * crs,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::IjkGridParametricRepresentation* createIjkGridParametricRepresentation(RESQML2_NS::AbstractFeatureInterpretation* interp, RESQML2_NS::AbstractLocal3dCrs * crs,
 			const std::string & guid, const std::string & title,
 			const unsigned int & iCount, const unsigned int & jCount, const unsigned int & kCount);
 
-		RESQML2_0_1_NS::IjkGridLatticeRepresentation* createIjkGridLatticeRepresentation(RESQML2_NS::AbstractLocal3dCrs * crs,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::IjkGridLatticeRepresentation* createIjkGridLatticeRepresentation(RESQML2_NS::AbstractLocal3dCrs * crs,
 			const std::string & guid, const std::string & title,
 			const unsigned int & iCount, const unsigned int & jCount, const unsigned int & kCount);
 
-		RESQML2_0_1_NS::IjkGridLatticeRepresentation* createIjkGridLatticeRepresentation(RESQML2_NS::AbstractFeatureInterpretation* interp, RESQML2_NS::AbstractLocal3dCrs * crs,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::IjkGridLatticeRepresentation* createIjkGridLatticeRepresentation(RESQML2_NS::AbstractFeatureInterpretation* interp, RESQML2_NS::AbstractLocal3dCrs * crs,
 			const std::string & guid, const std::string & title,
 			const unsigned int & iCount, const unsigned int & jCount, const unsigned int & kCount);
 
-		RESQML2_0_1_NS::IjkGridNoGeometryRepresentation* createIjkGridNoGeometryRepresentation(
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::IjkGridNoGeometryRepresentation* createIjkGridNoGeometryRepresentation(
 			const std::string & guid, const std::string & title,
 			const unsigned int & iCount, const unsigned int & jCount, const unsigned int & kCount);
 
-		RESQML2_0_1_NS::IjkGridNoGeometryRepresentation* createIjkGridNoGeometryRepresentation(RESQML2_NS::AbstractFeatureInterpretation* interp,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::IjkGridNoGeometryRepresentation* createIjkGridNoGeometryRepresentation(RESQML2_NS::AbstractFeatureInterpretation* interp,
 			const std::string & guid, const std::string & title,
 			const unsigned int & iCount, const unsigned int & jCount, const unsigned int & kCount);
 
-		RESQML2_0_1_NS::UnstructuredGridRepresentation* createPartialUnstructuredGridRepresentation(const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::UnstructuredGridRepresentation* createPartialUnstructuredGridRepresentation(const std::string & guid, const std::string & title);
 
-		RESQML2_0_1_NS::UnstructuredGridRepresentation* createUnstructuredGridRepresentation(RESQML2_NS::AbstractLocal3dCrs * crs,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::UnstructuredGridRepresentation* createUnstructuredGridRepresentation(RESQML2_NS::AbstractLocal3dCrs * crs,
 			const std::string & guid, const std::string & title,
 			const ULONG64 & cellCount);
 
-		RESQML2_NS::SubRepresentation* createPartialSubRepresentation(const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_NS::SubRepresentation* createPartialSubRepresentation(const std::string & guid, const std::string & title);
 
-		RESQML2_NS::SubRepresentation* createSubRepresentation(
+		DLL_IMPORT_OR_EXPORT RESQML2_NS::SubRepresentation* createSubRepresentation(
                 const std::string & guid, const std::string & title);
 
-		RESQML2_NS::SubRepresentation* createSubRepresentation(RESQML2_NS::AbstractFeatureInterpretation* interp,
+		DLL_IMPORT_OR_EXPORT RESQML2_NS::SubRepresentation* createSubRepresentation(RESQML2_NS::AbstractFeatureInterpretation* interp,
                 const std::string & guid, const std::string & title);
 
-		RESQML2_NS::GridConnectionSetRepresentation* createPartialGridConnectionSetRepresentation(const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_NS::GridConnectionSetRepresentation* createPartialGridConnectionSetRepresentation(const std::string & guid, const std::string & title);
 
-		RESQML2_NS::GridConnectionSetRepresentation* createGridConnectionSetRepresentation(const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_NS::GridConnectionSetRepresentation* createGridConnectionSetRepresentation(const std::string & guid, const std::string & title);
 
-		RESQML2_NS::GridConnectionSetRepresentation* createGridConnectionSetRepresentation(RESQML2_NS::AbstractFeatureInterpretation* interp,
+		DLL_IMPORT_OR_EXPORT RESQML2_NS::GridConnectionSetRepresentation* createGridConnectionSetRepresentation(RESQML2_NS::AbstractFeatureInterpretation* interp,
                 const std::string & guid, const std::string & title);
 
 		//************************************
 		//************* PROPERTIES ***********
 		//************************************
 
-		RESQML2_NS::TimeSeries* createTimeSeries(const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_NS::TimeSeries* createTimeSeries(const std::string & guid, const std::string & title);
 
-		RESQML2_NS::TimeSeries* createPartialTimeSeries(const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_NS::TimeSeries* createPartialTimeSeries(const std::string & guid, const std::string & title);
 
-		RESQML2_0_1_NS::StringTableLookup* createStringTableLookup(const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::StringTableLookup* createStringTableLookup(const std::string & guid, const std::string & title);
 
-		RESQML2_NS::PropertyKind* createPropertyKind(const std::string & guid, const std::string & title,
+		DLL_IMPORT_OR_EXPORT RESQML2_NS::PropertyKind* createPropertyKind(const std::string & guid, const std::string & title,
 			const std::string & namingSystem, const gsoap_resqml2_0_1::resqml2__ResqmlUom & uom, const gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind & parentEnergisticsPropertyKind);
 
-		RESQML2_NS::PropertyKind* createPropertyKind(const std::string & guid, const std::string & title,
+		DLL_IMPORT_OR_EXPORT RESQML2_NS::PropertyKind* createPropertyKind(const std::string & guid, const std::string & title,
 			const std::string & namingSystem, const gsoap_resqml2_0_1::resqml2__ResqmlUom & uom, RESQML2_NS::PropertyKind * parentPropType);
 
-		RESQML2_NS::PropertyKind* createPropertyKind(const std::string & guid, const std::string & title,
+		DLL_IMPORT_OR_EXPORT RESQML2_NS::PropertyKind* createPropertyKind(const std::string & guid, const std::string & title,
 			const std::string & namingSystem, const std::string & nonStandardUom, const gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind & parentEnergisticsPropertyKind);
 
-		RESQML2_NS::PropertyKind* createPropertyKind(const std::string & guid, const std::string & title,
+		DLL_IMPORT_OR_EXPORT RESQML2_NS::PropertyKind* createPropertyKind(const std::string & guid, const std::string & title,
 			const std::string & namingSystem, const std::string & nonStandardUom, RESQML2_NS::PropertyKind * parentPropType);
 
-		RESQML2_NS::PropertyKind* createPartialPropertyKind(const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_NS::PropertyKind* createPartialPropertyKind(const std::string & guid, const std::string & title);
 
-		RESQML2_0_1_NS::CommentProperty* createCommentProperty(RESQML2_NS::AbstractRepresentation * rep, const std::string & guid, const std::string & title,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::CommentProperty* createCommentProperty(RESQML2_NS::AbstractRepresentation * rep, const std::string & guid, const std::string & title,
 			const unsigned int & dimension, const gsoap_resqml2_0_1::resqml2__IndexableElements & attachmentKind, const gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind & energisticsPropertyKind);
 
-		RESQML2_0_1_NS::CommentProperty* createCommentProperty(RESQML2_NS::AbstractRepresentation * rep, const std::string & guid, const std::string & title,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::CommentProperty* createCommentProperty(RESQML2_NS::AbstractRepresentation * rep, const std::string & guid, const std::string & title,
 			const unsigned int & dimension, const gsoap_resqml2_0_1::resqml2__IndexableElements & attachmentKind, RESQML2_NS::PropertyKind * localPropType);
 	
-		RESQML2_0_1_NS::ContinuousProperty* createContinuousProperty(RESQML2_NS::AbstractRepresentation * rep, const std::string & guid, const std::string & title,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::ContinuousProperty* createContinuousProperty(RESQML2_NS::AbstractRepresentation * rep, const std::string & guid, const std::string & title,
 			const unsigned int & dimension, const gsoap_resqml2_0_1::resqml2__IndexableElements & attachmentKind, const gsoap_resqml2_0_1::resqml2__ResqmlUom & uom, const gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind & energisticsPropertyKind);
 
-		RESQML2_0_1_NS::ContinuousProperty* createContinuousProperty(RESQML2_NS::AbstractRepresentation * rep, const std::string & guid, const std::string & title,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::ContinuousProperty* createContinuousProperty(RESQML2_NS::AbstractRepresentation * rep, const std::string & guid, const std::string & title,
 			const unsigned int & dimension, const gsoap_resqml2_0_1::resqml2__IndexableElements & attachmentKind, const gsoap_resqml2_0_1::resqml2__ResqmlUom & uom, RESQML2_NS::PropertyKind * localPropType);
 
-		RESQML2_0_1_NS::ContinuousProperty* createContinuousProperty(RESQML2_NS::AbstractRepresentation * rep, const std::string & guid, const std::string & title,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::ContinuousProperty* createContinuousProperty(RESQML2_NS::AbstractRepresentation * rep, const std::string & guid, const std::string & title,
 			const unsigned int & dimension, const gsoap_resqml2_0_1::resqml2__IndexableElements & attachmentKind, const std::string & nonStandardUom, const gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind & energisticsPropertyKind);
 
-		RESQML2_0_1_NS::ContinuousProperty* createContinuousProperty(RESQML2_NS::AbstractRepresentation * rep, const std::string & guid, const std::string & title,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::ContinuousProperty* createContinuousProperty(RESQML2_NS::AbstractRepresentation * rep, const std::string & guid, const std::string & title,
 			const unsigned int & dimension, const gsoap_resqml2_0_1::resqml2__IndexableElements & attachmentKind, const std::string & nonStandardUom, RESQML2_NS::PropertyKind * localPropType);
 
-		RESQML2_0_1_NS::ContinuousPropertySeries* createContinuousPropertySeries(RESQML2_NS::AbstractRepresentation * rep, const std::string & guid, const std::string & title,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::ContinuousPropertySeries* createContinuousPropertySeries(RESQML2_NS::AbstractRepresentation * rep, const std::string & guid, const std::string & title,
 			const unsigned int & dimension, const gsoap_resqml2_0_1::resqml2__IndexableElements & attachmentKind, const gsoap_resqml2_0_1::resqml2__ResqmlUom & uom, const gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind & energisticsPropertyKind,
 			RESQML2_NS::TimeSeries * ts, const bool & useInterval = false);
 
-		RESQML2_0_1_NS::ContinuousPropertySeries* createContinuousPropertySeries(RESQML2_NS::AbstractRepresentation * rep, const std::string & guid, const std::string & title,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::ContinuousPropertySeries* createContinuousPropertySeries(RESQML2_NS::AbstractRepresentation * rep, const std::string & guid, const std::string & title,
 			const unsigned int & dimension, const gsoap_resqml2_0_1::resqml2__IndexableElements & attachmentKind, const gsoap_resqml2_0_1::resqml2__ResqmlUom & uom, RESQML2_NS::PropertyKind * localPropType,
 			RESQML2_NS::TimeSeries * ts, const bool & useInterval = false);
 	
-		RESQML2_0_1_NS::DiscreteProperty* createDiscreteProperty(RESQML2_NS::AbstractRepresentation * rep, const std::string & guid, const std::string & title,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::DiscreteProperty* createDiscreteProperty(RESQML2_NS::AbstractRepresentation * rep, const std::string & guid, const std::string & title,
 			const unsigned int & dimension, const gsoap_resqml2_0_1::resqml2__IndexableElements & attachmentKind, const gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind & energisticsPropertyKind);
 
-		RESQML2_0_1_NS::DiscreteProperty* createDiscreteProperty(RESQML2_NS::AbstractRepresentation * rep, const std::string & guid, const std::string & title,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::DiscreteProperty* createDiscreteProperty(RESQML2_NS::AbstractRepresentation * rep, const std::string & guid, const std::string & title,
 			const unsigned int & dimension, const gsoap_resqml2_0_1::resqml2__IndexableElements & attachmentKind, RESQML2_NS::PropertyKind * localPropType);
 	
-		RESQML2_0_1_NS::DiscretePropertySeries* createDiscretePropertySeries(RESQML2_NS::AbstractRepresentation * rep, const std::string & guid, const std::string & title,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::DiscretePropertySeries* createDiscretePropertySeries(RESQML2_NS::AbstractRepresentation * rep, const std::string & guid, const std::string & title,
 			const unsigned int & dimension, const gsoap_resqml2_0_1::resqml2__IndexableElements & attachmentKind, const gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind & energisticsPropertyKind,
 			RESQML2_NS::TimeSeries * ts, const bool & useInterval = false);
 
-		RESQML2_0_1_NS::DiscretePropertySeries* createDiscretePropertySeries(RESQML2_NS::AbstractRepresentation * rep, const std::string & guid, const std::string & title,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::DiscretePropertySeries* createDiscretePropertySeries(RESQML2_NS::AbstractRepresentation * rep, const std::string & guid, const std::string & title,
 			const unsigned int & dimension, const gsoap_resqml2_0_1::resqml2__IndexableElements & attachmentKind, RESQML2_NS::PropertyKind * localPropType,
 			RESQML2_NS::TimeSeries * ts, const bool & useInterval = false);
 
-		RESQML2_0_1_NS::CategoricalProperty* createCategoricalProperty(RESQML2_NS::AbstractRepresentation * rep, const std::string & guid, const std::string & title,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::CategoricalProperty* createCategoricalProperty(RESQML2_NS::AbstractRepresentation * rep, const std::string & guid, const std::string & title,
 			const unsigned int & dimension, const gsoap_resqml2_0_1::resqml2__IndexableElements & attachmentKind,
 			RESQML2_0_1_NS::StringTableLookup* strLookup, const gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind & energisticsPropertyKind);
 	
-		RESQML2_0_1_NS::CategoricalProperty* createCategoricalProperty(RESQML2_NS::AbstractRepresentation * rep, const std::string & guid, const std::string & title,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::CategoricalProperty* createCategoricalProperty(RESQML2_NS::AbstractRepresentation * rep, const std::string & guid, const std::string & title,
 			const unsigned int & dimension, const gsoap_resqml2_0_1::resqml2__IndexableElements & attachmentKind,
 			RESQML2_0_1_NS::StringTableLookup* strLookup, RESQML2_NS::PropertyKind * localPropType);
 
-		RESQML2_0_1_NS::CategoricalPropertySeries* createCategoricalPropertySeries(RESQML2_NS::AbstractRepresentation * rep, const std::string & guid, const std::string & title,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::CategoricalPropertySeries* createCategoricalPropertySeries(RESQML2_NS::AbstractRepresentation * rep, const std::string & guid, const std::string & title,
 			const unsigned int & dimension, const gsoap_resqml2_0_1::resqml2__IndexableElements & attachmentKind,
 			RESQML2_0_1_NS::StringTableLookup* strLookup, const gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind & energisticsPropertyKind,
 			RESQML2_NS::TimeSeries * ts, const bool & useInterval = false);
 
-		RESQML2_0_1_NS::CategoricalPropertySeries* createCategoricalPropertySeries(RESQML2_NS::AbstractRepresentation * rep, const std::string & guid, const std::string & title,
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::CategoricalPropertySeries* createCategoricalPropertySeries(RESQML2_NS::AbstractRepresentation * rep, const std::string & guid, const std::string & title,
 			const unsigned int & dimension, const gsoap_resqml2_0_1::resqml2__IndexableElements & attachmentKind,
 			RESQML2_0_1_NS::StringTableLookup* strLookup, RESQML2_NS::PropertyKind * localPropType,
 			RESQML2_NS::TimeSeries * ts, const bool & useInterval = false);
@@ -1116,33 +1116,33 @@ namespace COMMON_NS
 		//************* ACTIVITIES ***********
 		//************************************
 
-		RESQML2_NS::ActivityTemplate* createActivityTemplate(const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_NS::ActivityTemplate* createActivityTemplate(const std::string & guid, const std::string & title);
 		
-		RESQML2_NS::Activity* createActivity(RESQML2_NS::ActivityTemplate* activityTemplate, const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT RESQML2_NS::Activity* createActivity(RESQML2_NS::ActivityTemplate* activityTemplate, const std::string & guid, const std::string & title);
 		
 		//************************************
 		//*************** WITSML *************
 		//************************************
 		
-		WITSML2_0_NS::Well* createWell(const std::string & guid,
+		DLL_IMPORT_OR_EXPORT WITSML2_0_NS::Well* createWell(const std::string & guid,
 			const std::string & title);
 
-		WITSML2_0_NS::Well* createWell(const std::string & guid,
+		DLL_IMPORT_OR_EXPORT WITSML2_0_NS::Well* createWell(const std::string & guid,
 			const std::string & title,
 			const std::string & operator_,
 			gsoap_eml2_1::eml21__WellStatus statusWell,
 			gsoap_eml2_1::witsml2__WellDirection directionWell
 		);
 
-		WITSML2_0_NS::Wellbore* createPartialWellbore(
+		DLL_IMPORT_OR_EXPORT WITSML2_0_NS::Wellbore* createPartialWellbore(
 			const std::string & guid,
 			const std::string & title);
 
-		WITSML2_0_NS::Wellbore* createWellbore(WITSML2_0_NS::Well* witsmlWell,
+		DLL_IMPORT_OR_EXPORT WITSML2_0_NS::Wellbore* createWellbore(WITSML2_0_NS::Well* witsmlWell,
 			const std::string & guid,
 			const std::string & title);
 
-		WITSML2_0_NS::Wellbore* createWellbore(WITSML2_0_NS::Well* witsmlWell,
+		DLL_IMPORT_OR_EXPORT WITSML2_0_NS::Wellbore* createWellbore(WITSML2_0_NS::Well* witsmlWell,
 			const std::string & guid,
 			const std::string & title,
 			gsoap_eml2_1::eml21__WellStatus statusWellbore,
@@ -1150,17 +1150,17 @@ namespace COMMON_NS
 			bool achievedTD
 		);
 
-		WITSML2_0_NS::WellCompletion* createWellCompletion(WITSML2_0_NS::Well* witsmlWell,
+		DLL_IMPORT_OR_EXPORT WITSML2_0_NS::WellCompletion* createWellCompletion(WITSML2_0_NS::Well* witsmlWell,
 			const std::string & guid,
 			const std::string & title);
 
-		WITSML2_0_NS::WellboreCompletion* createWellboreCompletion(WITSML2_0_NS::Wellbore* witsmlWellbore,
+		DLL_IMPORT_OR_EXPORT WITSML2_0_NS::WellboreCompletion* createWellboreCompletion(WITSML2_0_NS::Wellbore* witsmlWellbore,
 			WITSML2_0_NS::WellCompletion* wellCompletion,
 			const std::string & guid,
 			const std::string & title,
 			const std::string & wellCompletionName);
 
-		WITSML2_0_NS::Trajectory* createTrajectory(WITSML2_0_NS::Wellbore* witsmlWellbore,
+		DLL_IMPORT_OR_EXPORT WITSML2_0_NS::Trajectory* createTrajectory(WITSML2_0_NS::Wellbore* witsmlWellbore,
 			const std::string & guid,
 			const std::string & title,
 			gsoap_eml2_1::witsml2__ChannelStatus channelStatus);
@@ -1169,8 +1169,8 @@ namespace COMMON_NS
 		//************* WARNINGS *************
 		//************************************
 
-		void addWarning(const std::string & warning);
-		const std::vector<std::string> & getWarnings() const;
+		DLL_IMPORT_OR_EXPORT void addWarning(const std::string & warning);
+		DLL_IMPORT_OR_EXPORT const std::vector<std::string> & getWarnings() const;
 
 	protected:
 		/**
@@ -1255,6 +1255,3 @@ namespace COMMON_NS
 		HdfProxyBuilderFromGsoapProxy2_0_1* make_hdf_proxy_from_gsoap_proxy_2_0_1; /// the builder for a v2.0.1 HDF proxy in reading mode of the epc document
 	};
 }
-
-
-

--- a/src/common/EpcExternalPartReference.h
+++ b/src/common/EpcExternalPartReference.h
@@ -27,7 +27,7 @@ namespace RESQML2_NS{
 
 namespace COMMON_NS
 {
-	class DLL_IMPORT_OR_EXPORT EpcExternalPartReference : public COMMON_NS::AbstractObject
+	class EpcExternalPartReference : public COMMON_NS::AbstractObject
 	{
 	public:
 		/**
@@ -56,10 +56,10 @@ namespace COMMON_NS
 		/**
 		* Get the relative path regarding packageDirectoryAbsolutePath where the external resource is located.
 		*/
-		std::string getRelativePath() const { return relativeFilePath; }
+		DLL_IMPORT_OR_EXPORT std::string getRelativePath() const { return relativeFilePath; }
 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const;
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const;
 
 	protected:
 

--- a/src/common/HdfProxy.h
+++ b/src/common/HdfProxy.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace COMMON_NS
 {
-	class DLL_IMPORT_OR_EXPORT HdfProxy : public AbstractHdfProxy
+	class HdfProxy : public AbstractHdfProxy
 	{
 	protected:
 
@@ -145,7 +145,7 @@ namespace COMMON_NS
 		/**
 		* Check if the Hdf file is open or not
 		*/
-		bool isOpened() const {return hdfFile != -1;}
+		DLL_IMPORT_OR_EXPORT bool isOpened() const {return hdfFile != -1;}
 
 		/**
 		* Close the file
@@ -201,7 +201,7 @@ namespace COMMON_NS
 		* Set the new compression level which will be used for all data to be written
 		* @param compressionLevel				Lower compression levels are faster but result in less compression. Range [0..9] is allowed.
 		*/
-		void setCompressionLevel(const unsigned int & newCompressionLevel) {if (newCompressionLevel > 9) compressionLevel = 9; else compressionLevel = newCompressionLevel;}
+		DLL_IMPORT_OR_EXPORT void setCompressionLevel(const unsigned int & newCompressionLevel) {if (newCompressionLevel > 9) compressionLevel = 9; else compressionLevel = newCompressionLevel;}
 
 		void writeArrayNdOfFloatValues(const std::string & groupName,
 			const std::string & name,
@@ -601,4 +601,3 @@ namespace COMMON_NS
 		unsigned int compressionLevel;
 	};
 }
-

--- a/src/resqml2/AbstractColumnLayerGridRepresentation.h
+++ b/src/resqml2/AbstractColumnLayerGridRepresentation.h
@@ -27,7 +27,7 @@ namespace RESQML2_0_1_NS
 
 namespace RESQML2_NS
 {
-	class DLL_IMPORT_OR_EXPORT AbstractColumnLayerGridRepresentation : public RESQML2_NS::AbstractGridRepresentation
+	class AbstractColumnLayerGridRepresentation : public RESQML2_NS::AbstractGridRepresentation
 	{
 	protected:
 
@@ -60,17 +60,17 @@ namespace RESQML2_NS
 		/**
 		* Get the K layer count of the grid
 		*/
-		unsigned int getKCellCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getKCellCount() const;
 
 		/**
 		* Set the K layer count of the grid
 		*/
-		void setKCellCount(const unsigned int & kCount);
+		DLL_IMPORT_OR_EXPORT void setKCellCount(const unsigned int & kCount);
 
 		/**
 		* Get the K direction of the grid.
 		*/
-		virtual gsoap_resqml2_0_1::resqml2__KDirection getKDirection() const = 0;
+		DLL_IMPORT_OR_EXPORT virtual gsoap_resqml2_0_1::resqml2__KDirection getKDirection() const = 0;
 
 		/**
 		* Set the stratigraphic organization interpretation which is associated to this grid representation.
@@ -78,7 +78,7 @@ namespace RESQML2_NS
 		* @param nullValue			The value which is used to tell the association between a grid interval and strati unit is unavailable.
 		* @param stratiOrgInterp	The stratigraphic organization interpretation which is associated to this grid representation.
 		*/
-		void setIntervalAssociationWithStratigraphicOrganizationInterpretation(ULONG64 * stratiUnitIndices, const ULONG64 & nullValue, RESQML2_0_1_NS::AbstractStratigraphicOrganizationInterpretation* stratiOrgInterp);
+		DLL_IMPORT_OR_EXPORT void setIntervalAssociationWithStratigraphicOrganizationInterpretation(ULONG64 * stratiUnitIndices, const ULONG64 & nullValue, RESQML2_0_1_NS::AbstractStratigraphicOrganizationInterpretation* stratiOrgInterp);
 
 		/**
 		* @return	null pointer if no stratigraphic organization interpretation is associated to this grid representation. Otherwise return the data objet reference of the associated stratigraphic organization interpretation.
@@ -88,14 +88,13 @@ namespace RESQML2_NS
 		/**
 		* @return	true if this grid representation has got some association between stratigraphic unit indices and interval. Intervals = layers + K gaps.
 		*/
-		bool hasIntervalStratigraphicUnitIndices() const;
+		DLL_IMPORT_OR_EXPORT bool hasIntervalStratigraphicUnitIndices() const;
 
 		/**
 		* Get the stratigraphic unit indices (regarding the associated stratigraphic organization interpretation) of each interval of this grid representation.
 		* @param stratiUnitIndices	This array must be allocated with a count equal to the count of interval in this grid. It will be filled in with the stratigraphic unit indices ordered as grid intervals are ordered.
 		* @return					The null value is returned. The null value is used to tell the association between a grid interval and strati unit is unavailable.
 		*/
-		ULONG64 getIntervalStratigraphicUnitIndices(ULONG64 * stratiUnitIndices);
+		DLL_IMPORT_OR_EXPORT ULONG64 getIntervalStratigraphicUnitIndices(ULONG64 * stratiUnitIndices);
 	};
 }
-

--- a/src/resqml2/AbstractFeature.h
+++ b/src/resqml2/AbstractFeature.h
@@ -24,7 +24,7 @@ under the License.
 
 namespace RESQML2_NS
 {
-	class DLL_IMPORT_OR_EXPORT AbstractFeature : public COMMON_NS::AbstractObject
+	class AbstractFeature : public COMMON_NS::AbstractObject
 	{
 	public:
 
@@ -53,17 +53,17 @@ namespace RESQML2_NS
 		/**
 		* Get all the interpretations of this feature
 		*/
-		std::vector<AbstractFeatureInterpretation*> 	getInterpretationSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<AbstractFeatureInterpretation*> 	getInterpretationSet() const;
 
 		/**
 		 * Get the interpretation count of this feature.
 		 */
-		unsigned int 								getInterpretationCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int 								getInterpretationCount() const;
 
 		/**
 		 * Get a particular interpretation of this feature according to its position in the interpretation ordering.
 		 */
-		AbstractFeatureInterpretation*				getInterpretation(const unsigned int & index) const;
+		DLL_IMPORT_OR_EXPORT AbstractFeatureInterpretation*				getInterpretation(const unsigned int & index) const;
 
 	protected:
 
@@ -75,4 +75,3 @@ namespace RESQML2_NS
 		friend void AbstractFeatureInterpretation::setInterpretedFeature(RESQML2_NS::AbstractFeature * feature);
 	};
 }
-

--- a/src/resqml2/AbstractFeatureInterpretation.h
+++ b/src/resqml2/AbstractFeatureInterpretation.h
@@ -27,7 +27,7 @@ namespace RESQML2_0_1_NS
 
 namespace RESQML2_NS
 {
-	class DLL_IMPORT_OR_EXPORT AbstractFeatureInterpretation : public COMMON_NS::AbstractObject
+	class AbstractFeatureInterpretation : public COMMON_NS::AbstractObject
 	{
 	protected:
 
@@ -61,48 +61,48 @@ namespace RESQML2_NS
 		*/
 		gsoap_resqml2_0_1::eml20__DataObjectReference* getInterpretedFeatureDor() const;
 
-		std::string getInterpretedFeatureUuid() const;
+		DLL_IMPORT_OR_EXPORT std::string getInterpretedFeatureUuid() const;
 
 		/**
 		 * Set the feature which is interpreted by the current instance.
 		 */
-		void setInterpretedFeature(AbstractFeature* feature);
+		DLL_IMPORT_OR_EXPORT void setInterpretedFeature(AbstractFeature* feature);
 
 		/**
 		* Get the feature this instance interprets
 		*/
-		AbstractFeature* getInterpretedFeature() const;
+		DLL_IMPORT_OR_EXPORT AbstractFeature* getInterpretedFeature() const;
 
 		/**
 		* Init the domain of the interpretation based on its representations
 		* @param	defaultDomain	The default domain to set when there is no representation set to this interpretation
 		*/
-		const gsoap_resqml2_0_1::resqml2__Domain & initDomain(const gsoap_resqml2_0_1::resqml2__Domain & defaultDomain) const;
+		DLL_IMPORT_OR_EXPORT const gsoap_resqml2_0_1::resqml2__Domain & initDomain(const gsoap_resqml2_0_1::resqml2__Domain & defaultDomain) const;
 
 		/**
 		* Set the domain of the interpretation
 		*/
-		gsoap_resqml2_0_1::resqml2__Domain getDomain() const;
+		DLL_IMPORT_OR_EXPORT gsoap_resqml2_0_1::resqml2__Domain getDomain() const;
 
 		/**
 		* Get all the representations of this interpretation
 		*/
-		std::vector<AbstractRepresentation*> getRepresentationSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<AbstractRepresentation*> getRepresentationSet() const;
 
 		/**
 		 * Get the interpretation count of this feature.
 		 */
-		unsigned int 						getRepresentationCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int 						getRepresentationCount() const;
 
 		/**
 		 * Get a particular interpretation of this feature according to its position in the interpretation ordering.
 		 */
-		AbstractRepresentation*				getRepresentation(const unsigned int & index) const;
+		DLL_IMPORT_OR_EXPORT AbstractRepresentation*				getRepresentation(const unsigned int & index) const;
 
 		/**
 		* Get all the Grid Connection Set Representation which reference this interpretation.
 		*/
-		std::vector<GridConnectionSetRepresentation *>	getGridConnectionSetRepresentationSet();
+		DLL_IMPORT_OR_EXPORT std::vector<GridConnectionSetRepresentation *>	getGridConnectionSetRepresentationSet();
 
 		/**
 		* Indicates that this interpretation is a frontier of a stack of an organization

--- a/src/resqml2/AbstractGridRepresentation.h
+++ b/src/resqml2/AbstractGridRepresentation.h
@@ -29,7 +29,7 @@ namespace RESQML2_0_1_NS
 
 namespace RESQML2_NS
 {
-	class DLL_IMPORT_OR_EXPORT AbstractGridRepresentation : public AbstractRepresentation
+	class AbstractGridRepresentation : public AbstractRepresentation
 	{
 	private:
 
@@ -75,7 +75,7 @@ namespace RESQML2_NS
 		/**
 		* Get the count of (volumic) cells in the grid.
 		*/
-		virtual ULONG64 getCellCount() const = 0;
+		DLL_IMPORT_OR_EXPORT virtual ULONG64 getCellCount() const = 0;
 
 		//************************************************************
 		//****************** GRID CONNECTION SET *********************
@@ -84,19 +84,19 @@ namespace RESQML2_NS
 		/**
 		* Get the vector of all grid connection set rep asociated to this grid instance.
 		*/
-		std::vector<RESQML2_NS::GridConnectionSetRepresentation*> getGridConnectionSetRepresentationSet() const {return gridConnectionSetRepresentationSet;}
+		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_NS::GridConnectionSetRepresentation*> getGridConnectionSetRepresentationSet() const {return gridConnectionSetRepresentationSet;}
 
 		/**
 		 * Get the GridConnectionSetRepresentation count into this EPC document which are associated to this grid.
 		 * It is mainly used in SWIG context for parsing the vector from a non C++ language.
 		 */
-		unsigned int getGridConnectionSetRepresentationCount() const {return static_cast<unsigned int>(gridConnectionSetRepresentationSet.size());}
+		DLL_IMPORT_OR_EXPORT unsigned int getGridConnectionSetRepresentationCount() const {return static_cast<unsigned int>(gridConnectionSetRepresentationSet.size());}
 
 		/**
 		 * Get a particular ijk parametric grid according to its position in the EPC document.
 		 * It is mainly used in SWIG context for parsing the vector from a non C++ language.
 		 */
-		RESQML2_NS::GridConnectionSetRepresentation* getGridConnectionSetRepresentation(const unsigned int & index) const;
+		DLL_IMPORT_OR_EXPORT RESQML2_NS::GridConnectionSetRepresentation* getGridConnectionSetRepresentation(const unsigned int & index) const;
 
 
 		//************************************************************
@@ -107,7 +107,7 @@ namespace RESQML2_NS
 		* Get the parent grid of this grid.
 		* @return	nullptr if the grid is not a child grid (not a LGR)
 		*/
-		AbstractGridRepresentation* getParentGrid() const;
+		DLL_IMPORT_OR_EXPORT AbstractGridRepresentation* getParentGrid() const;
 
 		/**
 		* Get the parent grid dor of this grid.
@@ -119,22 +119,22 @@ namespace RESQML2_NS
 		* Get the parent grid uuid of this grid.
 		* @return	empty string if the grid is not a child grid (not a LGR)
 		*/
-		std::string getParentGridUuid() const;
+		DLL_IMPORT_OR_EXPORT std::string getParentGridUuid() const;
 
 		/**
 		* Return the count of child grid in this grid.
 		*/
-		unsigned int getChildGridCount() const {return static_cast<unsigned int>(childGridSet.size());}
+		DLL_IMPORT_OR_EXPORT unsigned int getChildGridCount() const {return static_cast<unsigned int>(childGridSet.size());}
 
 		/**
 		* Return the count of child grid in this grid.
 		*/
-		AbstractGridRepresentation* getChildGrid(const unsigned int & index) const {return childGridSet[index];}
+		DLL_IMPORT_OR_EXPORT AbstractGridRepresentation* getChildGrid(const unsigned int & index) const {return childGridSet[index];}
 
 		/**
 		* Indicates that this grid takes place into another unstructured parent grid.
 		*/
-		void setParentWindow(ULONG64 * cellIndices, const ULONG64 & cellIndexCount, RESQML2_0_1_NS::UnstructuredGridRepresentation* parentGrid);
+		DLL_IMPORT_OR_EXPORT void setParentWindow(ULONG64 * cellIndices, const ULONG64 & cellIndexCount, RESQML2_0_1_NS::UnstructuredGridRepresentation* parentGrid);
 
 		/**
 		* Indicates that this grid takes place into another Column Layer parent grid.
@@ -147,7 +147,7 @@ namespace RESQML2_NS
 		* @param	parentGrid					The parent grid which is regridded.
 		* @param	childCellWeights			The weights that are proportional to the relative sizes of child cells within each interval. The weights need not to be normalized. The count of double values must be equal to the count of all child cells per column (sum of child cells per interval).
 		*/
-		void setParentWindow(unsigned int * columnIndices, const unsigned int & columnIndexCount,
+		DLL_IMPORT_OR_EXPORT void setParentWindow(unsigned int * columnIndices, const unsigned int & columnIndexCount,
 			const unsigned int & kLayerIndexRegridStart,
 			unsigned int * childCellCountPerInterval, unsigned int * parentCellCountPerInterval,  const unsigned int & intervalCount,
 			class AbstractColumnLayerGridRepresentation* parentGrid, double * childCellWeights = nullptr);
@@ -171,7 +171,7 @@ namespace RESQML2_NS
 		* @param	jChildCellWeights			The weights that are proportional to the relative j sizes of child cells within each j interval. The weights need not to be normalized. The count of double values must be equal to the count of all child cells on j dimension (sum of child cells per interval).
 		* @param	kChildCellWeights			The weights that are proportional to the relative k sizes of child cells within each k interval. The weights need not to be normalized. The count of double values must be equal to the count of all child cells on k dimension (sum of child cells per interval).
 		*/
-		void setParentWindow(
+		DLL_IMPORT_OR_EXPORT void setParentWindow(
 			const unsigned int & iCellIndexRegridStart, unsigned int * childCellCountPerIInterval, unsigned int * parentCellCountPerIInterval,  const unsigned int & iIntervalCount,
 			const unsigned int & jCellIndexRegridStart, unsigned int * childCellCountPerJInterval, unsigned int * parentCellCountPerJInterval,  const unsigned int & jIntervalCount,
 			const unsigned int & kCellIndexRegridStart, unsigned int * childCellCountPerKInterval, unsigned int * parentCellCountPerKInterval,  const unsigned int & kIntervalCount,
@@ -196,7 +196,7 @@ namespace RESQML2_NS
 		* @param	jChildCellWeights					The weights that are proportional to the relative j sizes of child cells within each j interval. The weights need not to be normalized. The count of double values must be equal to the count of all child cells on j dimension (sum of child cells per interval).
 		* @param	kChildCellWeights					The weights that are proportional to the relative k sizes of child cells within each k interval. The weights need not to be normalized. The count of double values must be equal to the count of all child cells on k dimension (sum of child cells per interval).
 		*/
-		void setParentWindow(
+		DLL_IMPORT_OR_EXPORT void setParentWindow(
 			const unsigned int & iCellIndexRegridStart, unsigned int constantChildCellCountPerIInterval, unsigned int constantParentCellCountPerIInterval, const unsigned int & iIntervalCount,
 			const unsigned int & jCellIndexRegridStart, unsigned int constantChildCellCountPerJInterval, unsigned int constantParentCellCountPerJInterval, const unsigned int & jIntervalCount,
 			const unsigned int & kCellIndexRegridStart, unsigned int constantChildCellCountPerKInterval, unsigned int constantParentCellCountPerKInterval, const unsigned int & kIntervalCount,
@@ -219,7 +219,7 @@ namespace RESQML2_NS
 		* @param	jChildCellWeights			The weights that are proportional to the relative j sizes of child cells. The weights need not to be normalized. The count of double values must be equal to jChildCellCount.
 		* @param	kChildCellWeights			The weights that are proportional to the relative k sizes of child cells. The weights need not to be normalized. The count of double values must be equal to kChildCellCount.
 		*/
-		void setParentWindow(
+		DLL_IMPORT_OR_EXPORT void setParentWindow(
 			const unsigned int & iCellIndexRegridStart, unsigned int iChildCellCount, unsigned int iParentCellCount,
 			const unsigned int & jCellIndexRegridStart, unsigned int jChildCellCount, unsigned int jParentCellCount,
 			const unsigned int & kCellIndexRegridStart, unsigned int kChildCellCount, unsigned int kParentCellCount,
@@ -229,50 +229,50 @@ namespace RESQML2_NS
 		* When a parent windows has been defined, this method allows to force some parent cells to be noted as non regridded.
 		* It mainly allows non-rectangular local grids to be specified.
 		*/
-		void setForcedNonRegridedParentCell(ULONG64 * cellIndices, const ULONG64 & cellIndexCount);
+		DLL_IMPORT_OR_EXPORT void setForcedNonRegridedParentCell(ULONG64 * cellIndices, const ULONG64 & cellIndexCount);
 
 		/**
 		* Optional cell volume overlap information between the current grid (the child) and the parent grid. Use this data-object when the child grid has an explicitly defined geometry, and these relationships cannot be inferred from the regrid descriptions.
 		*/
-		void setCellOverlap(const ULONG64 & parentChildCellPairCount, ULONG64 * parentChildCellPair,
+		DLL_IMPORT_OR_EXPORT void setCellOverlap(const ULONG64 & parentChildCellPairCount, ULONG64 * parentChildCellPair,
 			const gsoap_resqml2_0_1::eml20__VolumeUom & volumeUom = gsoap_resqml2_0_1::eml20__VolumeUom__m3, double * overlapVolumes = nullptr);
 
 		/**
 		* Only run this method for an unstructured parent grid.
 		* Use regrid information for ijk parent grid or (regrid and columIndexCount) for strict column layer parent grid.
 		*/
-		LONG64 getParentCellIndexCount() const;
+		DLL_IMPORT_OR_EXPORT LONG64 getParentCellIndexCount() const;
 
 		/**
 		* Only run this method for an unstructured parent grid.
 		* @param parentCellIndices	This array must have been preallocated with a size of getParentCellIndexCount().
 		*/
-		void getParentCellIndices(ULONG64 * parentCellIndices) const;
+		DLL_IMPORT_OR_EXPORT void getParentCellIndices(ULONG64 * parentCellIndices) const;
 
 		/**
 		* Only run this method for a strict column layer parent grid.
 		*/
-		LONG64 getParentColumnIndexCount() const;
+		DLL_IMPORT_OR_EXPORT LONG64 getParentColumnIndexCount() const;
 
 		/**
 		* Only run this method for an unstructured parent grid.
 		* @param parentCellIndices	This array must have been preallocated with a size of getParentCellIndexCount().
 		*/
-		void getParentColumnIndices(ULONG64 * parentColumnIndices) const;
+		DLL_IMPORT_OR_EXPORT void getParentColumnIndices(ULONG64 * parentColumnIndices) const;
 
 		/**
 		* Only run this method for an ijk parent grid or a strict column layer parent grid.
 		* Get the first cell index of the regrid on a particular dimension.
 		* @param	dimension	It must be either 'i', 'j' ou 'k' (upper or lower case) for an ijk parent grid. 'k' for a strict column layer parent grid.
 		*/
-		ULONG64 getRegridStartIndexOnParentGrid(const char & dimension) const;
+		DLL_IMPORT_OR_EXPORT ULONG64 getRegridStartIndexOnParentGrid(const char & dimension) const;
 
 		/**
 		* Only run this method for an ijk parent grid or a strict column layer parent grid.
 		* Get the count of intervals which are regridded on a particular dimension
 		* @param	dimension	It must be either 'i', 'j' ou 'k' (upper or lower case) for an ijk parent grid. 'k' for a strict column layer parent grid.
 		*/
-		ULONG64 getRegridIntervalCount(const char & dimension) const;
+		DLL_IMPORT_OR_EXPORT ULONG64 getRegridIntervalCount(const char & dimension) const;
 
 		/**
 		* Check if the cell count per interval is constant against a particular dimension.
@@ -280,7 +280,7 @@ namespace RESQML2_NS
 		* @param	dimension					It must be either 'i', 'j' ou 'k' (upper or lower case) for an ijk parent grid. 'k' for a strict column layer parent grid.
 		* @param	childVsParentCellCount		If true check if the child cell count per interval is constant. If false check if the parent cell count per interval is constant.
 		*/
-		bool isRegridCellCountPerIntervalConstant(const char & dimension, const bool & childVsParentCellCount) const;
+		DLL_IMPORT_OR_EXPORT bool isRegridCellCountPerIntervalConstant(const char & dimension, const bool & childVsParentCellCount) const;
 
 		/*
 		* Get the constant cell count per interval
@@ -288,7 +288,7 @@ namespace RESQML2_NS
 		* @param	dimension					It must be either 'i', 'j' ou 'k' (upper or lower case) for an ijk parent grid. 'k' for a strict column layer parent grid.
 		* @param	childVsParentCellCount		If true return the child cell count per interval. If false return the parent cell count per interval.
 		*/
-		ULONG64 getRegridConstantCellCountPerInterval(const char & dimension, const bool & childVsParentCellCount) const;
+		DLL_IMPORT_OR_EXPORT ULONG64 getRegridConstantCellCountPerInterval(const char & dimension, const bool & childVsParentCellCount) const;
 
 		/**
 		* Only run this method for an ijk parent grid or a strict column layer parent grid.
@@ -296,26 +296,26 @@ namespace RESQML2_NS
 		* @param	childCellCountPerInterval	This array must have been preallocated with a size of getRegridIntervalCount().
 		* @param	childVsParentCellCount		If true return the child cell count per interval. If false return the parent cell count per interval.
 		*/
-		void getRegridCellCountPerInterval(const char & dimension, ULONG64 * childCellCountPerInterval, const bool & childVsParentCellCount) const;
+		DLL_IMPORT_OR_EXPORT void getRegridCellCountPerInterval(const char & dimension, ULONG64 * childCellCountPerInterval, const bool & childVsParentCellCount) const;
 
 		/**
 		* Only run this method for an ijk parent grid or a strict column layer parent grid.
 		* @param	dimension					It must be either 'i', 'j' ou 'k' (upper or lower case) for an ijk parent grid. 'k' for a strict column layer parent grid.
 		*/
-		bool hasRegridChildCellWeights(const char & dimension) const;
+		DLL_IMPORT_OR_EXPORT bool hasRegridChildCellWeights(const char & dimension) const;
 
 		/**
 		* Only run this method for an ijk parent grid or a strict column layer parent grid.
 		* @param	dimension			It must be either 'i', 'j' ou 'k' (upper or lower case) for an ijk parent grid. 'k' for a strict column layer parent grid.
 		* @param	childCellWeights	This array must have been preallocated with a size equal to the sum of ChildCellCountPerInterval.
 		*/
-		void getRegridChildCellWeights(const char & dimension, ULONG64 * childCellWeights) const;
+		DLL_IMPORT_OR_EXPORT void getRegridChildCellWeights(const char & dimension, ULONG64 * childCellWeights) const;
 
 		/**
 		* When a parent windows has been defined, this method checks if some parent cells have been noted to be forced not to be regridded.
 		* It mainly occurs in case of non-rectangular local grids.
 		*/
-		bool hasForcedNonRegridedParentCell() const;
+		DLL_IMPORT_OR_EXPORT bool hasForcedNonRegridedParentCell() const;
 
 		//************************************************************
 		//**************** LINK WITH STRATIGRAPHY ********************
@@ -327,39 +327,39 @@ namespace RESQML2_NS
 		* @param nullValue			The value which is used to tell the association between a cell and strati unit is unavailable.
 		* @param stratiOrgInterp	The stratigraphic organization interpretation which is associated to this grid representation.
 		*/
-		void setCellAssociationWithStratigraphicOrganizationInterpretation(ULONG64 * stratiUnitIndices, const ULONG64 & nullValue, RESQML2_0_1_NS::AbstractStratigraphicOrganizationInterpretation* stratiOrgInterp);
+		DLL_IMPORT_OR_EXPORT void setCellAssociationWithStratigraphicOrganizationInterpretation(ULONG64 * stratiUnitIndices, const ULONG64 & nullValue, RESQML2_0_1_NS::AbstractStratigraphicOrganizationInterpretation* stratiOrgInterp);
 
 		/**
 		* @return	nullptr if no stratigraphic organization interpretation is associated to this grid representation. Otherwise return the associated stratigraphic organization interpretation.
 		*/
-		RESQML2_0_1_NS::AbstractStratigraphicOrganizationInterpretation* getStratigraphicOrganizationInterpretation() const;
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::AbstractStratigraphicOrganizationInterpretation* getStratigraphicOrganizationInterpretation() const;
 
 		/**
 		* @return	null pointer if no stratigraphic organization interpretation is associated to this grid representation. Otherwise return the data objet reference of the associated stratigraphic organization interpretation.
 		*/
-		virtual gsoap_resqml2_0_1::eml20__DataObjectReference* getStratigraphicOrganizationInterpretationDor() const;
+		DLL_IMPORT_OR_EXPORT virtual gsoap_resqml2_0_1::eml20__DataObjectReference* getStratigraphicOrganizationInterpretationDor() const;
 
 		/**
 		* @return	empty string if no stratigraphic organization interpretation is associated to this grid representation. Otherwise return the uuid of the associated stratigraphic organization interpretation.
 		*/
-		std::string getStratigraphicOrganizationInterpretationUuid() const;
+		DLL_IMPORT_OR_EXPORT std::string getStratigraphicOrganizationInterpretationUuid() const;
 
 		/**
 		* @return	empty string if no stratigraphic organization interpretation is associated to this grid representation. Otherwise return the title of the associated stratigraphic organization interpretation.
 		*/
-		std::string getStratigraphicOrganizationInterpretationTitle() const;
+		DLL_IMPORT_OR_EXPORT std::string getStratigraphicOrganizationInterpretationTitle() const;
 		
 		/**
 		* @return	true if this grid representation has got some association between stratigraphic unit indices and cell.
 		*/
-		bool hasCellStratigraphicUnitIndices() const;
+		DLL_IMPORT_OR_EXPORT bool hasCellStratigraphicUnitIndices() const;
 
 		/**
 		* Get the stratigraphic unit indices (regarding the associated stratigraphic organization interpretation) of each cell of this grid representation.
 		* @param stratiUnitIndices	This array must be allocated with a count equal to getCellCount(). It will be filled in with the stratigraphic unit indices ordered as grid cells are ordered.
 		* @return					The null value is returned. The null value is used to tell the association between a cell and strati unit is unavailable.
 		*/
-		ULONG64 getCellStratigraphicUnitIndices(ULONG64 * stratiUnitIndices);
+		DLL_IMPORT_OR_EXPORT ULONG64 getCellStratigraphicUnitIndices(ULONG64 * stratiUnitIndices);
 
 		//************************************************************
 		//**************** LINK WITH ROCKFLUID ********************
@@ -371,39 +371,39 @@ namespace RESQML2_NS
 		* @param nullValue			The value which is used to tell the association between a cell and rockFluid unit is unavailable.
 		* @param rockFluidOrgInterp	The rock fluid organization interpretation which is associated to this grid representation.
 		*/
-		void setCellAssociationWithRockFluidOrganizationInterpretation(ULONG64 * rockFluidUnitIndices, const ULONG64 & nullValue, RESQML2_0_1_NS::RockFluidOrganizationInterpretation* rockFluidOrgInterp);
+		DLL_IMPORT_OR_EXPORT void setCellAssociationWithRockFluidOrganizationInterpretation(ULONG64 * rockFluidUnitIndices, const ULONG64 & nullValue, RESQML2_0_1_NS::RockFluidOrganizationInterpretation* rockFluidOrgInterp);
 
 		/**
 		* @return	nullptr if no rock fluid organization interpretation is associated to this grid representation. Otherwise return the associated rock fluid organization interpretation.
 		*/
-		RESQML2_0_1_NS::RockFluidOrganizationInterpretation* getRockFluidOrganizationInterpretation() const;
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::RockFluidOrganizationInterpretation* getRockFluidOrganizationInterpretation() const;
 
 		/**
 		* @return	null pointer if no rock fluid organization interpretation is associated to this grid representation. Otherwise return the data objet reference of the associated rock fluid organization interpretation.
 		*/
-		virtual gsoap_resqml2_0_1::eml20__DataObjectReference* getRockFluidOrganizationInterpretationDor() const;
+		DLL_IMPORT_OR_EXPORT virtual gsoap_resqml2_0_1::eml20__DataObjectReference* getRockFluidOrganizationInterpretationDor() const;
 
 		/**
 		* @return	empty string if no rock fluid organization interpretation is associated to this grid representation. Otherwise return the uuid of the associated rock fluid organization interpretation.
 		*/
-		std::string getRockFluidOrganizationInterpretationUuid() const;
+		DLL_IMPORT_OR_EXPORT std::string getRockFluidOrganizationInterpretationUuid() const;
 
 		/**
 		* @return	empty string if no rock fluid organization interpretation is associated to this grid representation. Otherwise return the title of the associated rock fluid organization interpretation.
 		*/
-		std::string getRockFluidOrganizationInterpretationTitle() const;
+		DLL_IMPORT_OR_EXPORT std::string getRockFluidOrganizationInterpretationTitle() const;
 		
 		/**
 		* @return	true if this grid representation has got some association between rock fluid unit indices and cell.
 		*/
-		bool hasCellFluidPhaseUnitIndices() const;
+		DLL_IMPORT_OR_EXPORT bool hasCellFluidPhaseUnitIndices() const;
 
 		/**
 		* Get the rock fluid unit indices (regarding the associated rock fluid organization interpretation) of each cell of this grid representation.
 		* @param rockFluidUnitIndices	This array must be allocated with a count equal to getCellCount(). It will be filled in with the rock fluid unit indices ordered as grid cells are ordered.
 		* @return					The null value is returned. The null value is used to tell the association between a cell and rock fluid unit is unavailable.
 		*/
-		ULONG64 getCellFluidPhaseUnitIndices(ULONG64 * rockfluidUnitIndices);
+		DLL_IMPORT_OR_EXPORT ULONG64 getCellFluidPhaseUnitIndices(ULONG64 * rockfluidUnitIndices);
 
 
 		//************************************************************
@@ -413,18 +413,18 @@ namespace RESQML2_NS
 		/**
 		* Indicates wether this grid instance contains truncated pillars or not.
 		*/
-		bool isTruncated() const;
+		DLL_IMPORT_OR_EXPORT bool isTruncated() const;
 
 		/**
 		* Get the truncation face count. It does not include face of truncated cells whch are not truncated.
 		*/
-		ULONG64 getTruncatedFaceCount() const;
+		DLL_IMPORT_OR_EXPORT ULONG64 getTruncatedFaceCount() const;
 
 		/**
 		* Get all the node indices of the truncated faces.
 		* @param nodeIndices 			It must be pre allocated with the last value returned by getCumulativeNodeCountOfTruncatedFaces().
 		*/
-		void getNodeIndicesOfTruncatedFaces(ULONG64 * nodeIndices) const;
+		DLL_IMPORT_OR_EXPORT void getNodeIndicesOfTruncatedFaces(ULONG64 * nodeIndices) const;
 
 		/**
 		* Get the cumulative node count per truncated face. First value is the count of nodes in the first face.
@@ -433,7 +433,7 @@ namespace RESQML2_NS
 		* A single node count should be at least 3.
 		* @param nodeCountPerFace	It must be pre allocated with getTruncatedFaceCount() == last value of getCumulativeTruncatedFaceCountPerTruncatedCell()
 		*/
-		void getCumulativeNodeCountPerTruncatedFace(ULONG64 * nodeCountPerFace) const;
+		DLL_IMPORT_OR_EXPORT void getCumulativeNodeCountPerTruncatedFace(ULONG64 * nodeCountPerFace) const;
 
 		/**
 		* Less efficient than getCumulativeNodeCountPerTruncatedFace.
@@ -441,24 +441,24 @@ namespace RESQML2_NS
 		* Second value is the count of nodes in the second face. etc...
 		* @param nodeCountPerFace	It must be pre allocated with getTruncatedFaceCount() == last value of getCumulativeTruncatedFaceCountPerTruncatedCell()
 		*/
-		void getNodeCountPerTruncatedFace(ULONG64 * nodeCountPerFace) const;
+		DLL_IMPORT_OR_EXPORT void getNodeCountPerTruncatedFace(ULONG64 * nodeCountPerFace) const;
 
 		/**
 		* Get the truncated cell count.
 		*/
-		ULONG64 getTruncatedCellCount() const;
+		DLL_IMPORT_OR_EXPORT ULONG64 getTruncatedCellCount() const;
 
 		/**
 		* Get the the indices of the truncated cells in the non truncated grid.
 		*/
-		void getTruncatedCellIndices(ULONG64* cellIndices) const;
+		DLL_IMPORT_OR_EXPORT void getTruncatedCellIndices(ULONG64* cellIndices) const;
 
 		/**
 		* Get all the truncated face indices of all the truncated cells. It does not get the non truncated face indices of a truncated cell.
 		* Please use getNonTruncatedFaceIndicesOfTruncatedCells(ULONG64 * faceIndices) in addition to this method in order to get the full list of face indices for a truncated cell.
 		* @param faceIndices 			It must be pre allocated with the last value returned by getCumulativeTruncatedFaceCountPerTruncatedCell()
 		*/
-		void getTruncatedFaceIndicesOfTruncatedCells(ULONG64 * faceIndices) const;
+		DLL_IMPORT_OR_EXPORT void getTruncatedFaceIndicesOfTruncatedCells(ULONG64 * faceIndices) const;
 
 		/**
 		* Get the cumulative truncated face count per truncated cell. It does not take into account the non truncated face indices of a truncated cell.
@@ -468,7 +468,7 @@ namespace RESQML2_NS
 		* A single face count should be at least 4.
 		* @param cumulativeFaceCountPerCellIndex	It must be pre allocated with getTruncatedCellCount()
 		*/
-		void getCumulativeTruncatedFaceCountPerTruncatedCell(ULONG64 * cumulativeFaceCountPerCell) const;
+		DLL_IMPORT_OR_EXPORT void getCumulativeTruncatedFaceCountPerTruncatedCell(ULONG64 * cumulativeFaceCountPerCell) const;
 
 		/**
 		* Less efficient than getCumulativeTruncatedFaceCountPerTruncatedCell.
@@ -476,14 +476,14 @@ namespace RESQML2_NS
 		* Second value is the count of faces in the second cell. etc...
 		* @param faceCountPerCell	It must be pre allocated with getTruncatedCellCount()
 		*/
-		void getTruncatedFaceCountPerTruncatedCell(ULONG64 * faceCountPerCell) const;
+		DLL_IMPORT_OR_EXPORT void getTruncatedFaceCountPerTruncatedCell(ULONG64 * faceCountPerCell) const;
 
 		/**
 		* Get all the truncated face indices of all the truncated cells. It does not get the non truncated face indices of a truncated cell.
 		* Please use getNonTruncatedFaceIndicesOfTruncatedCells(ULONG64 * faceIndices) in addition to this method in order to get the full list of face indices for a truncated cell.
 		* @param faceIndices 			It must be pre allocated with the last value returned by getCumulativeTruncatedFaceCountPerTruncatedCell()
 		*/
-		void getNonTruncatedFaceIndicesOfTruncatedCells(ULONG64 * faceIndices) const;
+		DLL_IMPORT_OR_EXPORT void getNonTruncatedFaceIndicesOfTruncatedCells(ULONG64 * faceIndices) const;
 
 		/**
 		* Get the cumulative truncated face count per truncated cell. It does not take into account the non truncated face indices of a truncated cell.
@@ -493,7 +493,7 @@ namespace RESQML2_NS
 		* A single face count should be at least 4.
 		* @param cumulativeFaceCountPerCellIndex	It must be pre allocated with getTruncatedCellCount()
 		*/
-		void getCumulativeNonTruncatedFaceCountPerTruncatedCell(ULONG64 * cumulativeFaceCountPerCell) const;
+		DLL_IMPORT_OR_EXPORT void getCumulativeNonTruncatedFaceCountPerTruncatedCell(ULONG64 * cumulativeFaceCountPerCell) const;
 
 		/**
 		* Less efficient than getCumulativeTruncatedFaceCountPerTruncatedCell.
@@ -501,15 +501,15 @@ namespace RESQML2_NS
 		* Second value is the count of faces in the second cell. etc...
 		* @param faceCountPerCell	It must be pre allocated with getTruncatedCellCount()
 		*/
-		void getNonTruncatedFaceCountPerTruncatedCell(ULONG64 * faceCountPerCell) const;
+		DLL_IMPORT_OR_EXPORT void getNonTruncatedFaceCountPerTruncatedCell(ULONG64 * faceCountPerCell) const;
 
 		/**
 		* Retrieves orientation i.e. if each truncated face is right handed or not
 		* @param cellFaceIsRightHanded	It must be pre allocated with getTruncatedFaceCount()
 		*/
-		void getTruncatedFaceIsRightHanded(unsigned char* cellFaceIsRightHanded) const;
+		DLL_IMPORT_OR_EXPORT void getTruncatedFaceIsRightHanded(unsigned char* cellFaceIsRightHanded) const;
 
-		static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
 
 	protected:
 
@@ -528,4 +528,3 @@ namespace RESQML2_NS
 
 	};
 }
-

--- a/src/resqml2/AbstractProperty.h
+++ b/src/resqml2/AbstractProperty.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_NS
 {
-	class DLL_IMPORT_OR_EXPORT AbstractProperty: public COMMON_NS::AbstractObject
+	class AbstractProperty: public COMMON_NS::AbstractObject
 	{
 	public:
 
@@ -50,7 +50,7 @@ namespace RESQML2_NS
 		/**
 		 * Set the representation which is associated to the current property.
 		 */
-		void setRepresentation(class AbstractRepresentation * rep);
+		DLL_IMPORT_OR_EXPORT void setRepresentation(class AbstractRepresentation * rep);
 
 		/**
 		* @return	null pointer if no representation is associated to this property. Otherwise return the data object reference of the associated representation.
@@ -60,32 +60,32 @@ namespace RESQML2_NS
 		/**
 		* Getter for the representation which supports this instance values.
 		*/
-		class AbstractRepresentation* getRepresentation() const;
+		DLL_IMPORT_OR_EXPORT class AbstractRepresentation* getRepresentation() const;
 
 		/*
 		* Getter for the uuid of the representation which is described by this property
 		*/
-		std::string getRepresentationUuid() const;
+		DLL_IMPORT_OR_EXPORT std::string getRepresentationUuid() const;
 
 		/*
 		* Getter for the title of the representation which is described by this property
 		*/
-		std::string getRepresentationTitle() const;
+		DLL_IMPORT_OR_EXPORT std::string getRepresentationTitle() const;
 
 		/*
 		* Getter for the content type of the representation which is described by this property
 		*/
-		std::string getRepresentationContentType() const;
+		DLL_IMPORT_OR_EXPORT std::string getRepresentationContentType() const;
 
 		/**
 		 * Set the representation which is associated to the current property.
 		 */
-		void setTimeSeries(class TimeSeries * ts);
+		DLL_IMPORT_OR_EXPORT void setTimeSeries(class TimeSeries * ts);
 
 		/**
 		* Getter for the time series which is associated to this property.
 		*/
-		TimeSeries* getTimeSeries() const;
+		DLL_IMPORT_OR_EXPORT TimeSeries* getTimeSeries() const;
 
 		/**
 		* @return	null pointer if no time series is associated to this property. Otherwise return the data object reference of the associated time series.
@@ -95,12 +95,12 @@ namespace RESQML2_NS
 		/*
 		* Getter for the uuid of the time series which is associated to this property.
 		*/
-		std::string getTimeSeriesUuid() const;
+		DLL_IMPORT_OR_EXPORT std::string getTimeSeriesUuid() const;
 
 		/*
 		* Getter for the uuid of the time series which is associated to this property.
 		*/
-		std::string getTimeSeriesTitle() const;
+		DLL_IMPORT_OR_EXPORT std::string getTimeSeriesTitle() const;
 
 		/**
 		* Set the timestamp of this property by means of an index in a time series
@@ -108,39 +108,39 @@ namespace RESQML2_NS
 		* @param[in]	 timeIndex	The index of the timestamp of the property in the time series.
 		* @param[in]	 ts			The time series which contains the timestamp of this property.
 		*/
-		void setTimeIndex(const unsigned int & timeIndex, class TimeSeries * ts);
+		DLL_IMPORT_OR_EXPORT void setTimeIndex(const unsigned int & timeIndex, class TimeSeries * ts);
 
 		/**
 		* Set the timestep of this property
 		*/
-		void setTimeStep(const unsigned int & timeStep);
+		DLL_IMPORT_OR_EXPORT void setTimeStep(const unsigned int & timeStep);
 
 		/**
 		* Get the timestamp of this property
 		* @return maximum value of unsigned int is returned if no timestamp is allowed.
 		*/
-		time_t getTimestamp() const;
+		DLL_IMPORT_OR_EXPORT time_t getTimestamp() const;
 
 		/**
 		* Get the time index of this property in its assocaited time series
 		*/
-		unsigned int getTimeIndex() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getTimeIndex() const;
 
 		/**
 		* Set the Hdf Proxy where the numerical values are stored.
 		*/
-		void setHdfProxy(COMMON_NS::AbstractHdfProxy * proxy);
+		DLL_IMPORT_OR_EXPORT void setHdfProxy(COMMON_NS::AbstractHdfProxy * proxy);
 
 		/**
 		* Getter for the hdf proxy which stores this instance values.
 		*/
-		COMMON_NS::AbstractHdfProxy* getHdfProxy() const;
+		DLL_IMPORT_OR_EXPORT COMMON_NS::AbstractHdfProxy* getHdfProxy() const;
 
 		/*
 		 * Getter for the uuid of the hdf proxy which is used for storing the numerical values of this property.
 		 * An empty string is returned if no hd fproxy is used for storing the numerical values.
 		 */
-		std::string getHdfProxyUuid() const;
+		DLL_IMPORT_OR_EXPORT std::string getHdfProxyUuid() const;
 
 		/**
 		* Getter (in read only mode) of the element count per property value.
@@ -148,17 +148,17 @@ namespace RESQML2_NS
 		* If it is a vectorial one, the it should be more than one.
 		* It is not possible to have some tensor property values (more dimension than a vector).
 		*/
-		unsigned int getElementCountPerValue() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getElementCountPerValue() const;
 
 		/**
-		* Get the kind of elments the property values are attached to.
+		* Get the kind of elements the property values are attached to.
 		*/
-		gsoap_resqml2_0_1::resqml2__IndexableElements getAttachmentKind() const;
+		DLL_IMPORT_OR_EXPORT gsoap_resqml2_0_1::resqml2__IndexableElements getAttachmentKind() const;
 
 		/**
 		* Indicates if the property kind attached to this property is either from the standard catalog of Energistics or from a local property kind.
 		*/
-		bool isAssociatedToOneStandardEnergisticsPropertyKind() const;
+		DLL_IMPORT_OR_EXPORT bool isAssociatedToOneStandardEnergisticsPropertyKind() const;
 
 		//*********************************************
 		//****** PROP KIND ****************************
@@ -167,27 +167,27 @@ namespace RESQML2_NS
 		/**
 		* Get the title of the property kind of this property
 		*/
-		std::string getPropertyKindDescription() const;
+		DLL_IMPORT_OR_EXPORT std::string getPropertyKindDescription() const;
 
 		/**
 		* Get the title of the property kind of this property
 		*/
-		std::string getPropertyKindAsString() const;
+		DLL_IMPORT_OR_EXPORT std::string getPropertyKindAsString() const;
 
 		/**
 		* Get the title of the parent of the property kind.
 		*/
-		std::string getPropertyKindParentAsString() const;
+		DLL_IMPORT_OR_EXPORT std::string getPropertyKindParentAsString() const;
 
 		/**
 		* Getter for the energistics property kind which is associated to this intance.
 		*/
-		gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind getEnergisticsPropertyKind() const;
+		DLL_IMPORT_OR_EXPORT gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind getEnergisticsPropertyKind() const;
 
 		/**
 		* Set the property kind of the property to a local one.
 		*/
-		void setLocalPropertyKind(class PropertyKind* propKind);
+		DLL_IMPORT_OR_EXPORT void setLocalPropertyKind(class PropertyKind* propKind);
 
 		/**
 		* @return	null pointer if no local property kind is associated to this property. Otherwise return the data object reference of the associated local property kind.
@@ -197,18 +197,18 @@ namespace RESQML2_NS
 		/**
 		* Get the uuid of the local property kind which is associated to this property.
 		*/
-		std::string getLocalPropertyKindUuid() const;
+		DLL_IMPORT_OR_EXPORT std::string getLocalPropertyKindUuid() const;
 
 		/**
 		* Get the title of the local property kind which is associated to this property.
 		*/
-		std::string getLocalPropertyKindTitle() const;
+		DLL_IMPORT_OR_EXPORT std::string getLocalPropertyKindTitle() const;
 
 		/**
 		* Getter for the local property kind which is associated to this instance.
 		* If nullptr is returned then it means this instance is associated to an energistics standard property kind.
 		*/
-		class PropertyKind* getLocalPropertyKind() const;
+		DLL_IMPORT_OR_EXPORT class PropertyKind* getLocalPropertyKind() const;
 
 		/**
 		* Check if the associated local property kind is allowed for this property.

--- a/src/resqml2/AbstractRepresentation.h
+++ b/src/resqml2/AbstractRepresentation.h
@@ -24,7 +24,7 @@ under the License.
 
 namespace RESQML2_NS
 {
-	class DLL_IMPORT_OR_EXPORT AbstractRepresentation : public COMMON_NS::AbstractObject
+	class AbstractRepresentation : public COMMON_NS::AbstractObject
 	{
 	protected:
 
@@ -90,7 +90,7 @@ namespace RESQML2_NS
 		/**
 		* Getter (read/write access) for the localCrs
 		*/
-		class AbstractLocal3dCrs* getLocalCrs() const;
+		DLL_IMPORT_OR_EXPORT class AbstractLocal3dCrs* getLocalCrs() const;
 
 		/**
 		* Get the Local 3d CRS dor where the reference point ordinals are given
@@ -100,52 +100,52 @@ namespace RESQML2_NS
 		/**
 		* Get the Local 3d CRS uuid where the reference point ordinals are given
 		*/
-		std::string getLocalCrsUuid() const;
+		DLL_IMPORT_OR_EXPORT std::string getLocalCrsUuid() const;
 
 		/**
 		* Getter (read/write access) for the hdf Proxy
 		*/
-		COMMON_NS::AbstractHdfProxy* getHdfProxy() const;
+		DLL_IMPORT_OR_EXPORT COMMON_NS::AbstractHdfProxy* getHdfProxy() const;
 
 		/*
 		 * Getter for the uuid of the hdf proxy which is used for storing the numerical values of this representation i.e. geometry.
 		 * An empty string is returned if no hdf proxy is used for storing the representation/geometry.
 		 */
-		virtual std::string getHdfProxyUuid() const = 0;
+		DLL_IMPORT_OR_EXPORT virtual std::string getHdfProxyUuid() const = 0;
 
 		/**
 		* Getter (read only) of all the properties which use this representation as support.
 		*/
-		const std::vector<class AbstractProperty*> & getPropertySet() const;
+		DLL_IMPORT_OR_EXPORT const std::vector<class AbstractProperty*> & getPropertySet() const;
 
 		/**
 		* Getter of all the properties values which use this representation as support.
 		*/
-		std::vector<class AbstractValuesProperty*> getValuesPropertySet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<class AbstractValuesProperty*> getValuesPropertySet() const;
 
 		/**
 		* Getter of the count of values properties which use this representation as support.
 		* Necessary for now in SWIG context because I ma not sure if I can always wrap a vector of polymorphic class yet.
 		*/
-		unsigned int getValuesPropertyCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getValuesPropertyCount() const;
 
 		/**
 		* Getter of a particular values property which use this representation as support. It is identified by its index.
 		* Necessary for now in SWIG context because I ma not sure if I can always wrap a vector of polymorphic class yet.
 		* Throw an out of bound exception if the index is superior or equal to the count of values property.
 		*/
-		class AbstractValuesProperty* getValuesProperty(const unsigned int & index) const;
+		DLL_IMPORT_OR_EXPORT class AbstractValuesProperty* getValuesProperty(const unsigned int & index) const;
 
 		/**
 		 * Set the interpretation which is associated to this representation.
 		 * And push back this representation as a representation of the interpreation as well.
 		 */
-		void setInterpretation(class AbstractFeatureInterpretation * interp);
+		DLL_IMPORT_OR_EXPORT void setInterpretation(class AbstractFeatureInterpretation * interp);
 
 		/**
 		* Get the interpretation of this representation
 		*/
-		class AbstractFeatureInterpretation* getInterpretation() const;
+		DLL_IMPORT_OR_EXPORT class AbstractFeatureInterpretation* getInterpretation() const;
 
 		/**
 		* @return	null pointer if no interpretation is associated to this representation. Otherwise return the data object reference of the associated interpretation.
@@ -155,12 +155,12 @@ namespace RESQML2_NS
 		/**
 		* Get the interpretation uuid of this representation
 		*/
-		std::string getInterpretationUuid() const;
+		DLL_IMPORT_OR_EXPORT std::string getInterpretationUuid() const;
 
 		/**
 		* Get the interpretation content type of this representation
 		*/
-		std::string getInterpretationContentType() const;
+		DLL_IMPORT_OR_EXPORT std::string getInterpretationContentType() const;
 
 		/**
 		* DO NOT USE THIS METHOD EXCEPT IF YOU REALLY KNOW WHAT YOU ARE DOING.
@@ -172,116 +172,116 @@ namespace RESQML2_NS
 		/**
 		* Get all the subrepresentations of this instance.
 		*/
-		std::vector<SubRepresentation*> getSubRepresentationSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<SubRepresentation*> getSubRepresentationSet() const;
 
 		/**
 		 * Get the subrepresentation count into this EPC document.
 		 * It is mainly used in SWIG context for parsing the vector from a non C++ language.
 		 */
-		unsigned int getSubRepresentationCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getSubRepresentationCount() const;
 
 		/**
 		 * Get a particular subrepresentation according to its position in the EPC document.
 		 * It is mainly used in SWIG context for parsing the vector from a non C++ language.
 		 */
-		SubRepresentation* getSubRepresentation(const unsigned int & index) const;
+		DLL_IMPORT_OR_EXPORT SubRepresentation* getSubRepresentation(const unsigned int & index) const;
 
 		/**
 		* Get all the subrepresentations of this instance which represent a fault.
 		*/
-		std::vector<SubRepresentation*> getFaultSubRepresentationSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<SubRepresentation*> getFaultSubRepresentationSet() const;
 
 		/**
 		 * Get the subrepresentation count into this EPC document which are representations of a fault.
 		 * It is mainly used in SWIG context for parsing the vector from a non C++ language.
 		 */
-		unsigned int getFaultSubRepresentationCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getFaultSubRepresentationCount() const;
 
 		/**
 		 * Get a particular fault subrepresentation according to its position in the EPC document.
 		 * It is mainly used in SWIG context for parsing the vector from a non C++ language.
 		 */
-		SubRepresentation* getFaultSubRepresentation(const unsigned int & index) const;
+		DLL_IMPORT_OR_EXPORT SubRepresentation* getFaultSubRepresentation(const unsigned int & index) const;
         
 		/**
 		* Get the xyz point count in a given patch.
 		*/
-		virtual ULONG64 getXyzPointCountOfPatch(const unsigned int & patchIndex) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual ULONG64 getXyzPointCountOfPatch(const unsigned int & patchIndex) const = 0;
 
         /**
 		* Get the xyz point count of all patches of this representation.
 		*/
-		ULONG64 getXyzPointCountOfAllPatches() const;
+		DLL_IMPORT_OR_EXPORT ULONG64 getXyzPointCountOfAllPatches() const;
 
 		/**
 		* Get all the XYZ points of a particular patch of this representation.
 		* XYZ points are given in the local CRS.
 		* @param xyzPoints A linearized 2d array where the first (quickest) dimension is coordinate dimension (XYZ) and second dimension is vertex dimension. It must be pre allocated.
 		*/
-		 virtual void getXyzPointsOfPatch(const unsigned int & patchIndex, double * xyzPoints) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual void getXyzPointsOfPatch(const unsigned int & patchIndex, double * xyzPoints) const = 0;
 
 		/**
 		* Get all the XYZ points of a particular patch of this representation.
 		* XYZ points are given in the global CRS.
 		* @param xyzPoints A linearized 2d array where the first (quickest) dimension is coordinate dimension (XYZ) and second dimension is vertex dimension.  It must be pre allocated.
 		*/
-		void getXyzPointsOfPatchInGlobalCrs(const unsigned int & patchIndex, double * xyzPoints) const;
+		DLL_IMPORT_OR_EXPORT void getXyzPointsOfPatchInGlobalCrs(const unsigned int & patchIndex, double * xyzPoints) const;
 
 		/**
 		* Get all the XYZ points of all patches of this individual representation
 		* XYZ points are given in the local CRS.
 		* @param xyzPoints A linearized 2d array where the first (quickest) dimension is coordinate dimension (XYZ) and second dimension is vertex dimension. It must be pre allocated.
 		*/
-		void getXyzPointsOfAllPatches(double * xyzPoints) const;
+		DLL_IMPORT_OR_EXPORT void getXyzPointsOfAllPatches(double * xyzPoints) const;
 
 		/**
 		* Get all the XYZ points of all patches of this individual representation
 		* XYZ points are given in the global CRS.
 		* @param xyzPoints A linearized 2d array where the first (quickest) dimension is coordinate dimension (XYZ) and second dimension is vertex dimension.  It must be pre allocated.
 		*/
-		void getXyzPointsOfAllPatchesInGlobalCrs(double * xyzPoints) const;
+		DLL_IMPORT_OR_EXPORT void getXyzPointsOfAllPatchesInGlobalCrs(double * xyzPoints) const;
 
 		/**
 		* Get the seismic support of a specific patch.
 		* @return nullptr if seismic info have not been provided.
 		*/
-		AbstractRepresentation* getSeismicSupportOfPatch(const unsigned int & patchIndex) const;
+		DLL_IMPORT_OR_EXPORT AbstractRepresentation* getSeismicSupportOfPatch(const unsigned int & patchIndex) const;
 
 		/**
 		* Get all seismic support of the current geoemtry of this representation.
 		* This method does not return the seismic lattice representations which are support of 2D grid representation.
 		*/
-		std::set<AbstractRepresentation*> getAllSeismicSupport() const;
+		DLL_IMPORT_OR_EXPORT std::set<AbstractRepresentation*> getAllSeismicSupport() const;
 
-		virtual unsigned int getPatchCount() const = 0;
+		DLL_IMPORT_OR_EXPORT virtual unsigned int getPatchCount() const = 0;
 
 		/**
 		* Pushes back this representaiton into a representation set
 		* @param repSet	The representation set representation which will contain this representation.
 		* @param xml	If set to true (default), then xml relationships will be updated. If set to no, only memory (and epc) relationships will be updated.
 		*/
-		void pushBackIntoRepresentationSet(class RepresentationSetRepresentation * repSet, bool xml = true);
+		DLL_IMPORT_OR_EXPORT void pushBackIntoRepresentationSet(class RepresentationSetRepresentation * repSet, bool xml = true);
 
 		/**
 		 * Get the count of representation set representations which contain this representation
 		 */
-		ULONG64 getRepresentationSetRepresentationCount() const;
+		DLL_IMPORT_OR_EXPORT ULONG64 getRepresentationSetRepresentationCount() const;
 
 		/**
 		 * Get the parent representation set representations at the specified index of the representation set representation list.
 		 */
-		RepresentationSetRepresentation* getRepresentationSetRepresentation(const ULONG64  & index) const;
+		DLL_IMPORT_OR_EXPORT RepresentationSetRepresentation* getRepresentationSetRepresentation(const ULONG64  & index) const;
 
-		void setHdfProxy(COMMON_NS::AbstractHdfProxy * proxy);
+		DLL_IMPORT_OR_EXPORT void setHdfProxy(COMMON_NS::AbstractHdfProxy * proxy);
 
 		/**
 		* Push back a patch of seismic 3D coordinates info.
 		* The index this patch will be located must be consistent with the index of the geometry patch it is related to.
 		*/
-		void addSeismic3dCoordinatesToPatch(const unsigned int patchIndex, double * inlines, double * crosslines, const unsigned int & pointCount,
+		DLL_IMPORT_OR_EXPORT void addSeismic3dCoordinatesToPatch(const unsigned int patchIndex, double * inlines, double * crosslines, const unsigned int & pointCount,
 			RESQML2_NS::AbstractRepresentation * seismicSupport, COMMON_NS::AbstractHdfProxy * proxy);
 
-		void addSeismic3dCoordinatesToPatch(const unsigned int patchIndex, const double & startInline, const double & incrInline, const unsigned int & countInline,
+		DLL_IMPORT_OR_EXPORT void addSeismic3dCoordinatesToPatch(const unsigned int patchIndex, const double & startInline, const double & incrInline, const unsigned int & countInline,
 			const double & startCrossline, const double & incrCrossline, const unsigned int & countCrossline,
 			RESQML2_NS::AbstractRepresentation * seismicSupport);
 
@@ -292,7 +292,7 @@ namespace RESQML2_NS
 		* @param seismicSupport	The representation of the seismic line.
 		* @param proxy			The hdf proxy where the lineAbscissa are stored.
 		*/
-		void addSeismic2dCoordinatesToPatch(const unsigned int patchIndex, double * lineAbscissa,
+		DLL_IMPORT_OR_EXPORT void addSeismic2dCoordinatesToPatch(const unsigned int patchIndex, double * lineAbscissa,
 			RESQML2_NS::AbstractRepresentation * seismicSupport, COMMON_NS::AbstractHdfProxy * proxy);
 
 		/**
@@ -300,21 +300,21 @@ namespace RESQML2_NS
 		* @param patchIndex		The index of the geometry patch which stores the seismic coordinates
 		* @param values			The array where the abscissa are going to be stored. The count of this array must be equal to getXyzPointCountOfPatch(patchIndex).
 		*/
-		void getSeismicLineAbscissaOfPointsOfPatch(const unsigned int & patchIndex, double* values);
+		DLL_IMPORT_OR_EXPORT void getSeismicLineAbscissaOfPointsOfPatch(const unsigned int & patchIndex, double* values);
 
 		/**
 		* Get all the inline coordinates of the points of a specific patch related to seismic lattice.
 		* @param patchIndex		The index of the geometry patch which stores the seismic coordinates
 		* @param values			The array where the inlines coordinates are going to be stored. The count of this array must be equal to getXyzPointCountOfPatch(patchIndex).
 		*/
-		void getInlinesOfPointsOfPatch(const unsigned int & patchIndex, double * values);
+		DLL_IMPORT_OR_EXPORT void getInlinesOfPointsOfPatch(const unsigned int & patchIndex, double * values);
 
 		/**
 		* Get all the crossline coordinates of the points of a specific patch related to seismic lattice.
 		* @param patchIndex		The index of the geometry patch which stores the seismic coordinates
 		* @param values			The array where the crossline coordinates are going to be stored. The count of this array must be equal to getXyzPointCountOfPatch(patchIndex).
 		*/
-		void getCrosslinesOfPointsOfPatch(const unsigned int & patchIndex, double * values);
+		DLL_IMPORT_OR_EXPORT void getCrosslinesOfPointsOfPatch(const unsigned int & patchIndex, double * values);
 
 		static const char* XML_TAG;
 
@@ -337,6 +337,3 @@ namespace RESQML2_NS
 		friend void AbstractProperty::setRepresentation(AbstractRepresentation * rep);
 	};
 }
-
-
-

--- a/src/resqml2/AbstractValuesProperty.h
+++ b/src/resqml2/AbstractValuesProperty.h
@@ -23,7 +23,7 @@ under the License.
 
 namespace RESQML2_NS
 {
-	class DLL_IMPORT_OR_EXPORT AbstractValuesProperty : public AbstractProperty
+	class AbstractValuesProperty : public AbstractProperty
 	{
 	protected:
 		/**
@@ -71,12 +71,12 @@ namespace RESQML2_NS
 		/**
 		* Get the number of patches in this values property. It should be the same count as the patch count of the associated representation.
 		*/
-		unsigned int getPatchCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getPatchCount() const;
 
 		/**
 		* Get the values datatype in the HDF dataset
 		*/
-		AbstractValuesProperty::hdfDatatypeEnum getValuesHdfDatatype() const;
+		DLL_IMPORT_OR_EXPORT AbstractValuesProperty::hdfDatatypeEnum getValuesHdfDatatype() const;
 
 		/**
 		* Push back a new patch of values for this property where the values have not to be written in the HDF file.
@@ -86,35 +86,35 @@ namespace RESQML2_NS
 		* @param	nullValue			Only relevant for integer hdf5 datasets. Indeed, Resqml (and fesapi) forces null value for floating point to be NaN value.
 		* @return	The name of the hdf5 dataset.
 		*/
-		virtual std::string pushBackRefToExistingDataset(COMMON_NS::AbstractHdfProxy* hdfProxy, const std::string & datasetName = "", LONG64 nullValue = (std::numeric_limits<LONG64>::max)()) = 0;
+		DLL_IMPORT_OR_EXPORT virtual std::string pushBackRefToExistingDataset(COMMON_NS::AbstractHdfProxy* hdfProxy, const std::string & datasetName = "", LONG64 nullValue = (std::numeric_limits<LONG64>::max)()) = 0;
 
 		/**
 		* Get all the values of the instance which are supposed to be long ones.
 		* Not for continuous property values.
 		* @return the null value
 		*/
-		long getLongValuesOfPatch(const unsigned int & patchIndex, long * values);
+		DLL_IMPORT_OR_EXPORT long getLongValuesOfPatch(const unsigned int & patchIndex, long * values);
 
 		/**
 		* Get the null value of the instance which are supposed to be integer ones.
 		* Not for continuous property values.
 		* @return the null value
 		*/
-		LONG64 getNullValueOfPatch(unsigned int patchIndex);
+		DLL_IMPORT_OR_EXPORT LONG64 getNullValueOfPatch(unsigned int patchIndex);
 
 		/**
 		* Get all the values of the instance which are supposed to be unsigned long ones.
 		* Not for continuous property values.
 		* @return the null value
 		*/
-		unsigned long getULongValuesOfPatch(const unsigned int & patchIndex, unsigned long * values);
+		DLL_IMPORT_OR_EXPORT unsigned long getULongValuesOfPatch(const unsigned int & patchIndex, unsigned long * values);
 
 		/**
 		* Get all the values of the instance which are supposed to be int ones.
 		* Not for continuous property values.
 		* @return the null value
 		*/
-		int getIntValuesOfPatch(const unsigned int & patchIndex, int * values);
+		DLL_IMPORT_OR_EXPORT int getIntValuesOfPatch(const unsigned int & patchIndex, int * values);
 
 		/**
 		* Get some of the values of a particular patch of the instance which are supposed to be int ones. This method makes use of HDF5 hyperslabbing.
@@ -125,7 +125,7 @@ namespace RESQML2_NS
 		* @param numArrayDimensions			The number of dimensions of the HDF5 array to read.
 		* @return the null value
 		*/
-		int getIntValuesOfPatch(
+		DLL_IMPORT_OR_EXPORT int getIntValuesOfPatch(
 			const unsigned int& patchIndex,
 			int* values,
 			unsigned long long* numValuesInEachDimension,
@@ -144,7 +144,7 @@ namespace RESQML2_NS
 		* @param offsetInMiddleDim		The offset value to write in the middle dimension (mainly J dimension).
 		* @param offsetInSlowestDim		The offset value to write in the slowest dimension (mainly K dimension).
 		*/
-		void getIntValuesOf3dPatch(
+		DLL_IMPORT_OR_EXPORT void getIntValuesOf3dPatch(
 			const unsigned int& patchIndex,
 			int* values,
 			const unsigned int& valueCountInFastestDim,
@@ -160,40 +160,40 @@ namespace RESQML2_NS
 		* Not for continuous property values.
 		* @return the null value
 		*/
-		unsigned int getUIntValuesOfPatch(const unsigned int & patchIndex, unsigned int * values);
+		DLL_IMPORT_OR_EXPORT unsigned int getUIntValuesOfPatch(const unsigned int & patchIndex, unsigned int * values);
 		
 		/**
 		* Get all the values of the instance which are supposed to be short ones.
 		* Not for continuous property values.
 		* @return the null value
 		*/
-		short getShortValuesOfPatch(const unsigned int & patchIndex, short * values);
+		DLL_IMPORT_OR_EXPORT short getShortValuesOfPatch(const unsigned int & patchIndex, short * values);
 
 		/**
 		* Get all the values of the instance which are supposed to be unsigned short ones.
 		* Not for continuous property values.
 		* @return the null value
 		*/
-		unsigned short getUShortValuesOfPatch(const unsigned int & patchIndex, unsigned short * values);
+		DLL_IMPORT_OR_EXPORT unsigned short getUShortValuesOfPatch(const unsigned int & patchIndex, unsigned short * values);
 
 		/**
 		* Get all the values of the instance which are supposed to be char ones.
 		* Not for continuous property values.
 		* @return the null value
 		*/
-		char getCharValuesOfPatch(const unsigned int & patchIndex, char * values);
+		DLL_IMPORT_OR_EXPORT char getCharValuesOfPatch(const unsigned int & patchIndex, char * values);
 
 		/**
 		* Get all the values of the instance which are supposed to be unsigned char ones.
 		* Not for continuous property values.
 		* @return the null value
 		*/
-		unsigned char getUCharValuesOfPatch(const unsigned int & patchIndex, unsigned char * values);
+		DLL_IMPORT_OR_EXPORT unsigned char getUCharValuesOfPatch(const unsigned int & patchIndex, unsigned char * values);
 
 		/**
 		* Get the count of all values contained into the underlying HDF5 dataset of this property for a particular patch.
 		*/
-		unsigned int getValuesCountOfPatch (const unsigned int & patchIndex);
+		DLL_IMPORT_OR_EXPORT unsigned int getValuesCountOfPatch (const unsigned int & patchIndex);
 
 		/**
 		* Get the count of values on a specific dimension of the underlying HDF5 dataset of this property.
@@ -201,34 +201,34 @@ namespace RESQML2_NS
 		* @param patchIndex	The index of the patch we want to know the values count in this property.
 		* @return			The number of values, 0 otherwise.
 		*/
-		unsigned int getValuesCountOfDimensionOfPatch(const unsigned int & dimIndex, const unsigned int & patchIndex);
+		DLL_IMPORT_OR_EXPORT unsigned int getValuesCountOfDimensionOfPatch(const unsigned int & dimIndex, const unsigned int & patchIndex);
 
 		/**
 		* Get the count of dimension of the underlying HDF5 dataset of this property.
 		* @param patchIndex	The index of the patch we want to know the dimensions in this property.
 		* @return			The number of values, 0 otherwise.
 		*/
-		unsigned int getDimensionsCountOfPatch(const unsigned int & patchIndex);
+		DLL_IMPORT_OR_EXPORT unsigned int getDimensionsCountOfPatch(const unsigned int & patchIndex);
 
 		/**
 		* Pushes back a new facet to this intance
 		*/
-		void pushBackFacet(const gsoap_resqml2_0_1::resqml2__Facet & facet, const std::string & facetValue);
+		DLL_IMPORT_OR_EXPORT void pushBackFacet(const gsoap_resqml2_0_1::resqml2__Facet & facet, const std::string & facetValue);
 
 		/**
 		* Get the count of facet of this instance
 		*/
-		unsigned int getFacetCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getFacetCount() const;
 
 		/**
 		* Get the facet at a particular index of the facet collection of this instance
 		*/
-		gsoap_resqml2_0_1::resqml2__Facet getFacet(const unsigned int & index) const;
+		DLL_IMPORT_OR_EXPORT gsoap_resqml2_0_1::resqml2__Facet getFacet(const unsigned int & index) const;
 
 		/**
 		* Get the facet value at a particular index of the facet collection of this instance.
 		*/
-		std::string getFacetValue(const unsigned int & index) const;
+		DLL_IMPORT_OR_EXPORT std::string getFacetValue(const unsigned int & index) const;
 
 		//***************************
 		//*** For hyperslabbing *****
@@ -240,7 +240,7 @@ namespace RESQML2_NS
 		* @param numArrayDimensions		The number of dimensions of the array to write.
 		* @param proxy					The HDF proxy where to write the property values. It must be already opened for writing and won't be closed in this method.
 		*/
-		void createLongHdf5ArrayOfValues(
+		DLL_IMPORT_OR_EXPORT void createLongHdf5ArrayOfValues(
 			unsigned long long* numValues, 
 			const unsigned int& numArrayDimensions, 
 			COMMON_NS::AbstractHdfProxy* proxy
@@ -253,7 +253,7 @@ namespace RESQML2_NS
 		* @param valueCountInSlowestDim The number of values to write in the slowest dimension (mainly K dimension).
 		* @param proxy					The HDF proxy where to write the property values. It must be already opened for writing and won't be closed in this method.
 		*/
-		void createLongHdf5Array3dOfValues(
+		DLL_IMPORT_OR_EXPORT void createLongHdf5Array3dOfValues(
 			const unsigned int& valueCountInFastestDim, 
 			const unsigned int& valueCountInMiddleDim, 
 			const unsigned int& valueCountInSlowestDim, 
@@ -271,7 +271,7 @@ namespace RESQML2_NS
 		* @param offsetInSlowestDim		The offset value to write in the slowest dimension (mainly K dimension).
 		* @param proxy					The HDF proxy where to write the property values. It must be already opened for writing and won't be closed in this method.
 		*/
-		void pushBackLongHdf5SlabArray3dOfValues(
+		DLL_IMPORT_OR_EXPORT void pushBackLongHdf5SlabArray3dOfValues(
 			long* values, 
 			const unsigned int& valueCountInFastestDim, 
 			const unsigned int& valueCountInMiddleDim, 
@@ -291,7 +291,7 @@ namespace RESQML2_NS
 		* @param numArrayDimensions		The number of dimensions of the array to write.
 		* @param proxy					The HDF proxy where to write the property values. It must be already opened for writing and won't be closed in this method.
 		*/
-		void pushBackLongHdf5SlabArrayOfValues(
+		DLL_IMPORT_OR_EXPORT void pushBackLongHdf5SlabArrayOfValues(
 			long * values, 
 			unsigned long long * numValues,
 			unsigned long long * offsetValues,
@@ -307,7 +307,7 @@ namespace RESQML2_NS
 		* @param offsetValues			The offset values ordered by dimension of the array to write.
 		* @param numArrayDimensions		The number of dimensions of the array to write.
 		*/
-		void getLongValuesOfPatch(
+		DLL_IMPORT_OR_EXPORT void getLongValuesOfPatch(
 			const unsigned int& patchIndex, 
 			long* values, 
 			unsigned long long* numValuesInEachDimension,
@@ -326,7 +326,7 @@ namespace RESQML2_NS
 		* @param offsetInMiddleDim		The offset value to write in the middle dimension (mainly J dimension).
 		* @param offsetInSlowestDim		The offset value to write in the slowest dimension (mainly K dimension).
 		*/
-		void getLongValuesOf3dPatch(
+		DLL_IMPORT_OR_EXPORT void getLongValuesOf3dPatch(
 			const unsigned int& patchIndex, 
 			long* values, 
 			const unsigned int& valueCountInFastestDim, 
@@ -339,4 +339,3 @@ namespace RESQML2_NS
 
 	};
 }
-

--- a/src/resqml2/Activity.h
+++ b/src/resqml2/Activity.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_NS
 {
-	class DLL_IMPORT_OR_EXPORT Activity : public COMMON_NS::AbstractObject
+	class Activity : public COMMON_NS::AbstractObject
 	{
 	protected:
 		Activity() : AbstractObject() {}
@@ -42,14 +42,14 @@ namespace RESQML2_NS
 		* Push back a string parameter in the instance.
 		* This parameter must exist in the associated activity template.
 		*/
-		virtual void pushBackParameter(const std::string title,
+		DLL_IMPORT_OR_EXPORT virtual void pushBackParameter(const std::string title,
 			const std::string & value) = 0;
 
 		/**
 		* Push back an integer parameter in the instance.
 		* This parameter must exist in the associated activity template.
 		*/
-		virtual void pushBackParameter(const std::string title,
+		DLL_IMPORT_OR_EXPORT virtual void pushBackParameter(const std::string title,
 			const LONG64 & value) = 0;
 
 		/**
@@ -62,39 +62,39 @@ namespace RESQML2_NS
 		/**
 		* Get the count of all the parameters
 		*/
-		virtual unsigned int getParameterCount() const = 0;
+		DLL_IMPORT_OR_EXPORT virtual unsigned int getParameterCount() const = 0;
 
 		/**
 		* Get the count of all the parameters which have got the same title.
 		*/
-		virtual unsigned int getParameterCount(const std::string & paramTitle) const = 0;
-		virtual const std::string & getParameterTitle(const unsigned int & index) const = 0;
-		virtual std::vector<unsigned int> getParameterIndexOfTitle(const std::string & paramTitle) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual unsigned int getParameterCount(const std::string & paramTitle) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual const std::string & getParameterTitle(const unsigned int & index) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual std::vector<unsigned int> getParameterIndexOfTitle(const std::string & paramTitle) const = 0;
 
-		virtual bool isAFloatingPointQuantityParameter(const std::string & paramTitle) const = 0;
-		virtual bool isAFloatingPointQuantityParameter(const unsigned int & index) const = 0;
-		virtual std::vector<double> getFloatingPointQuantityParameterValue(const std::string & paramTitle) const = 0;
-		virtual double getFloatingPointQuantityParameterValue(const unsigned int & index) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual bool isAFloatingPointQuantityParameter(const std::string & paramTitle) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual bool isAFloatingPointQuantityParameter(const unsigned int & index) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual std::vector<double> getFloatingPointQuantityParameterValue(const std::string & paramTitle) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual double getFloatingPointQuantityParameterValue(const unsigned int & index) const = 0;
 
-		virtual bool isAnIntegerQuantityParameter(const std::string & paramTitle) const = 0;
-		virtual bool isAnIntegerQuantityParameter(const unsigned int & index) const = 0;
-		virtual std::vector<LONG64> getIntegerQuantityParameterValue(const std::string & paramTitle) const = 0;
-		virtual LONG64 getIntegerQuantityParameterValue(const unsigned int & index) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual bool isAnIntegerQuantityParameter(const std::string & paramTitle) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual bool isAnIntegerQuantityParameter(const unsigned int & index) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual std::vector<LONG64> getIntegerQuantityParameterValue(const std::string & paramTitle) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual LONG64 getIntegerQuantityParameterValue(const unsigned int & index) const = 0;
 
-		virtual bool isAStringParameter(const std::string & paramTitle) const = 0;
-		virtual bool isAStringParameter(const unsigned int & index) const = 0;
-		virtual std::vector<std::string> getStringParameterValue(const std::string & paramTitle) const = 0;
-		virtual const std::string & getStringParameterValue(const unsigned int & index) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual bool isAStringParameter(const std::string & paramTitle) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual bool isAStringParameter(const unsigned int & index) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual std::vector<std::string> getStringParameterValue(const std::string & paramTitle) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual const std::string & getStringParameterValue(const unsigned int & index) const = 0;
 
-		virtual bool isAResqmlObjectParameter(const std::string & paramTitle) const = 0;
-		virtual bool isAResqmlObjectParameter(const unsigned int & index) const = 0;
-		virtual std::vector<AbstractObject*> getResqmlObjectParameterValue(const std::string & paramTitle) const = 0;
-		virtual AbstractObject* getResqmlObjectParameterValue(const unsigned int & index) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual bool isAResqmlObjectParameter(const std::string & paramTitle) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual bool isAResqmlObjectParameter(const unsigned int & index) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual std::vector<AbstractObject*> getResqmlObjectParameterValue(const std::string & paramTitle) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual AbstractObject* getResqmlObjectParameterValue(const unsigned int & index) const = 0;
 
 		/**
 		* Set the activity template of the activity
 		**/
-		virtual void setActivityTemplate(class ActivityTemplate* activityTemplate) = 0;
+		DLL_IMPORT_OR_EXPORT virtual void setActivityTemplate(class ActivityTemplate* activityTemplate) = 0;
 
 		/**
 		* Get the activity template dor of the activity
@@ -104,18 +104,17 @@ namespace RESQML2_NS
 		/**
 		* Get the activity template of the activity
 		**/
-		class ActivityTemplate* getActivityTemplate() const;
+		DLL_IMPORT_OR_EXPORT class ActivityTemplate* getActivityTemplate() const;
 
 		/**
 		* Get all objects which are either input or output of this acitivty
 		**/
-		std::vector<AbstractObject*> getResqmlObjectSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<AbstractObject*> getResqmlObjectSet() const;
 
-		static const char* XML_TAG;
-		std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT std::string getXmlTag() const {return XML_TAG;}
 
 	protected:
-
 		std::vector<epc::Relationship> getAllEpcRelationships() const;
 	};
 }

--- a/src/resqml2/ActivityTemplate.h
+++ b/src/resqml2/ActivityTemplate.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_NS
 {
-	class DLL_IMPORT_OR_EXPORT ActivityTemplate : public COMMON_NS::AbstractObject
+	class ActivityTemplate : public COMMON_NS::AbstractObject
 	{
 	protected:
 		ActivityTemplate() : AbstractObject() {}
@@ -42,7 +42,7 @@ namespace RESQML2_NS
 		* Push back a parameter in the activity template instance.
 		* This parameter has an unconstrained type.
 		*/
-		virtual void pushBackParameter(const std::string title,
+		DLL_IMPORT_OR_EXPORT virtual void pushBackParameter(const std::string title,
 			const bool & isInput, const bool isOutput,
 			const unsigned int & minOccurs, const int & maxOccurs) = 0;
 
@@ -51,7 +51,7 @@ namespace RESQML2_NS
 		* This parameter must be of a data object kind.
 		* @param resqmlObjectContentType	If empty, there is no constraint on the content type of this parameter.
 		*/
-		virtual void pushBackParameter(const std::string title,
+		DLL_IMPORT_OR_EXPORT virtual void pushBackParameter(const std::string title,
 			const bool & isInput, const bool isOutput,
 			const unsigned int & minOccurs, const int & maxOccurs,
 			const std::string & resqmlObjectContentType) = 0;
@@ -60,24 +60,23 @@ namespace RESQML2_NS
 		* Check if the instance contains a parameter with a particular title
 		* @param paramTitle	The title of the parameter we are looking for into the instance
 		*/
-		virtual bool isAnExistingParameter(const std::string & paramTitle) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual bool isAnExistingParameter(const std::string & paramTitle) const = 0;
 
-		virtual unsigned int getParameterCount() const = 0;
-		virtual const std::string & getParameterTitle(const unsigned int & index) const = 0;
-		virtual const bool & getParameterIsInput(const unsigned int & index) const = 0;
-		virtual const bool & getParameterIsInput(const std::string & paramTitle) const = 0;
-		virtual const bool & getParameterIsOutput(const unsigned int & index) const = 0;
-		virtual const bool & getParameterIsOutput(const std::string & paramTitle) const = 0;
-		virtual LONG64 getParameterMinOccurences(const unsigned int & index) const = 0;
-		virtual LONG64 getParameterMinOccurences(const std::string & paramTitle) const = 0;
-		virtual LONG64 getParameterMaxOccurences(const unsigned int & index) const = 0;
-		virtual LONG64 getParameterMaxOccurences(const std::string & paramTitle) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual unsigned int getParameterCount() const = 0;
+		DLL_IMPORT_OR_EXPORT virtual const std::string & getParameterTitle(const unsigned int & index) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual const bool & getParameterIsInput(const unsigned int & index) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual const bool & getParameterIsInput(const std::string & paramTitle) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual const bool & getParameterIsOutput(const unsigned int & index) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual const bool & getParameterIsOutput(const std::string & paramTitle) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual LONG64 getParameterMinOccurences(const unsigned int & index) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual LONG64 getParameterMinOccurences(const std::string & paramTitle) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual LONG64 getParameterMaxOccurences(const unsigned int & index) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual LONG64 getParameterMaxOccurences(const std::string & paramTitle) const = 0;
 
-		const std::vector<Activity*> & getActivityInstanceSet() const { return activityInstanceSet; }
+		DLL_IMPORT_OR_EXPORT const std::vector<Activity*> & getActivityInstanceSet() const { return activityInstanceSet; }
 
-		static const char* XML_TAG;
-		std::string getXmlTag() const {return XML_TAG;}
-
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT std::string getXmlTag() const {return XML_TAG;}
 
 	private:
 		std::vector<epc::Relationship> getAllEpcRelationships() const;

--- a/src/resqml2/GridConnectionSetRepresentation.h
+++ b/src/resqml2/GridConnectionSetRepresentation.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_NS
 {
-	class DLL_IMPORT_OR_EXPORT GridConnectionSetRepresentation : public AbstractRepresentation
+	class GridConnectionSetRepresentation : public AbstractRepresentation
 	{
 	protected:
 
@@ -52,48 +52,48 @@ namespace RESQML2_NS
 		*/
 		virtual ~GridConnectionSetRepresentation() {}
         
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const;
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const;
 
-		virtual std::string getHdfProxyUuid() const = 0;
-
-		/**
-		* Get the cell index pair count of this grid connection representation
-		*/
-		virtual ULONG64 getCellIndexPairCount() const = 0;
+		DLL_IMPORT_OR_EXPORT virtual std::string getHdfProxyUuid() const = 0;
 
 		/**
 		* Get the cell index pair count of this grid connection representation
 		*/
-		virtual ULONG64 getCellIndexPairs(ULONG64 * cellIndexPairs) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual ULONG64 getCellIndexPairCount() const = 0;
+
+		/**
+		* Get the cell index pair count of this grid connection representation
+		*/
+		DLL_IMPORT_OR_EXPORT virtual ULONG64 getCellIndexPairs(ULONG64 * cellIndexPairs) const = 0;
 
 		/**
 		* Get the cell index pairs count which correspond to a particular interpretation.
 		* @param interpretationIndex The index of the interpretation in the collection of feature interpretation of this grid connection set.
 		*/
-		virtual unsigned int getCellIndexPairCountFromInterpretationIndex(unsigned int interpretationIndex) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual unsigned int getCellIndexPairCountFromInterpretationIndex(unsigned int interpretationIndex) const = 0;
 
 		/**
 		* Indicates wether the cell connection are associated to interpretation or not.
 		*/
-		virtual bool isAssociatedToInterpretations() const = 0;
+		DLL_IMPORT_OR_EXPORT virtual bool isAssociatedToInterpretations() const = 0;
 
 		/**
 		* Get the interpretation index cumulative count of this grid connection representation
 		* The count of cumulativeCount must be getCellIndexPairCount().
 		*/
-		virtual void getInterpretationIndexCumulativeCount(unsigned int * cumulativeCount) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual void getInterpretationIndexCumulativeCount(unsigned int * cumulativeCount) const = 0;
 
 		/**
 		* Get the interpretation indices of this grid connection representation
 		* The count of interpretationIndices is the last value of the array returning by getInterpretationIndexCumulativeCount.
 		*/
-		virtual void getInterpretationIndices(unsigned int * interpretationIndices) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual void getInterpretationIndices(unsigned int * interpretationIndices) const = 0;
 
 		/**
 		* Returns the null value for interpretation index.
 		*/
-		virtual LONG64 getInterpretationIndexNullValue() const = 0;
+		DLL_IMPORT_OR_EXPORT virtual LONG64 getInterpretationIndexNullValue() const = 0;
 
 		/**
 		* Get the cell index pairs, the grid index pairs (optional) and the local face pairs (optional) which correspond to a particular  interpretation.
@@ -102,29 +102,29 @@ namespace RESQML2_NS
 		* @param localFaceIndexPairs	Optional (put null if you don't want it). Must be allocated with getCellIndexPairCountFromIndex first.
 		* @param interpretationIndex	The index of the interpretation in the collection of feature interpretation of this grid connection set.
 		*/
-		virtual void getGridConnectionSetInformationFromInterpretationIndex(ULONG64 * cellIndexPairs, unsigned short * gridIndexPairs, int * localFaceIndexPairs, unsigned int interpretationIndex) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual void getGridConnectionSetInformationFromInterpretationIndex(ULONG64 * cellIndexPairs, unsigned short * gridIndexPairs, int * localFaceIndexPairs, unsigned int interpretationIndex) const = 0;
 
 		/**
 		* Get the UUID of a particular interpretation of this grid connection set.
 		* @param interpretationIndex The index of the interpretation in the collection of feature interpretation of this grid connection set.
 		*/
-		virtual std::string getInterpretationUuidFromIndex(const unsigned int & interpretationIndex) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual std::string getInterpretationUuidFromIndex(const unsigned int & interpretationIndex) const = 0;
 
 		/**
 		* Get a particular interpretation of this grid connection set.
 		* @param interpretationIndex The index of the interpretation in the collection of feature interpretation of this grid connection set.
 		*/
-		class AbstractFeatureInterpretation * getInterpretationFromIndex(const unsigned int & interpretationIndex) const;
+		DLL_IMPORT_OR_EXPORT class AbstractFeatureInterpretation * getInterpretationFromIndex(const unsigned int & interpretationIndex) const;
 
 		/**
 		* Get the count of interpretations in this grid connection set.
 		*/
-		virtual unsigned int getInterpretationCount() const = 0;
+		DLL_IMPORT_OR_EXPORT virtual unsigned int getInterpretationCount() const = 0;
 
 		/**
 		* Indicates if the grid connection set representation contains information on the connected faces of the two cells.
 		*/
-		virtual bool hasLocalFacePerCell() const = 0;
+		DLL_IMPORT_OR_EXPORT virtual bool hasLocalFacePerCell() const = 0;
 
 		/**
 		* Get the local face cell index pairs of this grid connection representation.
@@ -132,18 +132,18 @@ namespace RESQML2_NS
 		* @param localFacePerCellIndexPairs Tis array must be pre allocated and won't be deallocated byt fesapi. The count of localFacePerCellIndexPairs must be getCellIndexPairCount()*2.
 		* @return The used null value in localFacePerCellIndexPairs
 		*/
-		virtual LONG64 getLocalFacePerCellIndexPairs(int * localFacePerCellIndexPairs) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual LONG64 getLocalFacePerCellIndexPairs(int * localFacePerCellIndexPairs) const = 0;
 
 		/**
 		* Indicates if the grid connection set representation is based on several grids.
 		*/
-		virtual bool isBasedOnMultiGrids() const = 0;
+		DLL_IMPORT_OR_EXPORT virtual bool isBasedOnMultiGrids() const = 0;
 
 		/**
 		* Get the grid index pairs of this grid connection representation
 		* The count of gridIndexPairs must be getCellIndexPairCount()*2.
 		*/
-		virtual void getGridIndexPairs(unsigned short * gridIndexPairs) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual void getGridIndexPairs(unsigned short * gridIndexPairs) const = 0;
 
 		/**
 		* Set the cell index pairs of the grid connections representation using some exisiting hdf5 datasets.
@@ -154,7 +154,7 @@ namespace RESQML2_NS
 		* @param gridIndexPairNullValue	The integer null value used in the hdf grid index pair dataset.
         * @param gridIndexPair			The HDF dataset path where we can find all the grid index pair in a 1d Array where the grid indices go faster than the pair. The grid at an index must correspond to the cell at the same index in the cellIndexPair array.
 		*/
-		virtual void setCellIndexPairsUsingExistingDataset(ULONG64 cellIndexPairCount, const std::string & cellIndexPair, LONG64 cellIndexPairNullValue, COMMON_NS::AbstractHdfProxy * proxy, LONG64 gridIndexPairNullValue = -1, const std::string & gridIndexPair = "") = 0;
+		DLL_IMPORT_OR_EXPORT virtual void setCellIndexPairsUsingExistingDataset(ULONG64 cellIndexPairCount, const std::string & cellIndexPair, LONG64 cellIndexPairNullValue, COMMON_NS::AbstractHdfProxy * proxy, LONG64 gridIndexPairNullValue = -1, const std::string & gridIndexPair = "") = 0;
 
 		/**
 		* Set the cell index pairs of the grid connections representation
@@ -165,7 +165,7 @@ namespace RESQML2_NS
 		* @param gridIndexPairNullValue	The integer null value used in the hdf grid index pair dataset.
         * @param gridIndexPair			All the grid index pair in a 1d Array where the grid indices go faster than the pair. The grid at an index must correspond to the cell at the same index in the cellIndexPair array.
 		*/
-		void setCellIndexPairs(ULONG64 cellIndexPairCount, ULONG64 * cellIndexPair, ULONG64 cellIndexPairNullValue, COMMON_NS::AbstractHdfProxy * proxy, unsigned short gridIndexPairNullValue = (std::numeric_limits<unsigned short>::max)(), unsigned short * gridIndexPair = nullptr);
+		DLL_IMPORT_OR_EXPORT void setCellIndexPairs(ULONG64 cellIndexPairCount, ULONG64 * cellIndexPair, ULONG64 cellIndexPairNullValue, COMMON_NS::AbstractHdfProxy * proxy, unsigned short gridIndexPairNullValue = (std::numeric_limits<unsigned short>::max)(), unsigned short * gridIndexPair = nullptr);
 
 		/**
 		* 2 x #Connections array of local face-per-cell indices for (Cell1,Cell2) for each connection. Local face-per-cell indices are used because global face indices need not have been defined.
@@ -176,7 +176,7 @@ namespace RESQML2_NS
 		* @param nullValue					The null value in the localFacePerCellIndexPair dataset.
 		* @param proxy						The HDF proxy where the numerical values (cell indices) are stored.
 		*/
-		virtual void setLocalFacePerCellIndexPairs(ULONG64 cellIndexPairCount, int * localFacePerCellIndexPair, int nullValue, COMMON_NS::AbstractHdfProxy * proxy) = 0;
+		DLL_IMPORT_OR_EXPORT virtual void setLocalFacePerCellIndexPairs(ULONG64 cellIndexPairCount, int * localFacePerCellIndexPair, int nullValue, COMMON_NS::AbstractHdfProxy * proxy) = 0;
 
 		/**
 		* For each connection in the grid connection set representation, allow to map zero or one feature interpretation. TODO: Resqml allows to map with more than one feature interpretation.
@@ -185,63 +185,63 @@ namespace RESQML2_NS
 		* @param nullValue					The null value must be used as the corresponding interpretation index for each connection which are not associated to any interpretation.
 		* @param proxy						The Hdf proxy where the numerical values will be stored.
 		*/
-		virtual void setConnectionInterpretationIndices(unsigned int * interpretationIndices, unsigned int interpretationIndiceCount, unsigned int nullValue, COMMON_NS::AbstractHdfProxy * proxy) = 0;
+		DLL_IMPORT_OR_EXPORT virtual void setConnectionInterpretationIndices(unsigned int * interpretationIndices, unsigned int interpretationIndiceCount, unsigned int nullValue, COMMON_NS::AbstractHdfProxy * proxy) = 0;
 
 		/**
 		* Push back an interpretation which can be mapped with some connections.
 		* @param interp	The interpration to push back.
 		*/
-		void pushBackInterpretation(class AbstractFeatureInterpretation* interp);
+		DLL_IMPORT_OR_EXPORT void pushBackInterpretation(class AbstractFeatureInterpretation* interp);
 	
 		/**
 		 * Push back a grid representation which is one of the support of this representation.
 		 * And push back this representation as a grid connection information of the grid representation as well.
 		 */
-		void pushBackSupportingGridRepresentation(class AbstractGridRepresentation * supportingGridRep);
+		DLL_IMPORT_OR_EXPORT void pushBackSupportingGridRepresentation(class AbstractGridRepresentation * supportingGridRep);
 		
 		/**
 		* Get the count of the supporting grid representations of this grid connection representation.
 		*/
-		virtual unsigned int getSupportingGridRepresentationCount() const = 0;
+		DLL_IMPORT_OR_EXPORT virtual unsigned int getSupportingGridRepresentationCount() const = 0;
 
 		/**
 		* Get the supporting grid representation located at a specific index of this grid connection representation.
 		*/
-		class AbstractGridRepresentation* getSupportingGridRepresentation(unsigned int index) const;
+		DLL_IMPORT_OR_EXPORT class AbstractGridRepresentation* getSupportingGridRepresentation(unsigned int index) const;
 
 		/**
 		* Get one of the supporting grid representation dor of this grid connection representation.
 		*/
-		virtual gsoap_resqml2_0_1::eml20__DataObjectReference* getSupportingGridRepresentationDor(unsigned int index) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual gsoap_resqml2_0_1::eml20__DataObjectReference* getSupportingGridRepresentationDor(unsigned int index) const = 0;
 		
 		/**
 		* Get one of the supporting grid representation uuid of this grid connection representation.
 		*/
-		std::string getSupportingGridRepresentationUuid(unsigned int index) const;
+		DLL_IMPORT_OR_EXPORT std::string getSupportingGridRepresentationUuid(unsigned int index) const;
 
 		/**
 		* Get one of the supporting grid representation title of this grid connection representation.
 		*/
-		std::string getSupportingGridRepresentationTitle(unsigned int index) const;
+		DLL_IMPORT_OR_EXPORT std::string getSupportingGridRepresentationTitle(unsigned int index) const;
 
 		/**
 		* Get one of the supporting grid representation content type of this grid connection representation.
 		*/
-		std::string getSupportingGridRepresentationContentType(unsigned int index) const;
+		DLL_IMPORT_OR_EXPORT std::string getSupportingGridRepresentationContentType(unsigned int index) const;
 
-		ULONG64 getXyzPointCountOfPatch(const unsigned int & patchIndex) const;
+		DLL_IMPORT_OR_EXPORT ULONG64 getXyzPointCountOfPatch(const unsigned int & patchIndex) const;
 
 		/**
 		* Get all the XYZ points of a particular patch of this representation.
 		* XYZ points are given in the local CRS.
 		* @param xyzPoints A linearized 2d array where the first (quickest) dimension is coordinate dimension (XYZ) and second dimension is vertex dimension. It must be pre allocated.
 		*/
-		void getXyzPointsOfPatch(const unsigned int & patchIndex, double * xyzPoints) const;
+		DLL_IMPORT_OR_EXPORT void getXyzPointsOfPatch(const unsigned int & patchIndex, double * xyzPoints) const;
 
 		/**
 		* Always return one since this representation does not contain patches.
 		*/
-		unsigned int getPatchCount() const {return 1;}
+		DLL_IMPORT_OR_EXPORT unsigned int getPatchCount() const {return 1;}
 
 	private:
 
@@ -249,4 +249,3 @@ namespace RESQML2_NS
 		void importRelationshipSetFromEpc(COMMON_NS::EpcDocument* epcDoc);
 	};
 }
-

--- a/src/resqml2/MdDatum.h
+++ b/src/resqml2/MdDatum.h
@@ -28,7 +28,7 @@ namespace RESQML2_0_1_NS
 
 namespace RESQML2_NS
 {
-	class DLL_IMPORT_OR_EXPORT MdDatum : public COMMON_NS::AbstractObject
+	class MdDatum : public COMMON_NS::AbstractObject
 	{
 	protected :
 
@@ -68,18 +68,18 @@ namespace RESQML2_NS
 		*/
 		virtual ~MdDatum() {}
 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
 		/**
 		* Set the local CR Swhere the reference point ordinals are given
 		*/
-		void setLocalCrs(class AbstractLocal3dCrs * localCrs);
+		DLL_IMPORT_OR_EXPORT void setLocalCrs(class AbstractLocal3dCrs * localCrs);
 
 		/**
 		* Get the Local 3d CRS where the reference point ordinals are given
 		*/
-		class AbstractLocal3dCrs * getLocalCrs() const;
+		DLL_IMPORT_OR_EXPORT class AbstractLocal3dCrs * getLocalCrs() const;
 
 		/**
 		* Get the Local 3d CRS dor where the reference point ordinals are given
@@ -89,30 +89,30 @@ namespace RESQML2_NS
 		/**
 		* Get the Local 3d CRS uuid where the reference point ordinals are given
 		*/
-		std::string getLocalCrsUuid() const;
+		DLL_IMPORT_OR_EXPORT std::string getLocalCrsUuid() const;
 
 		/**
 		* Getter of the first ordinal of the reference location.
 		*/
-		virtual double getX() const = 0;
-		virtual double getXInGlobalCrs() const = 0;
+		DLL_IMPORT_OR_EXPORT virtual double getX() const = 0;
+		DLL_IMPORT_OR_EXPORT virtual double getXInGlobalCrs() const = 0;
 
 		/**
 		* Getter of the second ordinal of the reference location.
 		*/
-		virtual double getY() const = 0;
-		virtual double getYInGlobalCrs() const = 0;
+		DLL_IMPORT_OR_EXPORT virtual double getY() const = 0;
+		DLL_IMPORT_OR_EXPORT virtual double getYInGlobalCrs() const = 0;
 
 		/**
 		* Getter of the third ordinal of the reference location.
 		*/
-		virtual double getZ() const = 0;
-		virtual double getZInGlobalCrs() const = 0;
+		DLL_IMPORT_OR_EXPORT virtual double getZ() const = 0;
+		DLL_IMPORT_OR_EXPORT virtual double getZInGlobalCrs() const = 0;
 
 		/**
 		* Getter of the origin kind of the MD.
 		*/
-		virtual gsoap_resqml2_0_1::resqml2__MdReference getOriginKind() const = 0;
+		DLL_IMPORT_OR_EXPORT virtual gsoap_resqml2_0_1::resqml2__MdReference getOriginKind() const = 0;
 
 	protected:
 

--- a/src/resqml2/PropertyKind.h
+++ b/src/resqml2/PropertyKind.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_NS
 {
-	class DLL_IMPORT_OR_EXPORT PropertyKind : public COMMON_NS::AbstractObject
+	class PropertyKind : public COMMON_NS::AbstractObject
 	{
 	protected:
 
@@ -51,32 +51,32 @@ namespace RESQML2_NS
 		/**
 		* Getter (in read only mode) of the naming system of this property type
 		*/
-		const std::string & getNamingSystem() const;
+		DLL_IMPORT_OR_EXPORT const std::string & getNamingSystem() const;
 
 		/**
 		* Get the unit of measure of the values of this property kind.
 		*/
-		const gsoap_resqml2_0_1::resqml2__ResqmlUom & getUom() const;
+		DLL_IMPORT_OR_EXPORT const gsoap_resqml2_0_1::resqml2__ResqmlUom & getUom() const;
 
 		/**
 		* Get the unit of measure of the values of this property kind as a string.
 		*/
-		std::string getUomAsString() const;
+		DLL_IMPORT_OR_EXPORT std::string getUomAsString() const;
 
 		/**
 		 * Get the title of the parent of this property kind.
 		 */
-		std::string getParentAsString() const;
+		DLL_IMPORT_OR_EXPORT std::string getParentAsString() const;
 
 		/**
 		* Indicates if the property kind which is the parent of this property kind is either from the standard catalog of Energistics or from another local property kind.
 		*/
-		bool isParentAnEnergisticsPropertyKind() const;
+		DLL_IMPORT_OR_EXPORT bool isParentAnEnergisticsPropertyKind() const;
 
 		/**
 		* Getter for the energistics property kind which is associated to this intance.
 		*/
-		gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind getParentEnergisticsPropertyKind() const;
+		DLL_IMPORT_OR_EXPORT gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind getParentEnergisticsPropertyKind() const;
 
 		/**
 		* @return	null pointer if no local parent property kind is associated to this property. Otherwise return the data object reference of the associated parent local property kind.
@@ -86,44 +86,44 @@ namespace RESQML2_NS
 		/**
 		* Get the uuid of the local parent property kind which is associated to this property.
 		*/
-		std::string getParentLocalPropertyKindUuid() const;
+		DLL_IMPORT_OR_EXPORT std::string getParentLocalPropertyKindUuid() const;
 
 		/**
 		* Get the uuid of the local parent property kind which is associated to this property.
 		*/
-		std::string getParentLocalPropertyKindTitle() const;
+		DLL_IMPORT_OR_EXPORT std::string getParentLocalPropertyKindTitle() const;
 
 		/**
 		* Getter for the local property kind which is the parent of this instance.
 		* If nullptr is returned then it means this instance is associated to an energistics property kind.
 		*/
-		PropertyKind* getParentLocalPropertyKind() const;
+		DLL_IMPORT_OR_EXPORT PropertyKind* getParentLocalPropertyKind() const;
 
-		void setParentPropertyKind(PropertyKind* parentPropertyKind);
+		DLL_IMPORT_OR_EXPORT void setParentPropertyKind(PropertyKind* parentPropertyKind);
 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
 		/**
 		* Add a representation values object which uses this property type.
 		* Does not add the inverse relationship i.e. from the representation values object to this property type.
 		*/
-		void addProperty(class AbstractProperty* repVal) {propertySet.push_back(repVal);}
+		DLL_IMPORT_OR_EXPORT void addProperty(class AbstractProperty* repVal) {propertySet.push_back(repVal);}
 
 		/**
 		* Check if this property kind is a child of a particular standard Energistics Property kind.
 		*/
-		virtual bool isChildOf(gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind standardPropKind) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual bool isChildOf(gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind standardPropKind) const = 0;
 
 		/**
 		* Check if this property kind is abstract or not.
 		*/
-		virtual bool isAbstract() const = 0;
+		DLL_IMPORT_OR_EXPORT virtual bool isAbstract() const = 0;
 
 		/**
 		* Check if this property kind is partial or if one of its parent is partial.
 		*/
-		virtual bool isParentPartial() const = 0;
+		DLL_IMPORT_OR_EXPORT virtual bool isParentPartial() const = 0;
 
 	protected:
 		virtual void setXmlParentPropertyKind(PropertyKind* parentPropertyKind) = 0;

--- a/src/resqml2/RepresentationSetRepresentation.cpp
+++ b/src/resqml2/RepresentationSetRepresentation.cpp
@@ -98,7 +98,12 @@ bool RepresentationSetRepresentation::isHomogeneous() const
 unsigned int RepresentationSetRepresentation::getRepresentationCount() const
 {
 	if (gsoapProxy2_0_1 != nullptr) {
-		return static_cast<gsoap_resqml2_0_1::_resqml2__RepresentationSetRepresentation*>(gsoapProxy2_0_1)->Representation.size();
+		const size_t count = static_cast<gsoap_resqml2_0_1::_resqml2__RepresentationSetRepresentation*>(gsoapProxy2_0_1)->Representation.size();
+		if (count > (std::numeric_limits<unsigned int>::max)()) {
+			throw range_error("The count is too big.");
+		}
+
+		return static_cast<unsigned int>(count);
 	}
 	else {
 		throw logic_error("Not implemented yet");
@@ -107,7 +112,7 @@ unsigned int RepresentationSetRepresentation::getRepresentationCount() const
 
 RESQML2_NS::AbstractRepresentation* RepresentationSetRepresentation::getRepresentation(const unsigned int & index) const
 {
-	return static_cast<RESQML2_NS::AbstractRepresentation*>(epcDocument->getDataObjectByUuid(getRepresentationUuid(index)));
+	return epcDocument->getDataObjectByUuid<RESQML2_NS::AbstractRepresentation>(getRepresentationUuid(index));
 }
 
 gsoap_resqml2_0_1::eml20__DataObjectReference* RepresentationSetRepresentation::getRepresentationDor(const unsigned int & index) const

--- a/src/resqml2/RepresentationSetRepresentation.h
+++ b/src/resqml2/RepresentationSetRepresentation.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_NS
 {
-	class DLL_IMPORT_OR_EXPORT RepresentationSetRepresentation : public RESQML2_NS::AbstractRepresentation
+	class RepresentationSetRepresentation : public RESQML2_NS::AbstractRepresentation
 	{
 	protected:
 		RepresentationSetRepresentation(RESQML2_NS::AbstractFeatureInterpretation* interp) : AbstractRepresentation(interp, nullptr) {}
@@ -49,37 +49,36 @@ namespace RESQML2_NS
 		*/
 		virtual ~RepresentationSetRepresentation() {}
 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const;
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const;
 
 		std::string getHdfProxyUuid() const {return "";}
 
-
-		ULONG64 getXyzPointCountOfPatch(const unsigned int & patchIndex) const;
+		DLL_IMPORT_OR_EXPORT ULONG64 getXyzPointCountOfPatch(const unsigned int & patchIndex) const;
 
 		/**
 		* Get all the XYZ points of a particular patch of this representation.
 		* XYZ points are given in the local CRS.
 		* @param xyzPoints A linearized 2d array where the first (quickest) dimension is coordinate dimension (XYZ) and second dimension is vertex dimension. It must be pre allocated.
 		*/
-		void getXyzPointsOfPatch(const unsigned int & patchIndex, double * xyzPoints) const;
+		DLL_IMPORT_OR_EXPORT void getXyzPointsOfPatch(const unsigned int & patchIndex, double * xyzPoints) const;
 
-		unsigned int getPatchCount() const {return 0;}
+		DLL_IMPORT_OR_EXPORT unsigned int getPatchCount() const {return 0;}
 
 		/**
 		* Indicates if the representation set contains only one type of representations or several.
 		*/
-		bool isHomogeneous() const;
+		DLL_IMPORT_OR_EXPORT bool isHomogeneous() const;
 
 		/**
 		* Get the count of representations in this representation set.
 		*/
-		unsigned int getRepresentationCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getRepresentationCount() const;
 
 		/**
 		* Get a particular representation of this representation set according to its position.
 		*/
-		RESQML2_NS::AbstractRepresentation* getRepresentation(const unsigned int & index) const;
+		DLL_IMPORT_OR_EXPORT RESQML2_NS::AbstractRepresentation* getRepresentation(const unsigned int & index) const;
 
 		/**
 		* Get a particular representation dor of this representation set according to its position.
@@ -89,7 +88,7 @@ namespace RESQML2_NS
 		/**
 		* Get a particular representation uuid of this representation set according to its position.
 		*/
-		std::string getRepresentationUuid(const unsigned int & index) const;
+		DLL_IMPORT_OR_EXPORT std::string getRepresentationUuid(const unsigned int & index) const;
 
     protected:
 
@@ -101,4 +100,3 @@ namespace RESQML2_NS
 		friend void RESQML2_NS::AbstractRepresentation::pushBackIntoRepresentationSet(RepresentationSetRepresentation * repSet, bool xml);
 	};
 }
-

--- a/src/resqml2/SubRepresentation.h
+++ b/src/resqml2/SubRepresentation.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_NS
 {
-	class DLL_IMPORT_OR_EXPORT SubRepresentation : public RESQML2_NS::AbstractRepresentation
+	class SubRepresentation : public RESQML2_NS::AbstractRepresentation
 	{
 	protected:
 
@@ -50,47 +50,47 @@ namespace RESQML2_NS
 		*/
 		virtual ~SubRepresentation() {}
         
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
 		/**
 		* Get the kind of the selected elements for a particular patch of this subrepresentation.
 		*/
-		virtual indexableElement getElementKindOfPatch(const unsigned int & patchIndex, const unsigned int & elementIndicesIndex) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual indexableElement getElementKindOfPatch(const unsigned int & patchIndex, const unsigned int & elementIndicesIndex) const = 0;
 
 		/**
 		* Get the count of the selected elements for a particular patch of this subrepresentation.
 		*/
-		virtual ULONG64 getElementCountOfPatch(const unsigned int & patchIndex) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual ULONG64 getElementCountOfPatch(const unsigned int & patchIndex) const = 0;
 
 		/**
 		* Get the indices of the selected elements for a particular patch of this subrepresentation.
 		* @param	elementIndicesIndex	Must be equal to 0 if the element indices are not pairwise.
 		* @param	elementIndices		This array must be preallocated with getElementCountOfPatch() size.
 		*/
-		virtual void getElementIndicesOfPatch(const unsigned int & patchIndex, const unsigned int & elementIndicesIndex, ULONG64 * elementIndices) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual void getElementIndicesOfPatch(const unsigned int & patchIndex, const unsigned int & elementIndicesIndex, ULONG64 * elementIndices) const = 0;
 
 		/**
 		* Get the indices of the supporting representations of the selected elements for a particular patch of this subrepresentation.
 		* @param	supportingRepresentationIndices	This array must be preallocated with getElementCountOfPatch() size.
 		*/
-		virtual void getSupportingRepresentationIndicesOfPatch(const unsigned int & patchIndex, short * supportingRepresentationIndices) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual void getSupportingRepresentationIndicesOfPatch(const unsigned int & patchIndex, short * supportingRepresentationIndices) const = 0;
 
 		/**
 		* Check if the element of a particular patch are pairwise or not.
 		*/
-		virtual bool areElementIndicesPairwise(const unsigned int & patchIndex) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual bool areElementIndicesPairwise(const unsigned int & patchIndex) const = 0;
 
 		/**
 		* Check if the element indices of a particular patch are based on a lattice or not.
 		* @param elementIndicesIndex	In case of pairwise element, allow to select the first or second element indice of the pair.
 		*/
-		virtual bool areElementIndicesBasedOnLattice(const unsigned int & patchIndex, const unsigned int & elementIndicesIndex = 0) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual bool areElementIndicesBasedOnLattice(const unsigned int & patchIndex, const unsigned int & elementIndicesIndex = 0) const = 0;
 
-		virtual LONG64 getLatticeElementIndicesStartValue(const unsigned int & patchIndex, const unsigned int & elementIndicesIndex = 0) const = 0;
-		virtual unsigned int getLatticeElementIndicesDimensionCount(const unsigned int & patchIndex, const unsigned int & elementIndicesIndex = 0) const = 0;
-		virtual LONG64 getLatticeElementIndicesOffsetValue(const unsigned int & latticeDimensionIndex, const unsigned int & patchIndex, const unsigned int & elementIndicesIndex = 0) const = 0;
-		virtual ULONG64 getLatticeElementIndicesOffsetCount(const unsigned int & latticeDimensionIndex, const unsigned int & patchIndex, const unsigned int & elementIndicesIndex = 0) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual LONG64 getLatticeElementIndicesStartValue(const unsigned int & patchIndex, const unsigned int & elementIndicesIndex = 0) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual unsigned int getLatticeElementIndicesDimensionCount(const unsigned int & patchIndex, const unsigned int & elementIndicesIndex = 0) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual LONG64 getLatticeElementIndicesOffsetValue(const unsigned int & latticeDimensionIndex, const unsigned int & patchIndex, const unsigned int & elementIndicesIndex = 0) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual ULONG64 getLatticeElementIndicesOffsetCount(const unsigned int & latticeDimensionIndex, const unsigned int & patchIndex, const unsigned int & elementIndicesIndex = 0) const = 0;
 
 		/**
 		* Push back a new patch in the subrepresentation which is based on a lattice definition.
@@ -99,7 +99,7 @@ namespace RESQML2_NS
 		* @param elementCountInMiddleDimension		Commonly in J dimensionn.
 		* @param elementCountInFastestDimension		Commonly in I dimension.
 		*/
-		virtual void pushBackSubRepresentationPatch(const gsoap_resqml2_0_1::resqml2__IndexableElements & elementKind, const ULONG64 & originIndex,
+		DLL_IMPORT_OR_EXPORT virtual void pushBackSubRepresentationPatch(const gsoap_resqml2_0_1::resqml2__IndexableElements & elementKind, const ULONG64 & originIndex,
 			const unsigned int & elementCountInSlowestDimension,
 			const unsigned int & elementCountInMiddleDimension,
 			const unsigned int & elementCountInFastestDimension) = 0;
@@ -112,7 +112,7 @@ namespace RESQML2_NS
         * @param	proxy					The HDF proxy where the numerical values (indices) are stored.
 		* @param	supportingRepIndices	The indices of the supporting represenation for each elment in the supporting representation. The count must be elementCount.
 		*/
-		virtual void pushBackSubRepresentationPatch(const gsoap_resqml2_0_1::resqml2__IndexableElements & elementKind, const ULONG64 & elementCount, ULONG64 * elementIndices, COMMON_NS::AbstractHdfProxy* proxy, short * supportingRepIndices = nullptr) = 0;
+		DLL_IMPORT_OR_EXPORT virtual void pushBackSubRepresentationPatch(const gsoap_resqml2_0_1::resqml2__IndexableElements & elementKind, const ULONG64 & elementCount, ULONG64 * elementIndices, COMMON_NS::AbstractHdfProxy* proxy, short * supportingRepIndices = nullptr) = 0;
 
 		/**
 		* Push back a new patch in the subrepresentation which is constituted by means of pairwise elements.
@@ -123,7 +123,7 @@ namespace RESQML2_NS
 		* @param elementIndices1	The indices of the second part of the element pair in the supporting representation.
         * @param proxy				The HDF proxy where the numerical values (indices) are stored.
 		*/
-		virtual void pushBackSubRepresentationPatch(const gsoap_resqml2_0_1::resqml2__IndexableElements & elementKind0, const gsoap_resqml2_0_1::resqml2__IndexableElements & elementKind1,
+		DLL_IMPORT_OR_EXPORT virtual void pushBackSubRepresentationPatch(const gsoap_resqml2_0_1::resqml2__IndexableElements & elementKind0, const gsoap_resqml2_0_1::resqml2__IndexableElements & elementKind1,
 			const ULONG64 & elementCount,
 			ULONG64 * elementIndices0, ULONG64 * elementIndices1,
 			COMMON_NS::AbstractHdfProxy* proxy) = 0;
@@ -138,57 +138,57 @@ namespace RESQML2_NS
 		* @param	hdfProxy				The HDF5 proxy where the values are already or will be stored.
 		* @param	supportingRepDataset	The HDF5 dataset name where the element indices are stored. If empty, it won't be exported any information about suppporting rep relying on the fact there is only one suppporting rep for this whole patch.
 		*/
-		virtual void pushBackRefToExistingDataset(const gsoap_resqml2_0_1::resqml2__IndexableElements & elementKind, const ULONG64 & elementCount, const std::string & elementDataset,
+		DLL_IMPORT_OR_EXPORT virtual void pushBackRefToExistingDataset(const gsoap_resqml2_0_1::resqml2__IndexableElements & elementKind, const ULONG64 & elementCount, const std::string & elementDataset,
 			const LONG64 & nullValue, COMMON_NS::AbstractHdfProxy * proxy, const std::string & supportingRepDataset = "") = 0;
 
-		ULONG64 getXyzPointCountOfPatch(const unsigned int & patchIndex) const;
+		DLL_IMPORT_OR_EXPORT ULONG64 getXyzPointCountOfPatch(const unsigned int & patchIndex) const;
 
 		/**
 		* Get all the XYZ points of a particular patch of this representation.
 		* XYZ points are given in the local CRS.
 		* @param xyzPoints A linearized 2d array where the first (quickest) dimension is coordinate dimension (XYZ) and second dimension is vertex dimension. It must be pre allocated.
 		*/
-		void getXyzPointsOfPatch(const unsigned int & patchIndex, double * xyzPoints) const;
+		DLL_IMPORT_OR_EXPORT void getXyzPointsOfPatch(const unsigned int & patchIndex, double * xyzPoints) const;
 
-		virtual unsigned int getPatchCount() const = 0;
+		DLL_IMPORT_OR_EXPORT virtual unsigned int getPatchCount() const = 0;
 
 		/**
 		* Push back a representation which is one of the support of this representation.
 		* And push back this representation as a subrepresentation of the representation as well.
 		*/
-		void pushBackSupportingRepresentation(AbstractRepresentation * supportingRep);
+		DLL_IMPORT_OR_EXPORT void pushBackSupportingRepresentation(AbstractRepresentation * supportingRep);
 
 		/**
 		* Get the count of the supporting representations of this subrepresentation.
 		*/
-		virtual unsigned int getSupportingRepresentationCount() const = 0;
+		DLL_IMPORT_OR_EXPORT virtual unsigned int getSupportingRepresentationCount() const = 0;
 
 		/**
 		* Get the supporting representation located at a specific index of this subrepresentation.
 		*/
-		AbstractRepresentation* getSupportingRepresentation(unsigned int index) const;
+		DLL_IMPORT_OR_EXPORT AbstractRepresentation* getSupportingRepresentation(unsigned int index) const;
 
 		/**
 		* Get the supporting representation dor located at a specific index of this subrepresentation.
 		*/
-		virtual gsoap_resqml2_0_1::eml20__DataObjectReference* getSupportingRepresentationDor(unsigned int index) const = 0;
+		DLL_IMPORT_OR_EXPORT virtual gsoap_resqml2_0_1::eml20__DataObjectReference* getSupportingRepresentationDor(unsigned int index) const = 0;
 
 		/**
 		* Get one of the supporting representation uuid of this subrepresentation.
 		*/
-		std::string getSupportingRepresentationUuid(unsigned int index) const;
+		DLL_IMPORT_OR_EXPORT std::string getSupportingRepresentationUuid(unsigned int index) const;
 
 		/**
 		* Get one of the supporting representation title of this subrepresentation.
 		*/
-		std::string getSupportingRepresentationTitle(unsigned int index) const;
+		DLL_IMPORT_OR_EXPORT std::string getSupportingRepresentationTitle(unsigned int index) const;
 
 		/**
 		* Get one of the supporting representation content type of this subrepresentation.
 		* It is assumed by fesapi taht all supporting representations must have the same type.
 		* This is a current limitation of fesapi compared the Resqml datamodel.
 		*/
-		std::string getSupportingRepresentationContentType() const;
+		DLL_IMPORT_OR_EXPORT std::string getSupportingRepresentationContentType() const;
 
 	private:
 		

--- a/src/resqml2/TimeSeries.h
+++ b/src/resqml2/TimeSeries.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_NS
 {
-	class DLL_IMPORT_OR_EXPORT TimeSeries : public COMMON_NS::AbstractObject
+	class TimeSeries : public COMMON_NS::AbstractObject
 	{
 	protected:
 		/**
@@ -47,53 +47,53 @@ namespace RESQML2_NS
 		*/
 		~TimeSeries() {}
 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
 		/**
 		* Add a representation values object which uses this property type.
 		* Does not add the inverse relationship i.e. from the representation values object to this property type.
 		*/
-		void pushBackTimestamp(const time_t & timestamp);
+		DLL_IMPORT_OR_EXPORT void pushBackTimestamp(const time_t & timestamp);
 
 		/**
 		* Add a representation values object which uses this property type.
 		* Does not add the inverse relationship i.e. from the representation values object to this property type.
 		*/
-		void pushBackTimestamp(const tm & timestamp);
+		DLL_IMPORT_OR_EXPORT void pushBackTimestamp(const tm & timestamp);
 
 		/**
 		* Get the index of a timestamp in the time series.
 		* @return	uint.max if this timestamp has not been found in this time series.
 		*/
-		unsigned int getTimestampIndex(const time_t & timestamp) const;
+		DLL_IMPORT_OR_EXPORT unsigned int getTimestampIndex(const time_t & timestamp) const;
 
 		/**
 		* Get the index of a timestamp in the time series.
 		* @return	uint.max if this timestamp has not been found in this time series.
 		*/
-		unsigned int getTimestampIndex(const tm & timestamp) const;
+		DLL_IMPORT_OR_EXPORT unsigned int getTimestampIndex(const tm & timestamp) const;
 
 		/**
 		* Get the count of timestamps in this time series.
 		*/
-		unsigned int getTimestampCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getTimestampCount() const;
 
 		/**
 		* Get a timestamp at a particular index of this timeseries.
 		*/
-		time_t getTimestamp(const unsigned int & index) const;
+		DLL_IMPORT_OR_EXPORT time_t getTimestamp(const unsigned int & index) const;
 
 		/**
 		* Get a timestamp as a time structure at a particular index of this timeseries.
 		* It allows to read dates from 1900-01-01T00:00:00
 		*/
-		tm getTimestampAsTimeStructure(const unsigned int & index) const;
+		DLL_IMPORT_OR_EXPORT tm getTimestampAsTimeStructure(const unsigned int & index) const;
 
 		/**
 		* Get all the properties which use this time series
 		*/
-		const std::vector<RESQML2_NS::AbstractProperty*>& getPropertySet() const { return propertySet; }
+		DLL_IMPORT_OR_EXPORT const std::vector<RESQML2_NS::AbstractProperty*>& getPropertySet() const { return propertySet; }
 
 	protected:
 

--- a/src/resqml2_0_1/AbstractGeologicFeature.h
+++ b/src/resqml2_0_1/AbstractGeologicFeature.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT AbstractGeologicFeature : public RESQML2_NS::AbstractFeature
+	class AbstractGeologicFeature : public RESQML2_NS::AbstractFeature
 	{
 	protected:
 
@@ -40,9 +40,7 @@ namespace RESQML2_0_1_NS
 		AbstractGeologicFeature(gsoap_resqml2_0_1::resqml2__AbstractGeologicFeature* fromGsoap) : RESQML2_NS::AbstractFeature(fromGsoap) {}
 
 	public:
-
 		virtual ~AbstractGeologicFeature() {}
-
 	};
 }
 

--- a/src/resqml2_0_1/AbstractIjkGridRepresentation.h
+++ b/src/resqml2_0_1/AbstractIjkGridRepresentation.h
@@ -29,7 +29,7 @@ namespace RESQML2_0_1_NS
 	* This class is semantically abstract.
 	* Technically speaking, it is not an abstract because it can be used in case of partial transfer where we don't know the geometry of the ijk grid.
 	*/
-	class DLL_IMPORT_OR_EXPORT AbstractIjkGridRepresentation : public RESQML2_NS::AbstractColumnLayerGridRepresentation
+	class AbstractIjkGridRepresentation : public RESQML2_NS::AbstractColumnLayerGridRepresentation
 	{
 	private :
 
@@ -117,116 +117,116 @@ namespace RESQML2_0_1_NS
 		/**
 		* Get the I cell count of the grid
 		*/
-		unsigned int getICellCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getICellCount() const;
 
 		/**
 		* Set the I cell count of the grid
 		*/
-		void setICellCount(const unsigned int & iCount);
+		DLL_IMPORT_OR_EXPORT void setICellCount(const unsigned int & iCount);
 
 		/**
 		* Get the J cell count of the grid
 		*/
-		unsigned int getJCellCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getJCellCount() const;
 
 		/**
 		* Set the J cell count of the grid
 		*/
-		void setJCellCount(const unsigned int & jCount);
+		DLL_IMPORT_OR_EXPORT void setJCellCount(const unsigned int & jCount);
 
 		/**
 		* Get the count of cells in the grid
 		*/
-		ULONG64 getCellCount() const {return getICellCount() * getJCellCount() * getKCellCount();}
+		DLL_IMPORT_OR_EXPORT ULONG64 getCellCount() const {return getICellCount() * getJCellCount() * getKCellCount();}
 
 		/**
 		* Get the count of columns in the grid
 		*/
-		unsigned int getColumnCount() const {return getICellCount() * getJCellCount();}
+		DLL_IMPORT_OR_EXPORT unsigned int getColumnCount() const {return getICellCount() * getJCellCount();}
 
 		/**
 		* Get the count of pillars in the grid
 		*/
-		unsigned int getPillarCount() const {return (getICellCount()+1) * (getJCellCount()+1);}
+		DLL_IMPORT_OR_EXPORT unsigned int getPillarCount() const {return (getICellCount()+1) * (getJCellCount()+1);}
 
 		/**
 		* Get the count of faces in the grid
 		* This method requires you have already loaded the split information.
 		*/
-		unsigned int getFaceCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getFaceCount() const;
 
 		/**
 		* Get the I coordinate of a pillar from its global index in the grid.
 		*/
-		unsigned int getIPillarFromGlobalIndex(const unsigned int & globalIndex) const;
+		DLL_IMPORT_OR_EXPORT unsigned int getIPillarFromGlobalIndex(const unsigned int & globalIndex) const;
 
 		/**
 		* Get the J coordinate of a pillar from its global index in the grid.
 		*/
-		unsigned int getJPillarFromGlobalIndex(const unsigned int & globalIndex) const;
+		DLL_IMPORT_OR_EXPORT unsigned int getJPillarFromGlobalIndex(const unsigned int & globalIndex) const;
 
 		/**
 		* Get the global index of a pillar from its I and J indices in the grid.
 		*/
-		unsigned int getGlobalIndexPillarFromIjIndex(const unsigned int & iPillar, const unsigned int & jPillar) const;
+		DLL_IMPORT_OR_EXPORT unsigned int getGlobalIndexPillarFromIjIndex(const unsigned int & iPillar, const unsigned int & jPillar) const;
 
 		/**
 		* Get the I coordinate of a column from its global index in the grid.
 		*/
-		unsigned int getIColumnFromGlobalIndex(const unsigned int & globalIndex) const;
+		DLL_IMPORT_OR_EXPORT unsigned int getIColumnFromGlobalIndex(const unsigned int & globalIndex) const;
 
 		/**
 		* Get the J coordinate of a column from its global index in the grid.
 		*/
-		unsigned int getJColumnFromGlobalIndex(const unsigned int & globalIndex) const;
+		DLL_IMPORT_OR_EXPORT unsigned int getJColumnFromGlobalIndex(const unsigned int & globalIndex) const;
 
 		/**
 		* Get the global index of a cell from its I and J indices in the grid.
 		*/
-		unsigned int getGlobalIndexColumnFromIjIndex(const unsigned int & iColumn, const unsigned int & jColumn) const;
+		DLL_IMPORT_OR_EXPORT unsigned int getGlobalIndexColumnFromIjIndex(const unsigned int & iColumn, const unsigned int & jColumn) const;
 
 		/**
 		* Get the global index of a column from its I, J and K indices in the grid.
 		*/
-		unsigned int getGlobalIndexCellFromIjkIndex(const unsigned int & iCell, const unsigned int & jCell, const unsigned int & kCell) const;
+		DLL_IMPORT_OR_EXPORT unsigned int getGlobalIndexCellFromIjkIndex(const unsigned int & iCell, const unsigned int & jCell, const unsigned int & kCell) const;
 
-		bool isRightHanded() const;
+		DLL_IMPORT_OR_EXPORT bool isRightHanded() const;
 
 		/**
 		 * Get all the pillars which correspond to all split coordinate lines.
 		 * Order of the pillar correspond to order of the split coordinate lines.
 		 * @param pillarIndices It must be pre allocated.
 		 */
-		void getPillarsOfSplitCoordinateLines(unsigned int * pillarIndices, bool reverseIAxis = false, bool reverseJAxis = false) const;
+		DLL_IMPORT_OR_EXPORT void getPillarsOfSplitCoordinateLines(unsigned int * pillarIndices, bool reverseIAxis = false, bool reverseJAxis = false) const;
 
 		/**
 		 * Get all the columns impacted by all the split coordinate lines.
 		 * @param columnIndices 			It must be pre allocated.
 		 */
-		void getColumnsOfSplitCoordinateLines(unsigned int * columnIndices, bool reverseIAxis = false, bool reverseJAxis = false) const;
-		void getColumnCountOfSplitCoordinateLines(unsigned int * columnIndexCountPerSplitCoordinateLine) const;
+		DLL_IMPORT_OR_EXPORT void getColumnsOfSplitCoordinateLines(unsigned int * columnIndices, bool reverseIAxis = false, bool reverseJAxis = false) const;
+		DLL_IMPORT_OR_EXPORT void getColumnCountOfSplitCoordinateLines(unsigned int * columnIndexCountPerSplitCoordinateLine) const;
 
 		/**
 		 * Get the split coordinate line count
 		 */
-		unsigned long getSplitCoordinateLineCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned long getSplitCoordinateLineCount() const;
 
 		/**
 		 * Get the split coordinate line count within a block. Block information must be loaded.
 		 */
-		unsigned long getBlockSplitCoordinateLineCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned long getBlockSplitCoordinateLineCount() const;
 
 		/**
 		* Get the split coordinate line count
 		*/
-		ULONG64 getSplitNodeCount() const;
+		DLL_IMPORT_OR_EXPORT ULONG64 getSplitNodeCount() const;
 		
-		void getPillarGeometryIsDefined(bool * pillarGeometryIsDefined, bool reverseIAxis = false, bool reverseJAxis = false) const;
+		DLL_IMPORT_OR_EXPORT void getPillarGeometryIsDefined(bool * pillarGeometryIsDefined, bool reverseIAxis = false, bool reverseJAxis = false) const;
 
 		/**
 		 * Indicates if this grid contains information on enabled and disabled information.
 		 */
-		bool hasEnabledCellInformation() const;
+		DLL_IMPORT_OR_EXPORT bool hasEnabledCellInformation() const;
 
 		/**
 		 * Get the information on the dead/invisible cells.
@@ -234,20 +234,20 @@ namespace RESQML2_0_1_NS
 		 * A zero value in enabledCells means that the corresponding cell is disabled. A non zero value means that the corresponding cell is enabled.
 		 * @param	enabledCells	It must be preallocated with the size of the cell count in the ijk grid. It won't be disallocated.
 		 */
-		void getEnabledCells(bool * enabledCells, bool reverseIAxis = false, bool reverseJAxis= false, bool reverseKAxis= false) const;
+		DLL_IMPORT_OR_EXPORT void getEnabledCells(bool * enabledCells, bool reverseIAxis = false, bool reverseJAxis= false, bool reverseKAxis= false) const;
 
 		/**
 		 * Set the information on the dead/invisible cells. The geometry of the grid must have been defined yet.
 		 * The enabledCells array must have a count of getCellCount() and must follow the index ordering i then j then k.
 		 * A zero value in enabledCells means that the corresponding cell is disabled. A non zero value means that the corresponding cell is enabled.
 		 */
-		void setEnabledCells(unsigned char* enabledCells);
+		DLL_IMPORT_OR_EXPORT void setEnabledCells(unsigned char* enabledCells);
 
 		/**
 		* Load the split information into memory to speed up processes.
 		* Be aware that you must unload by yourself this memory.
 		*/
-		void loadSplitInformation();
+		DLL_IMPORT_OR_EXPORT void loadSplitInformation();
 
 		/**
 		 * Load the block information into memory to speed up the processes and make easier block geometry handling for the user.
@@ -258,12 +258,12 @@ namespace RESQML2_0_1_NS
 		 * @param kCellStart	The starting K cell index of the block taken from zero to kCellCount - 1.
 		 * @param kCellEnd		The ending K cell index of the block taken from zero to kCellCount - 1.
 		 */
-		void loadBlockInformation(const unsigned int & iInterfaceStart, const unsigned int & iInterfaceEnd, const unsigned int & jInterfaceStart, const unsigned int & jInterfaceEnd, const unsigned int & kInterfaceStart, const unsigned int & kInterfaceEnd);
+		DLL_IMPORT_OR_EXPORT void loadBlockInformation(const unsigned int & iInterfaceStart, const unsigned int & iInterfaceEnd, const unsigned int & jInterfaceStart, const unsigned int & jInterfaceEnd, const unsigned int & kInterfaceStart, const unsigned int & kInterfaceEnd);
 
 		/**
 		* Unload the split information from memory.
 		*/
-		void unloadSplitInformation();
+		DLL_IMPORT_OR_EXPORT void unloadSplitInformation();
 
 		/**
 		* Check either a column edge is splitted or not.
@@ -275,7 +275,7 @@ namespace RESQML2_0_1_NS
 		*					2 for edge from i+1 to i, upper j connection
 		*					3 for edge from j+1 to j, lower i connection
 		*/
-		bool isColumnEdgeSplitted(const unsigned int & iColumn, const unsigned int & jColumn, const unsigned int & edge) const;
+		DLL_IMPORT_OR_EXPORT bool isColumnEdgeSplitted(const unsigned int & iColumn, const unsigned int & jColumn, const unsigned int & edge) const;
 
 		/**
 		* Get the XYZ point index in the HDF dataset from the corner of a cell.
@@ -294,7 +294,7 @@ namespace RESQML2_0_1_NS
 		* @return index of the XYZ point corresponding to the iCell jCell and corner 
 		* parameters in the HDF dataset. Keep in mind to multiply the result by 3 to get the X index since the points are triplet of values.
 		*/
-		ULONG64 getXyzPointIndexFromCellCorner(const unsigned int & iCell, const unsigned int & jCell, const unsigned int & kCell, const unsigned int & corner) const;
+		DLL_IMPORT_OR_EXPORT ULONG64 getXyzPointIndexFromCellCorner(const unsigned int & iCell, const unsigned int & jCell, const unsigned int & kCell, const unsigned int & corner) const;
 
 		/**
 		* Gets the x, y and z values of the corner of a cell of a given block.
@@ -315,19 +315,19 @@ namespace RESQML2_0_1_NS
 		* @param y				(output parameter) the y value of the corner we look for.
 		* @param z				(output parameter) the z value of the corner we look for.
 		*/
-		void getXyzPointOfBlockFromCellCorner(const unsigned int & iCell, const unsigned int & jCell, const unsigned int & kCell, const unsigned int & corner,
+		DLL_IMPORT_OR_EXPORT void getXyzPointOfBlockFromCellCorner(const unsigned int & iCell, const unsigned int & jCell, const unsigned int & kCell, const unsigned int & corner,
 			const double* xyzPoints, double & x, double & y, double & z) const;
 
 		/**
 		* Get the xyz point count in each K Layer interface in a given patch.
 		* @param patchIndex	The index of the patch. It is generally zero.
 		*/
-		ULONG64 getXyzPointCountOfKInterfaceOfPatch(const unsigned int & patchIndex) const;
+		DLL_IMPORT_OR_EXPORT ULONG64 getXyzPointCountOfKInterfaceOfPatch(const unsigned int & patchIndex) const;
 
 		/**
 		 * Get the xyz point count of the current block. Block information must be loaded.
 		 */
-		ULONG64 getXyzPointCountOfBlock() const;
+		DLL_IMPORT_OR_EXPORT ULONG64 getXyzPointCountOfBlock() const;
 
 		/**
 		* Get all the XYZ points of a particular K interface of a particular patch of this representation.
@@ -337,27 +337,26 @@ namespace RESQML2_0_1_NS
 		* @param patchIndex	The index of the patch. It is generally zero.
 		* @param xyzPoints 	A linearized 2d array where the first (quickest) dimension is coordinate dimension (XYZ) and second dimension is vertex dimension. It must be pre allocated with a size of 3*getXyzPointCountOfKInterfaceOfPatch.
 		*/
-		void getXyzPointsOfKInterfaceOfPatch(const unsigned int & kInterface, const unsigned int & patchIndex, double * xyzPoints);
+		DLL_IMPORT_OR_EXPORT void getXyzPointsOfKInterfaceOfPatch(const unsigned int & kInterface, const unsigned int & patchIndex, double * xyzPoints);
 
-		virtual void getXyzPointsOfKInterfaceSequenceOfPatch(const unsigned int & kInterfaceStart, const unsigned int & kInterfaceEnd, const unsigned int & patchIndex, double * xyzPoints);
+		DLL_IMPORT_OR_EXPORT virtual void getXyzPointsOfKInterfaceSequenceOfPatch(const unsigned int & kInterfaceStart, const unsigned int & kInterfaceEnd, const unsigned int & patchIndex, double * xyzPoints);
 
-		virtual void getXyzPointsOfBlockOfPatch(const unsigned int & patchIndex, double * xyzPoints);
+		DLL_IMPORT_OR_EXPORT virtual void getXyzPointsOfBlockOfPatch(const unsigned int & patchIndex, double * xyzPoints);
 
 		/**
 		* Get the K direction of the grid.
 		*/
-		gsoap_resqml2_0_1::resqml2__KDirection getKDirection() const;
+		DLL_IMPORT_OR_EXPORT gsoap_resqml2_0_1::resqml2__KDirection getKDirection() const;
 
-		virtual geometryKind getGeometryKind() const { return UNKNOWN; }
-		virtual std::string getHdfProxyUuid() const { throw std::logic_error("Partial object"); }
-		virtual ULONG64 getXyzPointCountOfPatch(const unsigned int & patchIndex) const;
-		virtual void getXyzPointsOfPatch(const unsigned int & patchIndex, double * xyzPoints) const;
+		DLL_IMPORT_OR_EXPORT virtual geometryKind getGeometryKind() const { return UNKNOWN; }
+		DLL_IMPORT_OR_EXPORT virtual std::string getHdfProxyUuid() const { throw std::logic_error("Partial object"); }
+		DLL_IMPORT_OR_EXPORT virtual ULONG64 getXyzPointCountOfPatch(const unsigned int & patchIndex) const;
+		DLL_IMPORT_OR_EXPORT virtual void getXyzPointsOfPatch(const unsigned int & patchIndex, double * xyzPoints) const;
 
-		static const char* XML_TAG;
-		static const char* XML_TAG_TRUNCATED;
-		virtual std::string getXmlTag() const;
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG_TRUNCATED;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const;
 
-		unsigned int getPatchCount() const {return 1;}
+		DLL_IMPORT_OR_EXPORT unsigned int getPatchCount() const {return 1;}
 	};
 }
-

--- a/src/resqml2_0_1/AbstractOrganizationInterpretation.h
+++ b/src/resqml2_0_1/AbstractOrganizationInterpretation.h
@@ -25,7 +25,7 @@ namespace RESQML2_0_1_NS
 	/**
 	* This class defines the behaviour of all Resqml2 organizations
 	*/
-	class DLL_IMPORT_OR_EXPORT AbstractOrganizationInterpretation : public RESQML2_NS::AbstractFeatureInterpretation
+	class AbstractOrganizationInterpretation : public RESQML2_NS::AbstractFeatureInterpretation
 	{
 	protected:
 
@@ -51,20 +51,19 @@ namespace RESQML2_0_1_NS
 		/**
 		 * Add a binary contact to the organization interpretation by means of a simple sentence.
 		 */
-		void pushBackBinaryContact(const gsoap_resqml2_0_1::resqml2__ContactRelationship & kind, RESQML2_NS::AbstractFeatureInterpretation* subject, const gsoap_resqml2_0_1::resqml2__ContactVerb & verb, RESQML2_NS::AbstractFeatureInterpretation* directObject);
+		DLL_IMPORT_OR_EXPORT void pushBackBinaryContact(const gsoap_resqml2_0_1::resqml2__ContactRelationship & kind, RESQML2_NS::AbstractFeatureInterpretation* subject, const gsoap_resqml2_0_1::resqml2__ContactVerb & verb, RESQML2_NS::AbstractFeatureInterpretation* directObject);
 
 		/**
 		 * Add a binary contact to the organization itnerpretation by means of a sentence where the direct object can be qualified.
 		 */
-		void pushBackBinaryContact(const gsoap_resqml2_0_1::resqml2__ContactRelationship & kind, RESQML2_NS::AbstractFeatureInterpretation* subject, const gsoap_resqml2_0_1::resqml2__ContactVerb & verb, RESQML2_NS::AbstractFeatureInterpretation* directObject,
+		DLL_IMPORT_OR_EXPORT void pushBackBinaryContact(const gsoap_resqml2_0_1::resqml2__ContactRelationship & kind, RESQML2_NS::AbstractFeatureInterpretation* subject, const gsoap_resqml2_0_1::resqml2__ContactVerb & verb, RESQML2_NS::AbstractFeatureInterpretation* directObject,
 				const gsoap_resqml2_0_1::resqml2__ContactSide & directObjectQualifier);
 
         /**
          * Add a binary contact to the organization interpretation by means of a sentence where both the subject and the direct object can be qualified.
          */
-		void pushBackBinaryContact(const gsoap_resqml2_0_1::resqml2__ContactRelationship & kind, RESQML2_NS::AbstractFeatureInterpretation* subject, const gsoap_resqml2_0_1::resqml2__ContactSide & subjectQualifier,
+		DLL_IMPORT_OR_EXPORT void pushBackBinaryContact(const gsoap_resqml2_0_1::resqml2__ContactRelationship & kind, RESQML2_NS::AbstractFeatureInterpretation* subject, const gsoap_resqml2_0_1::resqml2__ContactSide & subjectQualifier,
                                    const gsoap_resqml2_0_1::resqml2__ContactVerb & verb,
 								   RESQML2_NS::AbstractFeatureInterpretation* directObject, const gsoap_resqml2_0_1::resqml2__ContactSide & directObjectQualifier);
 	};
 }
-

--- a/src/resqml2_0_1/AbstractStratigraphicOrganizationInterpretation.h
+++ b/src/resqml2_0_1/AbstractStratigraphicOrganizationInterpretation.h
@@ -23,7 +23,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT AbstractStratigraphicOrganizationInterpretation : public AbstractOrganizationInterpretation
+	class AbstractStratigraphicOrganizationInterpretation : public AbstractOrganizationInterpretation
 	{
 	protected:
 
@@ -51,20 +51,20 @@ namespace RESQML2_0_1_NS
 		/**
 		* @return The count of grid representation assocaited to this strati organization.
 		*/
-		unsigned int getGridRepresentationCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getGridRepresentationCount() const;
 
 		/**
 		* Get a grid representation associated to this strati org interp by means of its index.
 		* @param index	The index of the grid representation to get in the array of grid representaitons of this strati org interp.
 		*/
-		RESQML2_NS::AbstractGridRepresentation* getGridRepresentation(const unsigned int & index) const;
+		DLL_IMPORT_OR_EXPORT RESQML2_NS::AbstractGridRepresentation* getGridRepresentation(const unsigned int & index) const;
 
 		/**
 		* Check if a grid representation is wether associated to this strati org interp or not.
 		* @param gridRep	The grid representation to check its assocaition with this strati org interp.
 		* @return			True or false.
 		*/
-		bool isAssociatedToGridRepresentation(RESQML2_NS::AbstractGridRepresentation* gridRep) const;
+		DLL_IMPORT_OR_EXPORT bool isAssociatedToGridRepresentation(RESQML2_NS::AbstractGridRepresentation* gridRep) const;
 
 	private:
 

--- a/src/resqml2_0_1/AbstractSurfaceFrameworkRepresentation.h
+++ b/src/resqml2_0_1/AbstractSurfaceFrameworkRepresentation.h
@@ -26,7 +26,7 @@ namespace RESQML2_0_1_NS
 	* Parent class for a sealed or non-sealed surface framework representation. Each one instantiates a representation set representation.
 	* The difference between the sealed and non-sealed frameworks is that, in the non-sealed case, we do not have all of the contacts, or we have all of the contacts but they are not all sealed.
 	*/
-	class DLL_IMPORT_OR_EXPORT AbstractSurfaceFrameworkRepresentation : public RESQML2_NS::RepresentationSetRepresentation
+	class AbstractSurfaceFrameworkRepresentation : public RESQML2_NS::RepresentationSetRepresentation
 	{
 	protected:
 
@@ -67,7 +67,7 @@ namespace RESQML2_0_1_NS
 		* @param contactIndices	The sealed contacts involved within the identity.
 		* @param proxy			The hdf proxy.
 		*/
-		void pushBackContactIdentity(
+		DLL_IMPORT_OR_EXPORT void pushBackContactIdentity(
 			gsoap_resqml2_0_1::resqml2__IdentityKind kind,
 			unsigned int contactCount, int * contactIndices,
 			COMMON_NS::AbstractHdfProxy * proxy);
@@ -81,7 +81,7 @@ namespace RESQML2_0_1_NS
 		* @param identicalNodesIndexes	The indices of the identical nodes.
 		* @param proxy					The hdf proxy.
 		*/
-		void pushBackContactIdentity(
+		DLL_IMPORT_OR_EXPORT void pushBackContactIdentity(
 			gsoap_resqml2_0_1::resqml2__IdentityKind kind,
 			unsigned int contactCount, int * contactIndices,
 			unsigned int identicalNodesCount, int * identicalNodesIndexes,
@@ -92,13 +92,13 @@ namespace RESQML2_0_1_NS
 		*
 		* @return The count of contacts in this framework.
 		*/
-		virtual unsigned int getContactCount() const = 0;
+		DLL_IMPORT_OR_EXPORT virtual unsigned int getContactCount() const = 0;
 
 		/**
 		* Get the count of contact identity in this framework.
 		* @return The count of contact identity in this framework.
 		*/
-		unsigned int getContactIdentityCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getContactIdentityCount() const;
 
 		/**
 		* Get the kind of a contact identity located at a particular index.
@@ -106,7 +106,7 @@ namespace RESQML2_0_1_NS
 		* @param ciIndex	The index of the contact identity in the contact identity list. It must be in the interval [0..getContactIdentityCount()[.
 		* @return The kind of the contact identity located at a particular index.
 		*/
-		gsoap_resqml2_0_1::resqml2__IdentityKind getContactIdentityKind(unsigned int ciIndex) const;
+		DLL_IMPORT_OR_EXPORT gsoap_resqml2_0_1::resqml2__IdentityKind getContactIdentityKind(unsigned int ciIndex) const;
 
 		/**
 		* Get the count of contact of a particular contact identity.
@@ -114,7 +114,7 @@ namespace RESQML2_0_1_NS
 		* @param ciIndex	The index of the contact identity in the contact identity list. It must be in the interval [0..getContactIdentityCount()[.
 		* @return			The count of contact of a particular contact identity.
 		*/
-		unsigned int getContactCountInContactIdentity(unsigned int ciIndex) const;
+		DLL_IMPORT_OR_EXPORT unsigned int getContactCountInContactIdentity(unsigned int ciIndex) const;
 
 		/**
 		* Get the contact indices of a particular contact identity.
@@ -124,7 +124,7 @@ namespace RESQML2_0_1_NS
 		* @param contactRepIndices	This array must be preallocated with getContactCountOfContactIdentity(). It won't be deleted by fesapi.
 		*							It will be filled in with the desired contact rep indices.
 		*/
-		void getContactIndices(unsigned int ciIndex, unsigned int * contactRepIndices) const;
+		DLL_IMPORT_OR_EXPORT void getContactIndices(unsigned int ciIndex, unsigned int * contactRepIndices) const;
 
 		/*
 		* Check if all nodes of contacts are identical in a contact identity.
@@ -132,7 +132,7 @@ namespace RESQML2_0_1_NS
 		* @param ciIndex	The index of the contact identity in the contact identity list. It must be in the interval [0..getContactIdentityCount()[.
 		* @return			True if all node of contacts are identical else false.
 		*/
-		bool areAllContactNodesIdentical(unsigned int ciIndex) const;
+		DLL_IMPORT_OR_EXPORT bool areAllContactNodesIdentical(unsigned int ciIndex) const;
 
 		/**
 		* Get the count of identical nodes of a particular contact identity.
@@ -141,7 +141,7 @@ namespace RESQML2_0_1_NS
 		* @param ciIndex	The index of the contact identity in the contact identity list. It must be in the interval [0..getContactIdentityCount()[.
 		* @return			The count of identical nodes of a particular contact identity.
 		*/
-		unsigned int getIdenticalContactNodeCount(unsigned int ciIndex) const;
+		DLL_IMPORT_OR_EXPORT unsigned int getIdenticalContactNodeCount(unsigned int ciIndex) const;
 
 		/**
 		* Get the node indices of all contacts which are identical.
@@ -151,7 +151,6 @@ namespace RESQML2_0_1_NS
 		* @param nodeIndices	This array must be preallocated with getIdenticalContactlNodeCount(). It won't be deleted by fesapi.
 		*						It will be filled in with the desired node indices.
 		*/
-		void getIdenticalContactNodeIndices(unsigned int ciIndex, unsigned int * nodeIndices) const;
+		DLL_IMPORT_OR_EXPORT void getIdenticalContactNodeIndices(unsigned int ciIndex, unsigned int * nodeIndices) const;
 	};
 }
-

--- a/src/resqml2_0_1/AbstractSurfaceRepresentation.h
+++ b/src/resqml2_0_1/AbstractSurfaceRepresentation.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT AbstractSurfaceRepresentation : public RESQML2_NS::AbstractRepresentation
+	class AbstractSurfaceRepresentation : public RESQML2_NS::AbstractRepresentation
 	{
 	protected:
 
@@ -107,23 +107,20 @@ namespace RESQML2_0_1_NS
 		 * Push back an outer ring of this representation
 		 * The index of the ring must correspond to the index of the patch it delimits.
 		 */
-		void pushBackOuterRing(PolylineRepresentation * outerRing);
+		DLL_IMPORT_OR_EXPORT void pushBackOuterRing(PolylineRepresentation * outerRing);
 
 		/**
 		* Set the surface role of the representation.
 		* map : Representation support for properties.
 		* pick : Representation support for 3D points picked in 2D or 3D.
 		*/
-		void setSurfaceRole(const gsoap_resqml2_0_1::resqml2__SurfaceRole & surfaceRole);
+		DLL_IMPORT_OR_EXPORT void setSurfaceRole(const gsoap_resqml2_0_1::resqml2__SurfaceRole & surfaceRole);
 
 		/**
 		* Get the surface role of this representation.
 		* map : Representation support for properties.
 		* pick : Representation support for 3D points picked in 2D or 3D.
 		*/
-		const gsoap_resqml2_0_1::resqml2__SurfaceRole & getSurfaceRole() const;
-
-
+		DLL_IMPORT_OR_EXPORT const gsoap_resqml2_0_1::resqml2__SurfaceRole & getSurfaceRole() const;
 	};
 }
-

--- a/src/resqml2_0_1/AbstractTechnicalFeature.h
+++ b/src/resqml2_0_1/AbstractTechnicalFeature.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT AbstractTechnicalFeature : public RESQML2_NS::AbstractFeature
+	class AbstractTechnicalFeature : public RESQML2_NS::AbstractFeature
 	{
 	protected:
 
@@ -40,9 +40,7 @@ namespace RESQML2_0_1_NS
 		AbstractTechnicalFeature(gsoap_resqml2_0_1::resqml2__AbstractTechnicalFeature* fromGsoap) : RESQML2_NS::AbstractFeature(fromGsoap) {}
 
 	public:
-
 		virtual ~AbstractTechnicalFeature() {}
-
 	};
 }
 

--- a/src/resqml2_0_1/Activity.h
+++ b/src/resqml2_0_1/Activity.h
@@ -27,7 +27,7 @@ namespace RESQML2_NS
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT Activity : public RESQML2_NS::Activity
+	class Activity : public RESQML2_NS::Activity
 	{
 	protected:
 		Activity() : RESQML2_NS::Activity() {}
@@ -53,72 +53,72 @@ namespace RESQML2_0_1_NS
 		* Push back a double parameter in the instance.
 		* This parameter must exist in the associated activity template.
 		*/
-		void pushBackParameter(const std::string title,
+		DLL_IMPORT_OR_EXPORT void pushBackParameter(const std::string title,
 			const double & value, const gsoap_resqml2_0_1::resqml2__ResqmlUom & uom = gsoap_resqml2_0_1::resqml2__ResqmlUom__Euc);
 
 		/**
 		* Push back a string parameter in the instance.
 		* This parameter must exist in the associated activity template.
 		*/
-		void pushBackParameter(const std::string title,
+		DLL_IMPORT_OR_EXPORT void pushBackParameter(const std::string title,
 			const std::string & value);
 
 		/**
 		* Push back an integer parameter in the instance.
 		* This parameter must exist in the associated activity template.
 		*/
-		void pushBackParameter(const std::string title,
+		DLL_IMPORT_OR_EXPORT void pushBackParameter(const std::string title,
 			const LONG64 & value);
 
 		/**
 		* Push back a resqml object parameter in the instance.
 		* This parameter must exist in the associated activity template.
 		*/
-		void pushBackParameter(const std::string title,
+		DLL_IMPORT_OR_EXPORT void pushBackParameter(const std::string title,
 			AbstractObject* resqmlObject);
 		
 		/**
 		* Get the count of all the parameters
 		*/
-		unsigned int getParameterCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getParameterCount() const;
 
 		/**
 		* Get the count of all the parameters which have got the same title.
 		*/
-		unsigned int getParameterCount(const std::string & paramTitle) const;
-		const std::string & getParameterTitle(const unsigned int & index) const;
-		std::vector<unsigned int> getParameterIndexOfTitle(const std::string & paramTitle) const;
+		DLL_IMPORT_OR_EXPORT unsigned int getParameterCount(const std::string & paramTitle) const;
+		DLL_IMPORT_OR_EXPORT const std::string & getParameterTitle(const unsigned int & index) const;
+		DLL_IMPORT_OR_EXPORT std::vector<unsigned int> getParameterIndexOfTitle(const std::string & paramTitle) const;
 
-		bool isAFloatingPointQuantityParameter(const std::string & paramTitle) const;
-		bool isAFloatingPointQuantityParameter(const unsigned int & index) const;
-		std::vector<double> getFloatingPointQuantityParameterValue(const std::string & paramTitle) const;
-		double getFloatingPointQuantityParameterValue(const unsigned int & index) const;
-		std::vector<gsoap_resqml2_0_1::resqml2__ResqmlUom> getFloatingPointQuantityParameterUom(const std::string & paramTitle) const;
-		gsoap_resqml2_0_1::resqml2__ResqmlUom getFloatingPointQuantityParameterUom(const unsigned int & index) const;
+		DLL_IMPORT_OR_EXPORT bool isAFloatingPointQuantityParameter(const std::string & paramTitle) const;
+		DLL_IMPORT_OR_EXPORT bool isAFloatingPointQuantityParameter(const unsigned int & index) const;
+		DLL_IMPORT_OR_EXPORT std::vector<double> getFloatingPointQuantityParameterValue(const std::string & paramTitle) const;
+		DLL_IMPORT_OR_EXPORT double getFloatingPointQuantityParameterValue(const unsigned int & index) const;
+		DLL_IMPORT_OR_EXPORT std::vector<gsoap_resqml2_0_1::resqml2__ResqmlUom> getFloatingPointQuantityParameterUom(const std::string & paramTitle) const;
+		DLL_IMPORT_OR_EXPORT gsoap_resqml2_0_1::resqml2__ResqmlUom getFloatingPointQuantityParameterUom(const unsigned int & index) const;
 
-		bool isAnIntegerQuantityParameter(const std::string & paramTitle) const;
-		bool isAnIntegerQuantityParameter(const unsigned int & index) const;
-		std::vector<LONG64> getIntegerQuantityParameterValue(const std::string & paramTitle) const;
-		LONG64 getIntegerQuantityParameterValue(const unsigned int & index) const;
+		DLL_IMPORT_OR_EXPORT bool isAnIntegerQuantityParameter(const std::string & paramTitle) const;
+		DLL_IMPORT_OR_EXPORT bool isAnIntegerQuantityParameter(const unsigned int & index) const;
+		DLL_IMPORT_OR_EXPORT std::vector<LONG64> getIntegerQuantityParameterValue(const std::string & paramTitle) const;
+		DLL_IMPORT_OR_EXPORT LONG64 getIntegerQuantityParameterValue(const unsigned int & index) const;
 
-		bool isAStringParameter(const std::string & paramTitle) const;
-		bool isAStringParameter(const unsigned int & index) const;
-		std::vector<std::string> getStringParameterValue(const std::string & paramTitle) const;
-		const std::string & getStringParameterValue(const unsigned int & index) const;
+		DLL_IMPORT_OR_EXPORT bool isAStringParameter(const std::string & paramTitle) const;
+		DLL_IMPORT_OR_EXPORT bool isAStringParameter(const unsigned int & index) const;
+		DLL_IMPORT_OR_EXPORT std::vector<std::string> getStringParameterValue(const std::string & paramTitle) const;
+		DLL_IMPORT_OR_EXPORT const std::string & getStringParameterValue(const unsigned int & index) const;
 
-		bool isAResqmlObjectParameter(const std::string & paramTitle) const;
-		bool isAResqmlObjectParameter(const unsigned int & index) const;
-		std::vector<AbstractObject*> getResqmlObjectParameterValue(const std::string & paramTitle) const;
-		AbstractObject* getResqmlObjectParameterValue(const unsigned int & index) const;
+		DLL_IMPORT_OR_EXPORT bool isAResqmlObjectParameter(const std::string & paramTitle) const;
+		DLL_IMPORT_OR_EXPORT bool isAResqmlObjectParameter(const unsigned int & index) const;
+		DLL_IMPORT_OR_EXPORT std::vector<AbstractObject*> getResqmlObjectParameterValue(const std::string & paramTitle) const;
+		DLL_IMPORT_OR_EXPORT AbstractObject* getResqmlObjectParameterValue(const unsigned int & index) const;
 
 		/**
 		* Set the activity template of the activity
 		**/
-		void setActivityTemplate(RESQML2_NS::ActivityTemplate* activityTemplate);
+		DLL_IMPORT_OR_EXPORT void setActivityTemplate(RESQML2_NS::ActivityTemplate* activityTemplate);
 
 		gsoap_resqml2_0_1::eml20__DataObjectReference* getActivityTemplateDor() const;
 
-		std::string getResqmlVersion() const;
+		DLL_IMPORT_OR_EXPORT std::string getResqmlVersion() const;
 
 	private:
 

--- a/src/resqml2_0_1/ActivityTemplate.h
+++ b/src/resqml2_0_1/ActivityTemplate.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT ActivityTemplate : public RESQML2_NS::ActivityTemplate
+	class ActivityTemplate : public RESQML2_NS::ActivityTemplate
 	{
 	public:
 
@@ -46,7 +46,7 @@ namespace RESQML2_0_1_NS
 		* Push back a parameter in the activity template instance.
 		* This parameter has an unconstrained type.
 		*/
-		void pushBackParameter(const std::string title,
+		DLL_IMPORT_OR_EXPORT void pushBackParameter(const std::string title,
 			const bool & isInput, const bool isOutput,
 			const unsigned int & minOccurs, const int & maxOccurs);
 
@@ -54,7 +54,7 @@ namespace RESQML2_0_1_NS
 		* Push back a parameter in the activity template instance.
 		* This parameter must not be of a data object kind.
 		*/
-		void pushBackParameter(const std::string title,
+		DLL_IMPORT_OR_EXPORT void pushBackParameter(const std::string title,
 			const gsoap_resqml2_0_1::resqml2__ParameterKind & kind,
 			const bool & isInput, const bool isOutput,
 			const unsigned int & minOccurs, const int & maxOccurs);
@@ -64,7 +64,7 @@ namespace RESQML2_0_1_NS
 		* This parameter must be of a data object kind.
 		* @param resqmlObjectContentType	If empty, there is no constraint on the content type of this parameter.
 		*/
-		void pushBackParameter(const std::string title,
+		DLL_IMPORT_OR_EXPORT void pushBackParameter(const std::string title,
 			const bool & isInput, const bool isOutput,
 			const unsigned int & minOccurs, const int & maxOccurs,
 			const std::string & resqmlObjectContentType);
@@ -73,32 +73,31 @@ namespace RESQML2_0_1_NS
 		* Check if the instance contains a parameter with a particular title
 		* @param paramTitle	The title of the parameter we are looking for into the instance
 		*/
-		bool isAnExistingParameter(const std::string & paramTitle) const;
+		DLL_IMPORT_OR_EXPORT bool isAnExistingParameter(const std::string & paramTitle) const;
 
-		unsigned int getParameterCount() const;
-		const std::string & getParameterTitle(const unsigned int & index) const;
-		const std::vector<gsoap_resqml2_0_1::resqml2__ParameterKind> & getParameterAllowedKinds(const unsigned int & index) const;
-		const std::vector<gsoap_resqml2_0_1::resqml2__ParameterKind> & getParameterAllowedKinds(const std::string & paramTitle) const;
-		const bool & getParameterIsInput(const unsigned int & index) const;
-		const bool & getParameterIsInput(const std::string & paramTitle) const;
-		const bool & getParameterIsOutput(const unsigned int & index) const;
-		const bool & getParameterIsOutput(const std::string & paramTitle) const;
-		LONG64 getParameterMinOccurences(const unsigned int & index) const;
-		LONG64 getParameterMinOccurences(const std::string & paramTitle) const;
-		LONG64 getParameterMaxOccurences(const unsigned int & index) const;
-		LONG64 getParameterMaxOccurences(const std::string & paramTitle) const;
+		DLL_IMPORT_OR_EXPORT unsigned int getParameterCount() const;
+		DLL_IMPORT_OR_EXPORT const std::string & getParameterTitle(const unsigned int & index) const;
+		DLL_IMPORT_OR_EXPORT const std::vector<gsoap_resqml2_0_1::resqml2__ParameterKind> & getParameterAllowedKinds(const unsigned int & index) const;
+		DLL_IMPORT_OR_EXPORT const std::vector<gsoap_resqml2_0_1::resqml2__ParameterKind> & getParameterAllowedKinds(const std::string & paramTitle) const;
+		DLL_IMPORT_OR_EXPORT const bool & getParameterIsInput(const unsigned int & index) const;
+		DLL_IMPORT_OR_EXPORT const bool & getParameterIsInput(const std::string & paramTitle) const;
+		DLL_IMPORT_OR_EXPORT const bool & getParameterIsOutput(const unsigned int & index) const;
+		DLL_IMPORT_OR_EXPORT const bool & getParameterIsOutput(const std::string & paramTitle) const;
+		DLL_IMPORT_OR_EXPORT LONG64 getParameterMinOccurences(const unsigned int & index) const;
+		DLL_IMPORT_OR_EXPORT LONG64 getParameterMinOccurences(const std::string & paramTitle) const;
+		DLL_IMPORT_OR_EXPORT LONG64 getParameterMaxOccurences(const unsigned int & index) const;
+		DLL_IMPORT_OR_EXPORT LONG64 getParameterMaxOccurences(const std::string & paramTitle) const;
 
-		const std::vector<Activity*> & getActivityInstanceSet() const { return activityInstanceSet; }
+		DLL_IMPORT_OR_EXPORT const std::vector<Activity*> & getActivityInstanceSet() const { return activityInstanceSet; }
 
 		//******************************************************************
 		//******************** MANDATORY FOR GsoapWrapper ******************
 		//******************************************************************
 		
-		std::string getResqmlVersion() const;
+		DLL_IMPORT_OR_EXPORT std::string getResqmlVersion() const;
 
-		static const char* XML_TAG;
-		std::string getXmlTag() const {return XML_TAG;}
-
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT std::string getXmlTag() const {return XML_TAG;}
 
 	private:
 		std::vector<epc::Relationship> getAllEpcRelationships() const;

--- a/src/resqml2_0_1/BlockedWellboreRepresentation.h
+++ b/src/resqml2_0_1/BlockedWellboreRepresentation.h
@@ -27,7 +27,7 @@ namespace RESQML2_NS
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT BlockedWellboreRepresentation : public WellboreFrameRepresentation
+	class BlockedWellboreRepresentation : public WellboreFrameRepresentation
 	{
 	private:
 		void init(const std::string & guid, const std::string & title, class WellboreTrajectoryRepresentation * traj);
@@ -59,8 +59,8 @@ namespace RESQML2_0_1_NS
 		*/
 		~BlockedWellboreRepresentation() {}
         
-		static const char* XML_TAG;
-		std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT std::string getXmlTag() const {return XML_TAG;}
 	
 		/**
 		* Set all information about the intersected grid cells. You must first provide MD values of the frame before to use this method.
@@ -72,34 +72,34 @@ namespace RESQML2_0_1_NS
 		* @param localFacePairPerCellIndicesNullValue	The null value used in localFacePerCellIndices in order to indicate that it corresponds to a missing intersection, e.g., when a trajectory originates or terminates within a cell.
 		* @param hdfProxy								The hdf proxy where the numerical values will be stored.
 		*/
-		void setIntevalGridCells(unsigned int * gridIndices, unsigned int gridIndicesNullValue, unsigned int cellCount, ULONG64* cellIndices, unsigned char* localFacePairPerCellIndices, unsigned char localFacePairPerCellIndicesNullValue, COMMON_NS::AbstractHdfProxy * hdfProxy);
+		DLL_IMPORT_OR_EXPORT void setIntevalGridCells(unsigned int * gridIndices, unsigned int gridIndicesNullValue, unsigned int cellCount, ULONG64* cellIndices, unsigned char* localFacePairPerCellIndices, unsigned char localFacePairPerCellIndicesNullValue, COMMON_NS::AbstractHdfProxy * hdfProxy);
 
 		/**
 		* The number of non-null entries in the grid indices array.
 		*/
-		ULONG64 getCellCount() const;
+		DLL_IMPORT_OR_EXPORT ULONG64 getCellCount() const;
 
 		/**
 		* Size of array = IntervalCount on the wellbore frame rep. The grids (and there indices) are defined using pushBackSupportingGridRepresentation method.
 		* @return nullValue
 		*/
-		unsigned int getGridIndices(unsigned int * gridIndices) const;
+		DLL_IMPORT_OR_EXPORT unsigned int getGridIndices(unsigned int * gridIndices) const;
 
 		/**
 		 * Pushes back a grid representation which is one of the support of this representation.
 		 * And push back this representation as a grid connection information of the grid representation as well.
 		 */
-		void pushBackSupportingGridRepresentation(RESQML2_NS::AbstractGridRepresentation * supportingGridRep);
+		DLL_IMPORT_OR_EXPORT void pushBackSupportingGridRepresentation(RESQML2_NS::AbstractGridRepresentation * supportingGridRep);
 		
 		/**
 		* Get the count of the supporting grid representations of this grid connection representation.
 		*/
-		unsigned int getSupportingGridRepresentationCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getSupportingGridRepresentationCount() const;
 
 		/**
 		* Get the supporting grid representation located at a specific index of this blocked wellbore representation.
 		*/
-		RESQML2_NS::AbstractGridRepresentation* getSupportingGridRepresentation(unsigned int index) const;
+		DLL_IMPORT_OR_EXPORT RESQML2_NS::AbstractGridRepresentation* getSupportingGridRepresentation(unsigned int index) const;
 
 		/**
 		* Get the supporting grid representation dor located at a specific index of this blocked wellbore representation.
@@ -109,7 +109,7 @@ namespace RESQML2_0_1_NS
 		/**
 		* Get the supporting grid representation uuid located at a specific index of this blocked wellbore representation.
 		*/
-		std::string getSupportingGridRepresentationUuid(unsigned int index) const;
+		DLL_IMPORT_OR_EXPORT std::string getSupportingGridRepresentationUuid(unsigned int index) const;
 
 	private:
 
@@ -117,4 +117,3 @@ namespace RESQML2_0_1_NS
 		void importRelationshipSetFromEpc(COMMON_NS::EpcDocument* epcDoc);
 	};
 }
-

--- a/src/resqml2_0_1/BoundaryFeatureInterpretation.h
+++ b/src/resqml2_0_1/BoundaryFeatureInterpretation.h
@@ -23,7 +23,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT BoundaryFeatureInterpretation : public RESQML2_NS::AbstractFeatureInterpretation
+	class BoundaryFeatureInterpretation : public RESQML2_NS::AbstractFeatureInterpretation
 	{
 	public:
 
@@ -49,9 +49,8 @@ namespace RESQML2_0_1_NS
 		BoundaryFeatureInterpretation(gsoap_resqml2_0_1::_resqml2__BoundaryFeatureInterpretation* fromGsoap) : RESQML2_NS::AbstractFeatureInterpretation(fromGsoap) {}
 		virtual ~BoundaryFeatureInterpretation() {}
 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
-
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
 	protected:
 		virtual std::vector<epc::Relationship> getAllEpcRelationships() const;
@@ -61,4 +60,3 @@ namespace RESQML2_0_1_NS
 		friend void WellboreMarker::setBoundaryFeatureInterpretation(BoundaryFeatureInterpretation* interp);
 	};
 }
-

--- a/src/resqml2_0_1/CategoricalProperty.h
+++ b/src/resqml2_0_1/CategoricalProperty.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT CategoricalProperty : public RESQML2_NS::AbstractValuesProperty
+	class CategoricalProperty : public RESQML2_NS::AbstractValuesProperty
 	{
 	public:
 
@@ -71,8 +71,8 @@ namespace RESQML2_0_1_NS
 		*/
 		virtual ~CategoricalProperty() {}
 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
 		/**
 		* Add a 1d array of explicit long values to the property values.
@@ -80,7 +80,7 @@ namespace RESQML2_0_1_NS
 		* @param valueCount				The number of values to write.
 		* @param proxy					The HDF proxy where to write the property values. It must be already opened for writing and won't be closed in this method.
 		*/
-		void pushBackLongHdf5Array1dOfValues(const long * values, const ULONG64 & valueCount, COMMON_NS::AbstractHdfProxy * proxy, const long & nullValue);
+		DLL_IMPORT_OR_EXPORT void pushBackLongHdf5Array1dOfValues(const long * values, const ULONG64 & valueCount, COMMON_NS::AbstractHdfProxy * proxy, const long & nullValue);
 
 		/**
 		* Add a 2d array of explicit long values to the property values.
@@ -89,7 +89,7 @@ namespace RESQML2_0_1_NS
 		* @param valueCountInSlowestDim The number of values to write in the slowest dimension (mainly J dimension).
 		* @param proxy					The HDF proxy where to write the property values. It must be already opened for writing and won't be closed in this method.
 		*/
-		void pushBackLongHdf5Array2dOfValues(const long * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy * proxy, const long & nullValue);
+		DLL_IMPORT_OR_EXPORT void pushBackLongHdf5Array2dOfValues(const long * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy * proxy, const long & nullValue);
 
 		/**
 		* Add a 3d array of explicit long values to the property values.
@@ -99,7 +99,7 @@ namespace RESQML2_0_1_NS
 		* @param valueCountInSlowestDim The number of values to write in the slowest dimension (mainly K dimension).
 		* @param proxy					The HDF proxy where to write the property values. It must be already opened for writing and won't be closed in this method.
 		*/
-		void pushBackLongHdf5Array3dOfValues(const long * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInMiddleDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy * proxy, const long & nullValue);
+		DLL_IMPORT_OR_EXPORT void pushBackLongHdf5Array3dOfValues(const long * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInMiddleDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy * proxy, const long & nullValue);
 
 		/**
 		* Add an array (potentially multi dimensions) of long values to the property values which will be stored in the HDF file identified by its HDF proxy.
@@ -108,7 +108,7 @@ namespace RESQML2_0_1_NS
 		* @param numDimensionsInArray	The number of dimensions in the array to write.
 		* @param proxy					The HDF proxy where to write the property values. It must be already opened for writing and won't be closed in this method.
 		*/
-		void pushBackLongHdf5ArrayOfValues(const long * values, unsigned long long * numValues, const unsigned int & numDimensionsInArray, COMMON_NS::AbstractHdfProxy* proxy, const long & nullValue);
+		DLL_IMPORT_OR_EXPORT void pushBackLongHdf5ArrayOfValues(const long * values, unsigned long long * numValues, const unsigned int & numDimensionsInArray, COMMON_NS::AbstractHdfProxy* proxy, const long & nullValue);
 
 		/**
 		* Add a 1d array of explicit unsigned short values to the property values.
@@ -116,7 +116,7 @@ namespace RESQML2_0_1_NS
 		* @param valueCount				The number of values to write.
 		* @param proxy					The HDF proxy where to write the property values. It must be already opened for writing and won't be closed in this method.
 		*/
-		void pushBackUShortHdf5Array1dOfValues(const unsigned short * values, const ULONG64 & valueCount, COMMON_NS::AbstractHdfProxy * proxy, const long & nullValue);
+		DLL_IMPORT_OR_EXPORT void pushBackUShortHdf5Array1dOfValues(const unsigned short * values, const ULONG64 & valueCount, COMMON_NS::AbstractHdfProxy * proxy, const long & nullValue);
 
 		/**
 		* Add a 2d array of explicit unsigned short values to the property values.
@@ -125,7 +125,7 @@ namespace RESQML2_0_1_NS
 		* @param valueCountInSlowestDim The number of values to write in the slowest dimension (mainly J dimension).
 		* @param proxy					The HDF proxy where to write the property values. It must be already opened for writing and won't be closed in this method.
 		*/
-		void pushBackUShortHdf5Array2dOfValues(const unsigned short * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy * proxy, const long & nullValue);
+		DLL_IMPORT_OR_EXPORT void pushBackUShortHdf5Array2dOfValues(const unsigned short * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy * proxy, const long & nullValue);
 
 		/**
 		* Add a 3d array of explicit unsigned short values to the property values.
@@ -135,7 +135,7 @@ namespace RESQML2_0_1_NS
 		* @param valueCountInSlowestDim The number of values to write in the slowest dimension (mainly K dimension).
 		* @param proxy					The HDF proxy where to write the property values. It must be already opened for writing and won't be closed in this method.
 		*/
-		void pushBackUShortHdf5Array3dOfValues(const unsigned short * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInMiddleDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy * proxy, const long & nullValue);
+		DLL_IMPORT_OR_EXPORT void pushBackUShortHdf5Array3dOfValues(const unsigned short * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInMiddleDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy * proxy, const long & nullValue);
 
 		/**
 		* Add an array (potentially multi dimensions) of unsigned short values to the property values which will be stored in the HDF file identified by its HDF proxy.
@@ -144,19 +144,19 @@ namespace RESQML2_0_1_NS
 		* @param numDimensionsInArray	The number of dimensions in the array to write.
 		* @param proxy					The HDF proxy where to write the property values. It must be already opened for writing and won't be closed in this method.
 		*/
-		void pushBackUShortHdf5ArrayOfValues(const unsigned short * values, unsigned long long * numValues, const unsigned int & numDimensionsInArray, COMMON_NS::AbstractHdfProxy* proxy, const unsigned short & nullValue);
+		DLL_IMPORT_OR_EXPORT void pushBackUShortHdf5ArrayOfValues(const unsigned short * values, unsigned long long * numValues, const unsigned int & numDimensionsInArray, COMMON_NS::AbstractHdfProxy* proxy, const unsigned short & nullValue);
 
-		std::string pushBackRefToExistingDataset(COMMON_NS::AbstractHdfProxy* hdfProxy, const std::string & dataset = "", LONG64 nullValue = (std::numeric_limits<LONG64>::max)());
+		DLL_IMPORT_OR_EXPORT std::string pushBackRefToExistingDataset(COMMON_NS::AbstractHdfProxy* hdfProxy, const std::string & dataset = "", LONG64 nullValue = (std::numeric_limits<LONG64>::max)());
 
 		/**
 		* Get the string lookup which is associated to this categorical property values.
 		*/
-		class StringTableLookup* getStringLookup() {return stringLookup;}
+		DLL_IMPORT_OR_EXPORT class StringTableLookup* getStringLookup() {return stringLookup;}
 
 		/**
 		* Get the string lookup uuid which is associated to this categorical property values.
 		*/
-		std::string getStringLookupUuid() const;
+		DLL_IMPORT_OR_EXPORT std::string getStringLookupUuid() const;
 
 		/**
 		* Check if the associated local property kind is allowed for this property.
@@ -176,5 +176,3 @@ namespace RESQML2_0_1_NS
 		class StringTableLookup* stringLookup;
 	};
 }
-
-

--- a/src/resqml2_0_1/CategoricalPropertySeries.h
+++ b/src/resqml2_0_1/CategoricalPropertySeries.h
@@ -26,7 +26,7 @@ namespace RESQML2_0_1_NS
 	* This class is mainly useful for describing temporal properties on well objects.
 	* The prefered approach to describe temporal properties on Reservoir grids is to use one instance of CategoricalProperty per time step.
 	*/
-	class DLL_IMPORT_OR_EXPORT CategoricalPropertySeries : public CategoricalProperty
+	class CategoricalPropertySeries : public CategoricalProperty
 	{
 	public:
 
@@ -79,11 +79,9 @@ namespace RESQML2_0_1_NS
 		*/
 		virtual ~CategoricalPropertySeries() {}
 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
-		std::string getResqmlVersion() const {return "2.0.1";}
+		DLL_IMPORT_OR_EXPORT std::string getResqmlVersion() const {return "2.0.1";}
 	};
 }
-
-

--- a/src/resqml2_0_1/CommentProperty.h
+++ b/src/resqml2_0_1/CommentProperty.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT CommentProperty : public RESQML2_NS::AbstractValuesProperty
+	class CommentProperty : public RESQML2_NS::AbstractValuesProperty
 	{
 	public:
 
@@ -65,22 +65,22 @@ namespace RESQML2_0_1_NS
 		*/
 		~CommentProperty() {}
 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
 		/**
 		* Add an array of string values to the property values.
 		* @param values					All the property values to set ordered according the topology of the representation it is based on.
 		* @param proxy					The HDF proxy where to write the property values. It must be already opened for writing and won't be closed in this method.
 		*/
-		void pushBackStringHdf5ArrayOfValues(const std::vector<std::string> & values, COMMON_NS::AbstractHdfProxy* proxy);
+		DLL_IMPORT_OR_EXPORT void pushBackStringHdf5ArrayOfValues(const std::vector<std::string> & values, COMMON_NS::AbstractHdfProxy* proxy);
 
-		std::string pushBackRefToExistingDataset(COMMON_NS::AbstractHdfProxy* hdfProxy, const std::string & datasetName = "", LONG64 nullValue = (std::numeric_limits<LONG64>::max)());
+		DLL_IMPORT_OR_EXPORT std::string pushBackRefToExistingDataset(COMMON_NS::AbstractHdfProxy* hdfProxy, const std::string & datasetName = "", LONG64 nullValue = (std::numeric_limits<LONG64>::max)());
 
 		/**
 		* Get all the values of the instance which are supposed to be string ones.
 		*/
-		std::vector<std::string> getStringValuesOfPatch(const unsigned int & patchIndex);
+		DLL_IMPORT_OR_EXPORT std::vector<std::string> getStringValuesOfPatch(const unsigned int & patchIndex);
 
 		/**
 		* Check if the associated local property kind is allowed for this property.
@@ -91,7 +91,5 @@ namespace RESQML2_0_1_NS
 		* Check if the associated standard property kind is allowed for this property.
 		*/
 		bool validatePropertyKindAssociation(const gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind & pk);
-
 	};
 }
-

--- a/src/resqml2_0_1/ContinuousProperty.h
+++ b/src/resqml2_0_1/ContinuousProperty.h
@@ -26,7 +26,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT ContinuousProperty : public RESQML2_NS::AbstractValuesProperty
+	class ContinuousProperty : public RESQML2_NS::AbstractValuesProperty
 	{
 	protected:
 
@@ -117,20 +117,20 @@ namespace RESQML2_0_1_NS
 		*/
 		virtual ~ContinuousProperty() {}
 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
 		/**
 		* Get the unit of measure of the values of this property.
 		* If 'Euc'  is returned, you should check if an extrametadata called "Uom" also exists. If so, it would mean that the property uses a non standard uom. This is an official workaround for a known issue of Resqml 2.0.1.
 		*/
-		const gsoap_resqml2_0_1::resqml2__ResqmlUom & getUom() const;
+		DLL_IMPORT_OR_EXPORT const gsoap_resqml2_0_1::resqml2__ResqmlUom & getUom() const;
 
 		/**
 		* Get the unit of measure of the values of this property as a string.
 		* If 'Euc'  is returned, you should check if an extrametadata called "Uom" also exists. If so, it would mean that the property uses a non standard uom. This is an official workaround for a known issue of Resqml 2.0.1.
 		*/
-		std::string getUomAsString() const;
+		DLL_IMPORT_OR_EXPORT std::string getUomAsString() const;
 
 		/**
 		* Add a 1d array of explicit double values to the property values.
@@ -140,7 +140,7 @@ namespace RESQML2_0_1_NS
 		* @param minimumValue			The minimum value of the values to add. If NAN is provided then the minimum value will be computed from the values.
 		* @param maximumValue			The maximum value of the values to add. If NAN is provided then the maximum value will be computed from the values.
 		*/
-		void pushBackDoubleHdf5Array1dOfValues(const double * values, const ULONG64 & valueCount, COMMON_NS::AbstractHdfProxy* proxy,
+		DLL_IMPORT_OR_EXPORT void pushBackDoubleHdf5Array1dOfValues(const double * values, const ULONG64 & valueCount, COMMON_NS::AbstractHdfProxy* proxy,
 			const double & minimumValue = std::numeric_limits<double>::quiet_NaN(), const double & maximumValue = std::numeric_limits<double>::quiet_NaN());
 
 		/**
@@ -152,7 +152,7 @@ namespace RESQML2_0_1_NS
 		* @param minimumValue			The minimum value of the values to add. If NAN is provided then the minimum value will be computed from the values.
 		* @param maximumValue			The maximum value of the values to add. If NAN is provided then the maximum value will be computed from the values.
 		*/
-		void pushBackDoubleHdf5Array2dOfValues(const double * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy,
+		DLL_IMPORT_OR_EXPORT void pushBackDoubleHdf5Array2dOfValues(const double * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy,
 			const double & minimumValue = std::numeric_limits<double>::quiet_NaN(), const double & maximumValue = std::numeric_limits<double>::quiet_NaN());
 
 		/**
@@ -165,7 +165,7 @@ namespace RESQML2_0_1_NS
 		* @param minimumValue			The minimum value of the values to add. If NAN is provided then the minimum value will be computed from the values.
 		* @param maximumValue			The maximum value of the values to add. If NAN is provided then the maximum value will be computed from the values.
 		*/
-		void pushBackDoubleHdf5Array3dOfValues(const double * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInMiddleDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy,
+		DLL_IMPORT_OR_EXPORT void pushBackDoubleHdf5Array3dOfValues(const double * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInMiddleDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy,
 			const double & minimumValue = std::numeric_limits<double>::quiet_NaN(), const double & maximumValue = std::numeric_limits<double>::quiet_NaN());
 
 		/**
@@ -177,7 +177,7 @@ namespace RESQML2_0_1_NS
 		* @param minimumValue			The minimum value (or value vector) of the values to add. If nullptr is provided and the dimension of value is 1 then the minimum value will be computed from the values.
 		* @param maximumValue			The maximum value (or value vector) of the values to add. If nullptr is provided and the dimension of value is 1 then the maximum value will be computed from the values.
 		*/
-		void pushBackDoubleHdf5ArrayOfValues(const double * values, unsigned long long * numValues, const unsigned int & numArrayDimensions, COMMON_NS::AbstractHdfProxy* proxy,
+		DLL_IMPORT_OR_EXPORT void pushBackDoubleHdf5ArrayOfValues(const double * values, unsigned long long * numValues, const unsigned int & numArrayDimensions, COMMON_NS::AbstractHdfProxy* proxy,
 			double * minimumValue = nullptr, double * maximumValue = nullptr);
 
 		/**
@@ -188,7 +188,7 @@ namespace RESQML2_0_1_NS
 		* @param minimumValue			The minimum value of the values to add. If NAN is provided then the minimum value will be computed from the values.
 		* @param maximumValue			The maximum value of the values to add. If NAN is provided then the maximum value will be computed from the values.
 		*/
-		void pushBackFloatHdf5Array1dOfValues(const float * values, const ULONG64 & valueCount, COMMON_NS::AbstractHdfProxy* proxy,
+		DLL_IMPORT_OR_EXPORT void pushBackFloatHdf5Array1dOfValues(const float * values, const ULONG64 & valueCount, COMMON_NS::AbstractHdfProxy* proxy,
 			const float & minimumValue = std::numeric_limits<float>::quiet_NaN(), const float & maximumValue = std::numeric_limits<float>::quiet_NaN());
 
 		/**
@@ -200,7 +200,7 @@ namespace RESQML2_0_1_NS
 		* @param minimumValue			The minimum value of the values to add. If NAN is provided then the minimum value will be computed from the values.
 		* @param maximumValue			The maximum value of the values to add. If NAN is provided then the maximum value will be computed from the values.
 		*/
-		void pushBackFloatHdf5Array2dOfValues(const float * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy,
+		DLL_IMPORT_OR_EXPORT void pushBackFloatHdf5Array2dOfValues(const float * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy,
 			const float & minimumValue = std::numeric_limits<float>::quiet_NaN(), const float & maximumValue = std::numeric_limits<float>::quiet_NaN());
 
 		/**
@@ -213,7 +213,7 @@ namespace RESQML2_0_1_NS
 		* @param minimumValue			The minimum value of the values to add. If NAN is provided then the minimum value will be computed from the values.
 		* @param maximumValue			The maximum value of the values to add. If NAN is provided then the maximum value will be computed from the values.
 		*/
-		void pushBackFloatHdf5Array3dOfValues(const float * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInMiddleDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy,
+		DLL_IMPORT_OR_EXPORT void pushBackFloatHdf5Array3dOfValues(const float * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInMiddleDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy,
 			const float & minimumValue = std::numeric_limits<float>::quiet_NaN(), const float & maximumValue = std::numeric_limits<float>::quiet_NaN());
 
 		/**
@@ -225,7 +225,7 @@ namespace RESQML2_0_1_NS
 		* @param minimumValue			The minimum value (or value vector) of the values to add. If nullptr is provided and the dimension of value is 1 then the minimum value will be computed from the values.
 		* @param maximumValue			The maximum value (or value vector) of the values to add. If nullptr is provided and the dimension of value is 1 then the maximum value will be computed from the values.
 		*/
-		void pushBackFloatHdf5ArrayOfValues(const float * values, unsigned long long * numValues, const unsigned int & numArrayDimensions, COMMON_NS::AbstractHdfProxy* proxy,
+		DLL_IMPORT_OR_EXPORT void pushBackFloatHdf5ArrayOfValues(const float * values, unsigned long long * numValues, const unsigned int & numArrayDimensions, COMMON_NS::AbstractHdfProxy* proxy,
 			float * minimumValue = nullptr, float * maximumValue = nullptr);
 
 		/**
@@ -234,7 +234,7 @@ namespace RESQML2_0_1_NS
 		* @param numArrayDimensions		The number of dimensions of the array to write.
 		* @param proxy					The HDF proxy where to write the property values. It must be already opened for writing and won't be closed in this method.
 		*/
-		void pushBackFloatHdf5ArrayOfValues(
+		DLL_IMPORT_OR_EXPORT void pushBackFloatHdf5ArrayOfValues(
 			const unsigned long long* numValues,
 			const unsigned int& numArrayDimensions, 
 			COMMON_NS::AbstractHdfProxy* proxy
@@ -247,7 +247,7 @@ namespace RESQML2_0_1_NS
 		* @param valueCountInSlowestDim The number of values to write in the slowest dimension (mainly K dimension).
 		* @param proxy					The HDF proxy where to write the property values. It must be already opened for writing and won't be closed in this method.
 		*/
-		void pushBackFloatHdf5ArrayOfValues(
+		DLL_IMPORT_OR_EXPORT void pushBackFloatHdf5ArrayOfValues(
 			const ULONG64& valueCountInFastestDim,
 			const ULONG64& valueCountInMiddleDim,
 			const ULONG64& valueCountInSlowestDim,
@@ -267,7 +267,7 @@ namespace RESQML2_0_1_NS
 		* @param proxy					The HDF proxy where to write the property values. It must be already opened for writing and won't be closed in this method.
 		* @param patchIndex				The index of the patch we want to set some values. If not present, the last patch is arbitrarily taken into account.
 		*/
-		void setValuesOfFloatHdf5ArrayOfValues(
+		DLL_IMPORT_OR_EXPORT void setValuesOfFloatHdf5ArrayOfValues(
 			float* values, 
 			const ULONG64& valueCountInFastestDim,
 			const ULONG64& valueCountInMiddleDim,
@@ -289,7 +289,7 @@ namespace RESQML2_0_1_NS
 		* @param proxy					The HDF proxy where to write the property values. It must be already opened for writing and won't be closed in this method.
 		* @param patchIndex				The index of the patch we want to set some values.  If not present, the last patch is arbitrarily taken into account.
 		*/
-		void setValuesOfFloatHdf5ArrayOfValues(
+		DLL_IMPORT_OR_EXPORT void setValuesOfFloatHdf5ArrayOfValues(
 			float * values, 
 			unsigned long long * numValues,
 			unsigned long long * offsetValues,
@@ -306,21 +306,21 @@ namespace RESQML2_0_1_NS
 		* @param	nullValue			Only relevant for integer hdf5 datasets. Indeed, Resqml (and fesapi) forces null value for floating point ot be NaN value.
 		* @return	The name of the hdf5 dataset.
 		*/
-		std::string pushBackRefToExistingDataset(COMMON_NS::AbstractHdfProxy* hdfProxy, const std::string & datasetName = "", LONG64 nullValue = (std::numeric_limits<LONG64>::max)());
+		DLL_IMPORT_OR_EXPORT std::string pushBackRefToExistingDataset(COMMON_NS::AbstractHdfProxy* hdfProxy, const std::string & datasetName = "", LONG64 nullValue = (std::numeric_limits<LONG64>::max)());
 
 		/**
 		* Get all the values of a particular patch of the instance which are supposed to be double ones.
 		* @param patchIndex	The index of the patch we want the values from.
 		* @param values		The array (pointer) of values must be preallocated.
 		*/
-		void getDoubleValuesOfPatch(const unsigned int & patchIndex, double * values);
+		DLL_IMPORT_OR_EXPORT void getDoubleValuesOfPatch(const unsigned int & patchIndex, double * values);
 
 		/**
 		* Get all the values of a particular patch of the instance which are supposed to be float ones.
 		* @param patchIndex	The index of the patch we want the values from.
 		* @param values		The array (pointer) of values must be preallocated.
 		*/
-		void getFloatValuesOfPatch(const unsigned int & patchIndex, float * values);
+		DLL_IMPORT_OR_EXPORT void getFloatValuesOfPatch(const unsigned int & patchIndex, float * values);
 
 		/**
 		* Get some of the values of a particular patch of the instance which are supposed to be float ones. This method makes use of HDF5 hyperslabbing.
@@ -330,7 +330,7 @@ namespace RESQML2_0_1_NS
 		* @param offsetInEachDimension		The offset values ordered by dimension of the array to write.
 		* @param numArrayDimensions			The number of dimensions of the HDF5 array to read.
 		*/
-		void getFloatValuesOfPatch(
+		DLL_IMPORT_OR_EXPORT void getFloatValuesOfPatch(
 			const unsigned int& patchIndex, 
 			float* values, 
 			unsigned long long* numValuesInEachDimension,
@@ -349,7 +349,7 @@ namespace RESQML2_0_1_NS
 		* @param offsetInMiddleDim		The offset value to read in the middle dimension (mainly J dimension).
 		* @param offsetInSlowestDim		The offset value to read in the slowest dimension (mainly K dimension).
 		*/
-		void getFloatValuesOf3dPatch(
+		DLL_IMPORT_OR_EXPORT void getFloatValuesOf3dPatch(
 			const unsigned int& patchIndex, 
 			float* values, 
 			const ULONG64& valueCountInFastestDim,
@@ -364,13 +364,13 @@ namespace RESQML2_0_1_NS
 		* Get the minimum value in this continuous properties. It reads it from file.
 		* @return the minimum value if present in the file otherwise NaN.
 		*/
-		double getMinimumValue();
+		DLL_IMPORT_OR_EXPORT double getMinimumValue();
 
 		/*
 		* Get the maximum value in this discrete properties. It reads it from file.
 		* @return the maximum value if present in the file otherwise NaN.
 		*/
-		double getMaximumValue();
+		DLL_IMPORT_OR_EXPORT double getMaximumValue();
 
 		/**
 		* Check if the associated local property kind is allowed for this property.
@@ -462,4 +462,3 @@ namespace RESQML2_0_1_NS
 		}
 	};
 }
-

--- a/src/resqml2_0_1/ContinuousPropertySeries.h
+++ b/src/resqml2_0_1/ContinuousPropertySeries.h
@@ -26,7 +26,7 @@ namespace RESQML2_0_1_NS
 	* This class is mainly useful for describing temporal properties on well objects.
 	* The prefered approach to describe temporal properties on Reservoir grids is to use one instance of ContinuousProperty per time step.
 	*/
-	class DLL_IMPORT_OR_EXPORT ContinuousPropertySeries : public ContinuousProperty
+	class ContinuousPropertySeries : public ContinuousProperty
 	{
 	public:
 
@@ -79,10 +79,9 @@ namespace RESQML2_0_1_NS
 		*/
 		~ContinuousPropertySeries() {}
 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
 		std::string getResqmlVersion() const {return "2.0.1";}
 	};
 }
-

--- a/src/resqml2_0_1/DeviationSurveyRepresentation.h
+++ b/src/resqml2_0_1/DeviationSurveyRepresentation.h
@@ -29,7 +29,7 @@ namespace RESQML2_0_1_NS
 {
 	class WellboreTrajectoryRepresentation;
 
-	class DLL_IMPORT_OR_EXPORT DeviationSurveyRepresentation : public RESQML2_NS::AbstractRepresentation
+	class DeviationSurveyRepresentation : public RESQML2_NS::AbstractRepresentation
 	{
 	public:
 
@@ -56,8 +56,8 @@ namespace RESQML2_0_1_NS
 
 		~DeviationSurveyRepresentation() {}
 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
 		/*
 		*  Set the geometry of the representation by means of a parametric line without MD information.
@@ -71,7 +71,7 @@ namespace RESQML2_0_1_NS
 		* @param proxy							The HDF proxy which indicates in which HDF5 file the numerical values will be stored.
 		*										It must be already opened for writing and won't be closed.
 		*/
-		void setGeometry(double * firstStationLocation, const ULONG64 & stationCount,
+		DLL_IMPORT_OR_EXPORT void setGeometry(double * firstStationLocation, const ULONG64 & stationCount,
 			const gsoap_resqml2_0_1::eml20__LengthUom & mdUom, double * mds,
 			const gsoap_resqml2_0_1::eml20__PlaneAngleUom & angleUom, double * azimuths, double * inclinations,
 			COMMON_NS::AbstractHdfProxy* proxy);
@@ -79,7 +79,7 @@ namespace RESQML2_0_1_NS
 		/**
 		* Set the Md datum of this trajectory
 		*/
-		void setMdDatum(RESQML2_NS::MdDatum* mdDatum);
+		DLL_IMPORT_OR_EXPORT void setMdDatum(RESQML2_NS::MdDatum* mdDatum);
 
 		/**
 		* @return	null pointer if no md datum is associated to this representation. Otherwise return the data object reference of the associated md datum.
@@ -89,17 +89,17 @@ namespace RESQML2_0_1_NS
 		/**
 		* Getter of the md information associated to this WellboreFeature trajectory representation.
 		*/
-		RESQML2_NS::MdDatum * getMdDatum() const;
+		DLL_IMPORT_OR_EXPORT RESQML2_NS::MdDatum * getMdDatum() const;
 
 		/**
 		* Getter of the md information uuid associated to this WellboreFeature trajectory representation.
 		*/
-		std::string getMdDatumUuid() const;
+		DLL_IMPORT_OR_EXPORT std::string getMdDatumUuid() const;
 
 		/**
 		* Used to indicate that this is a final version of the deviation survey, as distinct from the interim interpretations.
 		*/
-		bool isFinal() const;
+		DLL_IMPORT_OR_EXPORT bool isFinal() const;
 
 		/**
 		* Get the xyz point count in a given patch.
@@ -111,12 +111,12 @@ namespace RESQML2_0_1_NS
 		* XYZ points are given in the local CRS.
 		* @param xyzPoints A linearized 2d array where the first (quickest) dimension is coordinate dimension (XYZ) and second dimension is vertex dimension. It must be pre allocated.
 		*/
-		void getXyzPointsOfPatch(const unsigned int & patchIndex, double * xyzPoints) const;
+		DLL_IMPORT_OR_EXPORT void getXyzPointsOfPatch(const unsigned int & patchIndex, double * xyzPoints) const;
 
 		/**
 		* Units of measure of the measured depths along this deviation survey.
 		*/
-		gsoap_resqml2_0_1::eml20__LengthUom getMdUom() const;
+		DLL_IMPORT_OR_EXPORT gsoap_resqml2_0_1::eml20__LengthUom getMdUom() const;
 
 		/**
 		* Defines the units of measure for the azimuth and inclination
@@ -128,14 +128,14 @@ namespace RESQML2_0_1_NS
 		* Uom is given by getMdUom().
 		* @param values	It must preallocated with a count of getXyzPointCountOfPatch(0)
 		*/
-		void getMdValues(double* values);
+		DLL_IMPORT_OR_EXPORT void getMdValues(double* values);
 
 		/**
 		* Getter of the inclination double values associated to each trajectory station of this WellboreFeature trajectory representation.
 		* Uom is given by getAngleUom().
 		* @param values	It must preallocated with a count of getXyzPointCountOfPatch(0)
 		*/
-		void getInclinations(double* values);
+		DLL_IMPORT_OR_EXPORT void getInclinations(double* values);
 
 		/**
 		* Getter of the azimuth double values associated to each trajectory station of this WellboreFeature trajectory representation.
@@ -143,47 +143,47 @@ namespace RESQML2_0_1_NS
 		* Uom is given by getAngleUom().
 		* @param values	It must preallocated with a count of getXyzPointCountOfPatch(0)
 		*/
-		void getAzimuths(double* values);
+		DLL_IMPORT_OR_EXPORT void getAzimuths(double* values);
 
 		/**
 		* Getter of all the wellbore frame representations of associated wellbore trajectory which share the same md datum and md uom.
 		*/
-		std::vector<class WellboreFrameRepresentation*> getWellboreFrameRepresentationSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<class WellboreFrameRepresentation*> getWellboreFrameRepresentationSet() const;
 
 		/**
 		* Get the count of all the wellbore frame representations of associated wellbore trajectory which share the same md datum and md uom.
 		* Necessary for now in SWIG context because I am not sure if I can always wrap a vector of polymorphic class yet.
 		*/
-		unsigned int getWellboreFrameRepresentationCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getWellboreFrameRepresentationCount() const;
 
 		/**
 		* Get a particular wellbore frame representation according to its position.
 		* Necessary for now in SWIG context because I am not sure if I can always wrap a vector of polymorphic class yet.
 		* Throw an out of bound exception if the index is superior or equal to the count of wellbore frame representation.
 		*/
-		class WellboreFrameRepresentation* getWellboreFrameRepresentation(unsigned int index) const;
+		DLL_IMPORT_OR_EXPORT class WellboreFrameRepresentation* getWellboreFrameRepresentation(unsigned int index) const;
 
 		/**
 		* Getter (in read only mode) of all the wellbore trajectories which are associated to this deviation survey.
 		*/
-		const std::vector<class WellboreTrajectoryRepresentation*>& getWellboreTrajectoryRepresentationSet() const;
+		DLL_IMPORT_OR_EXPORT const std::vector<class WellboreTrajectoryRepresentation*>& getWellboreTrajectoryRepresentationSet() const;
 
 		/**
 		* Get the count of all the wellbore trajectories which are associated to this deviation survey.
 		* Necessary for now in SWIG context because I am not sure if I can always wrap a vector of polymorphic class yet.
 		*/
-		unsigned int getWellboreTrajectoryRepresentationCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getWellboreTrajectoryRepresentationCount() const;
 
 		/**
 		* Get a particular wellbore trajectory according to its position.
 		* Necessary for now in SWIG context because I am not sure if I can always wrap a vector of polymorphic class yet.
 		* Throw an out of bound exception if the index is superior or equal to the count of wellbore frame representation.
 		*/
-		class WellboreTrajectoryRepresentation* getWellboreTrajectoryRepresentation(const unsigned int & index) const;
+		DLL_IMPORT_OR_EXPORT class WellboreTrajectoryRepresentation* getWellboreTrajectoryRepresentation(const unsigned int & index) const;
 
-		std::string getHdfProxyUuid() const;
+		DLL_IMPORT_OR_EXPORT std::string getHdfProxyUuid() const;
 
-		unsigned int getPatchCount() const {return 1;}
+		DLL_IMPORT_OR_EXPORT unsigned int getPatchCount() const {return 1;}
 
 	protected:
 
@@ -198,4 +198,3 @@ namespace RESQML2_0_1_NS
 		std::vector<class WellboreTrajectoryRepresentation*> wbTrajectoryRepSet;
 	};
 }
-

--- a/src/resqml2_0_1/DiscreteProperty.h
+++ b/src/resqml2_0_1/DiscreteProperty.h
@@ -26,7 +26,7 @@ namespace RESQML2_0_1_NS
 	* This class is mainly useful for describing temporal properties on well objects.
 	* The prefered approach to describe temporal properties on Reservoir grids is to use one instance of DiscreteProperty per time step.
 	*/
-	class DLL_IMPORT_OR_EXPORT DiscreteProperty : public RESQML2_NS::AbstractValuesProperty
+	class DiscreteProperty : public RESQML2_NS::AbstractValuesProperty
 	{
 	public:
 
@@ -71,8 +71,8 @@ namespace RESQML2_0_1_NS
 		*/
 		virtual ~DiscreteProperty() {}
 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
 		/**
 		* Add a 1d array of explicit long values to the property values.
@@ -82,14 +82,14 @@ namespace RESQML2_0_1_NS
 		* @param minimumValue			The minimum value of the values to add. If not provided then the minimum value will be computed from the values.
 		* @param maximumValue			The maximum value of the values to add. If not provided then the maximum value will be computed from the values.
 		*/
-		void pushBackLongHdf5Array1dOfValues(const long * values, const ULONG64 & valueCount, COMMON_NS::AbstractHdfProxy* proxy, const long & nullValue, const long & minimumValue, const long & maximumValue);
-		void pushBackLongHdf5Array1dOfValues(const long * values, const ULONG64 & valueCount, COMMON_NS::AbstractHdfProxy* proxy, const long & nullValue);
-		void pushBackIntHdf5Array1dOfValues(const int * values, const ULONG64 & valueCount, COMMON_NS::AbstractHdfProxy* proxy, const int & nullValue, const int & minimumValue, const int & maximumValue);
-		void pushBackIntHdf5Array1dOfValues(const int * values, const ULONG64 & valueCount, COMMON_NS::AbstractHdfProxy* proxy, const int & nullValue);
-		void pushBackShortHdf5Array1dOfValues(const short * values, const ULONG64 & valueCount, COMMON_NS::AbstractHdfProxy* proxy, const short & nullValue, const short & minimumValue, const short & maximumValue);
-		void pushBackShortHdf5Array1dOfValues(const short * values, const ULONG64 & valueCount, COMMON_NS::AbstractHdfProxy* proxy, const short & nullValue);
-		void pushBackCharHdf5Array1dOfValues(const char * values, const ULONG64 & valueCount, COMMON_NS::AbstractHdfProxy* proxy, const char & nullValue, const char & minimumValue, const char & maximumValue);
-		void pushBackCharHdf5Array1dOfValues(const char * values, const ULONG64 & valueCount, COMMON_NS::AbstractHdfProxy* proxy, const char & nullValue);
+		DLL_IMPORT_OR_EXPORT void pushBackLongHdf5Array1dOfValues(const long * values, const ULONG64 & valueCount, COMMON_NS::AbstractHdfProxy* proxy, const long & nullValue, const long & minimumValue, const long & maximumValue);
+		DLL_IMPORT_OR_EXPORT void pushBackLongHdf5Array1dOfValues(const long * values, const ULONG64 & valueCount, COMMON_NS::AbstractHdfProxy* proxy, const long & nullValue);
+		DLL_IMPORT_OR_EXPORT void pushBackIntHdf5Array1dOfValues(const int * values, const ULONG64 & valueCount, COMMON_NS::AbstractHdfProxy* proxy, const int & nullValue, const int & minimumValue, const int & maximumValue);
+		DLL_IMPORT_OR_EXPORT void pushBackIntHdf5Array1dOfValues(const int * values, const ULONG64 & valueCount, COMMON_NS::AbstractHdfProxy* proxy, const int & nullValue);
+		DLL_IMPORT_OR_EXPORT void pushBackShortHdf5Array1dOfValues(const short * values, const ULONG64 & valueCount, COMMON_NS::AbstractHdfProxy* proxy, const short & nullValue, const short & minimumValue, const short & maximumValue);
+		DLL_IMPORT_OR_EXPORT void pushBackShortHdf5Array1dOfValues(const short * values, const ULONG64 & valueCount, COMMON_NS::AbstractHdfProxy* proxy, const short & nullValue);
+		DLL_IMPORT_OR_EXPORT void pushBackCharHdf5Array1dOfValues(const char * values, const ULONG64 & valueCount, COMMON_NS::AbstractHdfProxy* proxy, const char & nullValue, const char & minimumValue, const char & maximumValue);
+		DLL_IMPORT_OR_EXPORT void pushBackCharHdf5Array1dOfValues(const char * values, const ULONG64 & valueCount, COMMON_NS::AbstractHdfProxy* proxy, const char & nullValue);
 
 		/**
 		* Add a 2d array of explicit long values to the property values.
@@ -100,16 +100,16 @@ namespace RESQML2_0_1_NS
 		* @param minimumValue			The minimum value of the values to add. If not provided then the minimum value will be computed from the values.
 		* @param maximumValue			The maximum value of the values to add. If not provided then the maximum value will be computed from the values.
 		*/
-		void pushBackLongHdf5Array2dOfValues(const long * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy, const long & nullValue, const long & minimumValue, const long & maximumValue);
-		void pushBackLongHdf5Array2dOfValues(const long * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy, const long & nullValue);
-		void pushBackIntHdf5Array2dOfValues(const int * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy, const int & nullValue, const int & minimumValue, const int & maximumValue);
-		void pushBackIntHdf5Array2dOfValues(const int * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy, const int & nullValue);
-		void pushBackShortHdf5Array2dOfValues(const short * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy, const short & nullValue, const short & minimumValue, const short & maximumValue);
-		void pushBackShortHdf5Array2dOfValues(const short * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy, const short & nullValue);
-		void pushBackUShortHdf5Array2dOfValues(const unsigned short * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy, const unsigned short & nullValue, const unsigned short & minimumValue, const unsigned short & maximumValue);
-		void pushBackUShortHdf5Array2dOfValues(const unsigned short * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy, const unsigned short & nullValue);
-		void pushBackCharHdf5Array2dOfValues(const char * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy, const char & nullValue, const char & minimumValue, const char & maximumValue);
-		void pushBackCharHdf5Array2dOfValues(const char * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy, const char & nullValue);
+		DLL_IMPORT_OR_EXPORT void pushBackLongHdf5Array2dOfValues(const long * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy, const long & nullValue, const long & minimumValue, const long & maximumValue);
+		DLL_IMPORT_OR_EXPORT void pushBackLongHdf5Array2dOfValues(const long * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy, const long & nullValue);
+		DLL_IMPORT_OR_EXPORT void pushBackIntHdf5Array2dOfValues(const int * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy, const int & nullValue, const int & minimumValue, const int & maximumValue);
+		DLL_IMPORT_OR_EXPORT void pushBackIntHdf5Array2dOfValues(const int * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy, const int & nullValue);
+		DLL_IMPORT_OR_EXPORT void pushBackShortHdf5Array2dOfValues(const short * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy, const short & nullValue, const short & minimumValue, const short & maximumValue);
+		DLL_IMPORT_OR_EXPORT void pushBackShortHdf5Array2dOfValues(const short * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy, const short & nullValue);
+		DLL_IMPORT_OR_EXPORT void pushBackUShortHdf5Array2dOfValues(const unsigned short * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy, const unsigned short & nullValue, const unsigned short & minimumValue, const unsigned short & maximumValue);
+		DLL_IMPORT_OR_EXPORT void pushBackUShortHdf5Array2dOfValues(const unsigned short * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy, const unsigned short & nullValue);
+		DLL_IMPORT_OR_EXPORT void pushBackCharHdf5Array2dOfValues(const char * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy, const char & nullValue, const char & minimumValue, const char & maximumValue);
+		DLL_IMPORT_OR_EXPORT void pushBackCharHdf5Array2dOfValues(const char * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy, const char & nullValue);
 
 		/**
 		* Add a 3d array of explicit long values to the property values.
@@ -121,16 +121,16 @@ namespace RESQML2_0_1_NS
 		* @param minimumValue			The minimum value of the values to add. If not provided then the minimum value will be computed from the values.
 		* @param maximumValue			The maximum value of the values to add. If not provided then the maximum value will be computed from the values.
 		*/
-		void pushBackLongHdf5Array3dOfValues(const long * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInMiddleDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy, const long & nullValue, const long & minimumValue, const long & maximumValue);
-		void pushBackLongHdf5Array3dOfValues(const long * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInMiddleDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy, const long & nullValue);
-		void pushBackIntHdf5Array3dOfValues(const int * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInMiddleDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy, const int & nullValue, const int & minimumValue, const int & maximumValue);
-		void pushBackIntHdf5Array3dOfValues(const int * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInMiddleDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy, const int & nullValue);
-		void pushBackShortHdf5Array3dOfValues(const short * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInMiddleDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy, const short & nullValue, const short & minimumValue, const short & maximumValue);
-		void pushBackShortHdf5Array3dOfValues(const short * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInMiddleDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy, const short & nullValue);
-		void pushBackUShortHdf5Array3dOfValues(const unsigned short * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInMiddleDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy, const unsigned short & nullValue, const unsigned short & minimumValue, const unsigned short & maximumValue);
-		void pushBackUShortHdf5Array3dOfValues(const unsigned short * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInMiddleDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy, const unsigned short & nullValue);
-		void pushBackCharHdf5Array3dOfValues(const char * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInMiddleDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy, const char & nullValue, const char & minimumValue, const char & maximumValue);
-		void pushBackCharHdf5Array3dOfValues(const char * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInMiddleDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy, const char & nullValue);
+		DLL_IMPORT_OR_EXPORT void pushBackLongHdf5Array3dOfValues(const long * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInMiddleDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy, const long & nullValue, const long & minimumValue, const long & maximumValue);
+		DLL_IMPORT_OR_EXPORT void pushBackLongHdf5Array3dOfValues(const long * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInMiddleDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy, const long & nullValue);
+		DLL_IMPORT_OR_EXPORT void pushBackIntHdf5Array3dOfValues(const int * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInMiddleDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy, const int & nullValue, const int & minimumValue, const int & maximumValue);
+		DLL_IMPORT_OR_EXPORT void pushBackIntHdf5Array3dOfValues(const int * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInMiddleDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy, const int & nullValue);
+		DLL_IMPORT_OR_EXPORT void pushBackShortHdf5Array3dOfValues(const short * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInMiddleDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy, const short & nullValue, const short & minimumValue, const short & maximumValue);
+		DLL_IMPORT_OR_EXPORT void pushBackShortHdf5Array3dOfValues(const short * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInMiddleDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy, const short & nullValue);
+		DLL_IMPORT_OR_EXPORT void pushBackUShortHdf5Array3dOfValues(const unsigned short * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInMiddleDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy, const unsigned short & nullValue, const unsigned short & minimumValue, const unsigned short & maximumValue);
+		DLL_IMPORT_OR_EXPORT void pushBackUShortHdf5Array3dOfValues(const unsigned short * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInMiddleDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy, const unsigned short & nullValue);
+		DLL_IMPORT_OR_EXPORT void pushBackCharHdf5Array3dOfValues(const char * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInMiddleDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy, const char & nullValue, const char & minimumValue, const char & maximumValue);
+		DLL_IMPORT_OR_EXPORT void pushBackCharHdf5Array3dOfValues(const char * values, const ULONG64 & valueCountInFastestDim, const ULONG64 & valueCountInMiddleDim, const ULONG64 & valueCountInSlowestDim, COMMON_NS::AbstractHdfProxy* proxy, const char & nullValue);
 
 		/**
 		* Add an array (potentially multi dimensions) of explicit values to the property values.
@@ -141,16 +141,16 @@ namespace RESQML2_0_1_NS
 		* @param minimumValue			The minimum value of the values to add. If not provided then the minimum value will be computed from the values.
 		* @param maximumValue			The maximum value of the values to add. If not provided then the maximum value will be computed from the values.
 		*/
-		void pushBackLongHdf5ArrayOfValues(const long * values, unsigned long long * numValues, const unsigned int & numDimensionsInArray, COMMON_NS::AbstractHdfProxy* proxy, const long & nullValue, const long & minimumValue, const long & maximumValue);
-		void pushBackLongHdf5ArrayOfValues(const long * values, unsigned long long * numValues, const unsigned int & numDimensionsInArray, COMMON_NS::AbstractHdfProxy* proxy, const long & nullValue);
-		void pushBackIntHdf5ArrayOfValues(const int * values, unsigned long long * numValues, const unsigned int & numDimensionsInArray, COMMON_NS::AbstractHdfProxy* proxy, const int & nullValue, const int & minimumValue, const int & maximumValue);
-		void pushBackIntHdf5ArrayOfValues(const int * values, unsigned long long * numValues, const unsigned int & numDimensionsInArray, COMMON_NS::AbstractHdfProxy* proxy, const int & nullValue);
-		void pushBackShortHdf5ArrayOfValues(const short * values, unsigned long long * numValues, const unsigned int & numDimensionsInArray, COMMON_NS::AbstractHdfProxy* proxy, const short & nullValue, const short & minimumValue, const short & maximumValue);
-		void pushBackShortHdf5ArrayOfValues(const short * values, unsigned long long * numValues, const unsigned int & numDimensionsInArray, COMMON_NS::AbstractHdfProxy* proxy, const short & nullValue);
-		void pushBackUShortHdf5ArrayOfValues(const unsigned short * values, unsigned long long * numValues, const unsigned int & numDimensionsInArray, COMMON_NS::AbstractHdfProxy* proxy, const unsigned short & nullValue, const unsigned short & minimumValue, const unsigned short & maximumValue);
-		void pushBackUShortHdf5ArrayOfValues(const unsigned short * values, unsigned long long * numValues, const unsigned int & numDimensionsInArray, COMMON_NS::AbstractHdfProxy* proxy, const unsigned short & nullValue);
-		void pushBackCharHdf5ArrayOfValues(const char * values, unsigned long long * numValues, const unsigned int & numDimensionsInArray, COMMON_NS::AbstractHdfProxy* proxy, const char & nullValue, const char & minimumValue, const char & maximumValue);
-		void pushBackCharHdf5ArrayOfValues(const char * values, unsigned long long * numValues, const unsigned int & numDimensionsInArray, COMMON_NS::AbstractHdfProxy* proxy, const char & nullValue);
+		DLL_IMPORT_OR_EXPORT void pushBackLongHdf5ArrayOfValues(const long * values, unsigned long long * numValues, const unsigned int & numDimensionsInArray, COMMON_NS::AbstractHdfProxy* proxy, const long & nullValue, const long & minimumValue, const long & maximumValue);
+		DLL_IMPORT_OR_EXPORT void pushBackLongHdf5ArrayOfValues(const long * values, unsigned long long * numValues, const unsigned int & numDimensionsInArray, COMMON_NS::AbstractHdfProxy* proxy, const long & nullValue);
+		DLL_IMPORT_OR_EXPORT void pushBackIntHdf5ArrayOfValues(const int * values, unsigned long long * numValues, const unsigned int & numDimensionsInArray, COMMON_NS::AbstractHdfProxy* proxy, const int & nullValue, const int & minimumValue, const int & maximumValue);
+		DLL_IMPORT_OR_EXPORT void pushBackIntHdf5ArrayOfValues(const int * values, unsigned long long * numValues, const unsigned int & numDimensionsInArray, COMMON_NS::AbstractHdfProxy* proxy, const int & nullValue);
+		DLL_IMPORT_OR_EXPORT void pushBackShortHdf5ArrayOfValues(const short * values, unsigned long long * numValues, const unsigned int & numDimensionsInArray, COMMON_NS::AbstractHdfProxy* proxy, const short & nullValue, const short & minimumValue, const short & maximumValue);
+		DLL_IMPORT_OR_EXPORT void pushBackShortHdf5ArrayOfValues(const short * values, unsigned long long * numValues, const unsigned int & numDimensionsInArray, COMMON_NS::AbstractHdfProxy* proxy, const short & nullValue);
+		DLL_IMPORT_OR_EXPORT void pushBackUShortHdf5ArrayOfValues(const unsigned short * values, unsigned long long * numValues, const unsigned int & numDimensionsInArray, COMMON_NS::AbstractHdfProxy* proxy, const unsigned short & nullValue, const unsigned short & minimumValue, const unsigned short & maximumValue);
+		DLL_IMPORT_OR_EXPORT void pushBackUShortHdf5ArrayOfValues(const unsigned short * values, unsigned long long * numValues, const unsigned int & numDimensionsInArray, COMMON_NS::AbstractHdfProxy* proxy, const unsigned short & nullValue);
+		DLL_IMPORT_OR_EXPORT void pushBackCharHdf5ArrayOfValues(const char * values, unsigned long long * numValues, const unsigned int & numDimensionsInArray, COMMON_NS::AbstractHdfProxy* proxy, const char & nullValue, const char & minimumValue, const char & maximumValue);
+		DLL_IMPORT_OR_EXPORT void pushBackCharHdf5ArrayOfValues(const char * values, unsigned long long * numValues, const unsigned int & numDimensionsInArray, COMMON_NS::AbstractHdfProxy* proxy, const char & nullValue);
 
 		/**
 		* Push back a a reference to an existing (or a "to exist") HDF5 dataset in a particular hdf proxy.
@@ -162,8 +162,8 @@ namespace RESQML2_0_1_NS
 		* @param	maximumValue			The maximum value of the values in the HDF5 dataset.
 		* @return	The name of the referenced HDF5 dataset.
 		*/
-		std::string pushBackRefToExistingDataset(COMMON_NS::AbstractHdfProxy* proxy, const std::string & datasetName, LONG64 nullValue, LONG64 minimumValue, LONG64 maximumValue);
-		std::string pushBackRefToExistingDataset(COMMON_NS::AbstractHdfProxy* hdfProxy, const std::string & dataset = "", LONG64 nullValue = (std::numeric_limits<LONG64>::max)());
+		DLL_IMPORT_OR_EXPORT std::string pushBackRefToExistingDataset(COMMON_NS::AbstractHdfProxy* proxy, const std::string & datasetName, LONG64 nullValue, LONG64 minimumValue, LONG64 maximumValue);
+		DLL_IMPORT_OR_EXPORT std::string pushBackRefToExistingDataset(COMMON_NS::AbstractHdfProxy* hdfProxy, const std::string & dataset = "", LONG64 nullValue = (std::numeric_limits<LONG64>::max)());
 
 		/**
 		* Check if the associated local property kind is allowed for this property.
@@ -179,13 +179,12 @@ namespace RESQML2_0_1_NS
 		* Get the minimum value in this discrete properties. It reads it from file.
 		* @return the minimum value if present in the file otherwise long.max.
 		*/
-		LONG64 getMinimumValue();
+		DLL_IMPORT_OR_EXPORT LONG64 getMinimumValue();
 
 		/*
 		* Get the maximum value in this discrete properties. It reads it from file.
 		* @return the maximum value if present in the file otherwise long.min.
 		*/
-		LONG64 getMaximumValue();
+		DLL_IMPORT_OR_EXPORT LONG64 getMaximumValue();
 	};
 }
-

--- a/src/resqml2_0_1/DiscretePropertySeries.h
+++ b/src/resqml2_0_1/DiscretePropertySeries.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT DiscretePropertySeries : public DiscreteProperty
+	class DiscretePropertySeries : public DiscreteProperty
 	{
 	public:
 
@@ -73,10 +73,9 @@ namespace RESQML2_0_1_NS
 		*/
 		~DiscretePropertySeries() {}
 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
 		std::string getResqmlVersion() const {return "2.0.1";}
 	};
 }
-

--- a/src/resqml2_0_1/FaultInterpretation.h
+++ b/src/resqml2_0_1/FaultInterpretation.h
@@ -23,7 +23,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT FaultInterpretation : public BoundaryFeatureInterpretation
+	class FaultInterpretation : public BoundaryFeatureInterpretation
 	{
 	public:
 
@@ -61,15 +61,15 @@ namespace RESQML2_0_1_NS
 		*/
 		~FaultInterpretation() {}
 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 		
 		/**
 		 * Pushes back a new throw interpretation for this fault interpretation.
 		 * More than one throw kind is necessary if for example the throw is reverse at a time period and then normal at another time period.
 		 * TODO : add a parameter to be able to indicate the time period the throw occured.
 		 */
-		void pushBackThrowInterpretation(const gsoap_resqml2_0_1::resqml2__ThrowKind & throwKind);
+		DLL_IMPORT_OR_EXPORT void pushBackThrowInterpretation(const gsoap_resqml2_0_1::resqml2__ThrowKind & throwKind);
 
 	private:
 		
@@ -81,4 +81,3 @@ namespace RESQML2_0_1_NS
 		friend void StructuralOrganizationInterpretation::pushBackFaultInterpretation(FaultInterpretation * faultInterpretation);
 	};
 }
-

--- a/src/resqml2_0_1/FrontierFeature.h
+++ b/src/resqml2_0_1/FrontierFeature.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT FrontierFeature : public AbstractTechnicalFeature
+	class FrontierFeature : public AbstractTechnicalFeature
 	{
 	public:
 
@@ -49,8 +49,7 @@ namespace RESQML2_0_1_NS
 		*/
 		~FrontierFeature() {}
 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 	};
 }
-

--- a/src/resqml2_0_1/GenericFeatureInterpretation.h
+++ b/src/resqml2_0_1/GenericFeatureInterpretation.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT GenericFeatureInterpretation : public RESQML2_NS::AbstractFeatureInterpretation
+	class GenericFeatureInterpretation : public RESQML2_NS::AbstractFeatureInterpretation
 	{
 	public:
 
@@ -43,8 +43,7 @@ namespace RESQML2_0_1_NS
 
 		~GenericFeatureInterpretation() {}
 	
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 	};
 }
-

--- a/src/resqml2_0_1/GeneticBoundaryFeature.h
+++ b/src/resqml2_0_1/GeneticBoundaryFeature.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT GeneticBoundaryFeature : public BoundaryFeature
+	class GeneticBoundaryFeature : public BoundaryFeature
 	{
 	protected :
 
@@ -54,25 +54,24 @@ namespace RESQML2_0_1_NS
 		/**
 		* Indicates wether the instance is an horizon (or a geobody boundary). This public method is especially needed for SWIG reason.
 		*/
-		bool isAnHorizon() const;
+		DLL_IMPORT_OR_EXPORT bool isAnHorizon() const;
 
 		/**
 		* Sets the age of the isntance.
 		*/
-		void setAge(unsigned int age);
+		DLL_IMPORT_OR_EXPORT void setAge(unsigned int age);
 
 		/**
 		* Indicates if the instance has got an age or not.
 		*/
-		bool hasAnAge() const;
+		DLL_IMPORT_OR_EXPORT bool hasAnAge() const;
 
 		/**
 		* @return	The age of the horizon.
 		*/
-		ULONG64 getAge() const;
+		DLL_IMPORT_OR_EXPORT ULONG64 getAge() const;
 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 	};
 }
-

--- a/src/resqml2_0_1/GeobodyBoundaryInterpretation.h
+++ b/src/resqml2_0_1/GeobodyBoundaryInterpretation.h
@@ -24,7 +24,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT GeobodyBoundaryInterpretation : public BoundaryFeatureInterpretation
+	class GeobodyBoundaryInterpretation : public BoundaryFeatureInterpretation
 	{
 	public:
 
@@ -54,8 +54,7 @@ namespace RESQML2_0_1_NS
 		*/
 		~GeobodyBoundaryInterpretation() {}
 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 	};
 }
-

--- a/src/resqml2_0_1/GeobodyFeature.h
+++ b/src/resqml2_0_1/GeobodyFeature.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT GeobodyFeature : public GeologicUnitFeature
+	class GeobodyFeature : public GeologicUnitFeature
 	{
 	public:
 
@@ -49,8 +49,7 @@ namespace RESQML2_0_1_NS
 		*/
 		~GeobodyFeature() {}
 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 	};
 }
-

--- a/src/resqml2_0_1/GeobodyInterpretation.h
+++ b/src/resqml2_0_1/GeobodyInterpretation.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT GeobodyInterpretation : public RESQML2_NS::AbstractFeatureInterpretation
+	class GeobodyInterpretation : public RESQML2_NS::AbstractFeatureInterpretation
 	{
 	public:
 
@@ -52,20 +52,19 @@ namespace RESQML2_0_1_NS
 		/**
 		* Set the geobody 3d shape
 		*/
-		void set3dShape(gsoap_resqml2_0_1::resqml2__Geobody3dShape geobody3dShape);
+		DLL_IMPORT_OR_EXPORT void set3dShape(gsoap_resqml2_0_1::resqml2__Geobody3dShape geobody3dShape);
 
 		/**
 		* check if the 3d shape of this geobody is known
 		*/
-		bool has3dShape() const;
+		DLL_IMPORT_OR_EXPORT bool has3dShape() const;
 
 		/**
 		* get the 3d shape of this geobody
 		*/
-		gsoap_resqml2_0_1::resqml2__Geobody3dShape get3dShape() const;
+		DLL_IMPORT_OR_EXPORT gsoap_resqml2_0_1::resqml2__Geobody3dShape get3dShape() const;
 			
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 	};
 }
-

--- a/src/resqml2_0_1/GeologicUnitFeature.h
+++ b/src/resqml2_0_1/GeologicUnitFeature.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT GeologicUnitFeature : public AbstractGeologicFeature
+	class GeologicUnitFeature : public AbstractGeologicFeature
 	{
 	protected :
 
@@ -50,8 +50,7 @@ namespace RESQML2_0_1_NS
 		GeologicUnitFeature(gsoap_resqml2_0_1::_resqml2__GeologicUnitFeature* fromGsoap): AbstractGeologicFeature(fromGsoap) {}
 		virtual ~GeologicUnitFeature() {}
 	
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 	};
 }
-

--- a/src/resqml2_0_1/Grid2dRepresentation.h
+++ b/src/resqml2_0_1/Grid2dRepresentation.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT Grid2dRepresentation : public AbstractSurfaceRepresentation
+	class Grid2dRepresentation : public AbstractSurfaceRepresentation
 	{
 	private :
 		gsoap_resqml2_0_1::resqml2__PointGeometry* getPointGeometry2_0_1(const unsigned int & patchIndex) const;
@@ -70,88 +70,88 @@ namespace RESQML2_0_1_NS
 		*/
 		~Grid2dRepresentation() {}
 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
-		std::string getHdfProxyUuid() const;
+		DLL_IMPORT_OR_EXPORT std::string getHdfProxyUuid() const;
 
 		/**
 		* Get the number of nodes in the I direction of the lattice 2d grid
 		*/
-		ULONG64 getNodeCountAlongIAxis() const;
+		DLL_IMPORT_OR_EXPORT ULONG64 getNodeCountAlongIAxis() const;
 
 		/**
 		* Get the number of nodes in the J direction of the lattice 2d grid
 		*/
-		ULONG64 getNodeCountAlongJAxis() const;
+		DLL_IMPORT_OR_EXPORT ULONG64 getNodeCountAlongJAxis() const;
 
 		/**
 		* Get the xyz point count in a given patch.
 		*/
-		ULONG64 getXyzPointCountOfPatch(const unsigned int & patchIndex) const;
+		DLL_IMPORT_OR_EXPORT ULONG64 getXyzPointCountOfPatch(const unsigned int & patchIndex) const;
 
 		/**
 		* Get all the XYZ points of a particular patch of this representation.
 		* XYZ points are given in the local CRS.
 		* @param xyzPoints A linearized 2d array where the first (quickest) dimension is coordinate dimension (XYZ) and second dimension is vertex dimension. It must be pre allocated.
 		*/
-		void getXyzPointsOfPatch(const unsigned int & patchIndex, double * xyzPoints) const;
+		DLL_IMPORT_OR_EXPORT void getXyzPointsOfPatch(const unsigned int & patchIndex, double * xyzPoints) const;
 
 		/**
 		* Get all the z values of a patch located at a specific index of the geometry points.
 		* Z Values are given in the local CRS.
 		* @param values		All the z values of the selected patch. i dimension is the quickest. It must be preallocated and won't be freed by this method. Its size must be equel to getNodeCountAlongIAxis() * getNodeCountAlongJAxis().
 		*/
-		void getZValues(double * values) const;
+		DLL_IMPORT_OR_EXPORT void getZValues(double * values) const;
 
 		/**
 		* Get all the z values of a patch located at a specific index of the geometry points.
 		* Z Values are given in the global CRS.
 		* @param values		All the z values of the selected patch. i dimension is the quickest. It must be preallocated and won't be freed by this method. Its size must be equel to getNodeCountAlongIAxis() * getNodeCountAlongJAxis().
 		*/
-		void getZValuesInGlobalCrs(double * values) const;
+		DLL_IMPORT_OR_EXPORT void getZValuesInGlobalCrs(double * values) const;
 
 		/**
 		* Get the X origin of this geometry.
 		* X coordinate is given in the local CRS.
 		* @return				A double.NAN coordinate if something's wrong. The X origin point otherwise.
 		*/
-		double getXOrigin() const;
+		DLL_IMPORT_OR_EXPORT double getXOrigin() const;
 
 		/**
 		* Get the Y origin of this geometry.
 		* Y coordinate is given in the local CRS.
 		* @return				A double.NAN coordinate if something's wrong. The Y origin point otherwise.
 		*/
-		double getYOrigin() const;
+		DLL_IMPORT_OR_EXPORT double getYOrigin() const;
 
 		/**
 		* Get the Z origin of this geometry.
 		* Z coordinate is given in the local CRS.
 		* @return				A double.NAN coordinate if something's wrong. The Z origin point otherwise.
 		*/
-		double getZOrigin() const;
+		DLL_IMPORT_OR_EXPORT double getZOrigin() const;
 
 		/**
 		* Get the X origin of this geometry.
 		* X coordinate is given in the global CRS.
 		* @return				A double.NAN coordinate if something's wrong. The X origin point otherwise.
 		*/
-		double getXOriginInGlobalCrs() const;
+		DLL_IMPORT_OR_EXPORT double getXOriginInGlobalCrs() const;
 
 		/**
 		* Get the Y origin of this geometry.
 		* Y coordinate is given in the global CRS.
 		* @return				A double.NAN coordinate if something's wrong. The Y origin point otherwise.
 		*/
-		double getYOriginInGlobalCrs() const;
+		DLL_IMPORT_OR_EXPORT double getYOriginInGlobalCrs() const;
 
 		/**
 		* Get the Z origin of this geometry.
 		* Z coordinate is given in the global CRS.
 		* @return				A double.NAN coordinate if something's wrong. The Z origin point otherwise.
 		*/
-		double getZOriginInGlobalCrs() const;
+		DLL_IMPORT_OR_EXPORT double getZOriginInGlobalCrs() const;
 
 		/**
 		* Get the X (in local crs) offset on the J axis.
@@ -160,7 +160,7 @@ namespace RESQML2_0_1_NS
 		* X coordinate is given in the local CRS.
 		* @return				A double.NAN coordinate if something's wrong. The X offset point otherwise.
 		*/
-		double getXJOffset() const;
+		DLL_IMPORT_OR_EXPORT double getXJOffset() const;
 
 		/**
 		* Get the Y (in local crs) offset on the J axis.
@@ -169,7 +169,7 @@ namespace RESQML2_0_1_NS
 		* Y coordinate is given in the local CRS.
 		* @return				A double.NAN coordinate if something's wrong. The Y offset point otherwise.
 		*/
-		double getYJOffset() const;
+		DLL_IMPORT_OR_EXPORT double getYJOffset() const;
 
 		/**
 		* Get the Z (in local crs) offset on the J axis.
@@ -178,112 +178,112 @@ namespace RESQML2_0_1_NS
 		* Z coordinate is given in the local CRS.
 		* @return				A double.NAN coordinate if something's wrong. The Z offset point otherwise.
 		*/
-		double getZJOffset() const;
+		DLL_IMPORT_OR_EXPORT double getZJOffset() const;
 
 		/**
 		* Get the X (in global crs) offset between two consecutive nodes lying on the J axis.
 		* X coordinate is given in the global CRS.
 		* @return				A double.NAN coordinate if something's wrong. The X offset point otherwise.
 		*/
-		double getXJOffsetInGlobalCrs() const;
+		DLL_IMPORT_OR_EXPORT double getXJOffsetInGlobalCrs() const;
 
 		/**
 		* Get the Y (in global crs) offset between two consecutive nodes lying on the J axis.
 		* Y coordinate is given in the global CRS.
 		* @return				A double.NAN coordinate if something's wrong. The Y offset point otherwise.
 		*/
-		double getYJOffsetInGlobalCrs() const;
+		DLL_IMPORT_OR_EXPORT double getYJOffsetInGlobalCrs() const;
 
 		/**
 		* Get the Z (in global crs) offset between two consecutive nodes lying on the J axis.
 		* Z coordinate is given in the global CRS.
 		* @return				A double.NAN coordinate if something's wrong. The Z offset point otherwise.
 		*/
-		double getZJOffsetInGlobalCrs() const;
+		DLL_IMPORT_OR_EXPORT double getZJOffsetInGlobalCrs() const;
 
 		/**
 		* Get the X (in local crs) offset between two consecutive nodes lying on the I axis.
 		* X coordinate is given in the local CRS.
 		* @return				A double.NAN coordinate if something's wrong. The X offset point otherwise.
 		*/
-		double getXIOffset() const;
+		DLL_IMPORT_OR_EXPORT double getXIOffset() const;
 
 		/**
 		* Get the Y (in local crs) offset between two consecutive nodes lying on the I axis.
 		* Y coordinate is given in the local CRS.
 		* @return				A double.NAN coordinate if something's wrong. The Y offset point otherwise.
 		*/
-		double getYIOffset() const;
+		DLL_IMPORT_OR_EXPORT double getYIOffset() const;
 
 		/**
 		* Get the Z (in local crs) offset between two consecutive nodes lying on the I axis.
 		* Z coordinate is given in the local CRS.
 		* @return				A double.NAN coordinate if something's wrong. The Z offset point otherwise.
 		*/
-		double getZIOffset() const;
+		DLL_IMPORT_OR_EXPORT double getZIOffset() const;
 
 		/**
 		* Get the X (in global crs) offset between two consecutive nodes lying on the I axis.
 		* X coordinate is given in the global CRS.
 		* @return				A double.NAN coordinate if something's wrong. The X offset point otherwise.
 		*/
-		double getXIOffsetInGlobalCrs() const;
+		DLL_IMPORT_OR_EXPORT double getXIOffsetInGlobalCrs() const;
 
 		/**
 		* Get the Y (in global crs) offset between two consecutive nodes lying on the I axis.
 		* Y coordinate is given in the global CRS.
 		* @return				A double.NAN coordinate if something's wrong. The Y offset point otherwise.
 		*/
-		double getYIOffsetInGlobalCrs() const;
+		DLL_IMPORT_OR_EXPORT double getYIOffsetInGlobalCrs() const;
 
 		/**
 		* Get the Z (in global crs) offset between two consecutive nodes lying on the I axis.
 		* Z coordinate is given in the global CRS.
 		* @return				A double.NAN coordinate if something's wrong. The Z offset point otherwise.
 		*/
-		double getZIOffsetInGlobalCrs() const;
+		DLL_IMPORT_OR_EXPORT double getZIOffsetInGlobalCrs() const;
 
 		/**
 		* Checkes wether the spacing between nodes on J dimension is constant or not.
 		*/
-		bool isJSpacingConstant() const;
+		DLL_IMPORT_OR_EXPORT bool isJSpacingConstant() const;
 
 		/**
 		* Checkes wether the spacing between nodes on I dimension is constant or not.
 		*/
-		bool isISpacingConstant() const;
+		DLL_IMPORT_OR_EXPORT bool isISpacingConstant() const;
 		
 		/**
 		* Get the constant J (fastest) spacing of this 2d grid representation.
 		* @return	The constant spacing in the J direction of the 2d grid representation.
 		*/
-		double getJSpacing() const;
+		DLL_IMPORT_OR_EXPORT double getJSpacing() const;
 
 		/**
 		* Get all the J (fastest) spacings of this 2d grid representation.
 		* @param jSpacings	The count of this array should be getNodeCountAlongJAxis - 1. It must be preallocated and won't be freed by this method.
 		* @return			All the spacings in the J direction of the 2d grid representation.
 		*/
-		void getJSpacing(double* const jSpacings) const;
+		DLL_IMPORT_OR_EXPORT void getJSpacing(double* const jSpacings) const;
 
 		/**
 		* Get the constant I (slowest) spacing of this 2d grid representation.
 		* @return	The constant spacing in the I direction of the 2d grid representation.
 		*/
-		double getISpacing() const;
+		DLL_IMPORT_OR_EXPORT double getISpacing() const;
 
 		/**
 		* Get all the I (fastest) spacings of this 2d grid representation.
 		* @param iSpacings	The count of this array shouhd be getNodeCountAlongIAxis - 1. It must be preallocated and won't be freed by this method.
 		* @return			All the spacings in the I direction of the 2d grid representation.
 		*/
-		void getISpacing(double* const iSpacings) const;
+		DLL_IMPORT_OR_EXPORT void getISpacing(double* const iSpacings) const;
 
 		/**
 		* Set the geometry patch for a lattice 2d grid.
 		* The set geometry is an array 2d of lattice points3d.
 		*/
-		void setGeometryAsArray2dOfLatticePoints3d(
+		DLL_IMPORT_OR_EXPORT void setGeometryAsArray2dOfLatticePoints3d(
 			const unsigned int & numPointsInFastestDirection, const unsigned int & numPointsInSlowestDirection,
 			const double & xOrigin, const double & yOrigin, const double & zOrigin,
 			const double & xOffsetInFastestDirection, const double & yOffsetInFastestDirection, const double & zOffsetInFastestDirection,
@@ -294,7 +294,7 @@ namespace RESQML2_0_1_NS
 		* Set the geometry patch for a lattice 2d grid.
 		* The set geometry is an array 2d of explicit Z based on an existing representation
 		*/
-		void setGeometryAsArray2dOfExplicitZ(
+		DLL_IMPORT_OR_EXPORT void setGeometryAsArray2dOfExplicitZ(
 				double * zValues,
 				const unsigned int & numI, const unsigned int & numJ, COMMON_NS::AbstractHdfProxy* proxy,
 				Grid2dRepresentation * supportingGrid2dRepresentation,
@@ -305,7 +305,7 @@ namespace RESQML2_0_1_NS
 		* Set the geometry patch for a lattice 2d grid.
 		* The set geometry is an array 2d of explicit Z.
 		*/
-		void setGeometryAsArray2dOfExplicitZ(
+		DLL_IMPORT_OR_EXPORT void setGeometryAsArray2dOfExplicitZ(
 				double * zValues,
 				const unsigned int & numI, const unsigned int & numJ, COMMON_NS::AbstractHdfProxy* proxy,
 				const double & originX, const double & originY, const double & originZ,
@@ -316,35 +316,35 @@ namespace RESQML2_0_1_NS
 		* Get the supporting representation uuid of this representation.
 		* Useful when the supporting representation is not accessible. At least we know its uuid.
 		*/
-		std::string getSupportingRepresentationUuid() const;
+		DLL_IMPORT_OR_EXPORT std::string getSupportingRepresentationUuid() const;
 
 		/**
 		* Get the supporting representation of this representation
 		*/
-		Grid2dRepresentation*  getSupportingRepresentation() {return supportingRepresentation;}
+		DLL_IMPORT_OR_EXPORT Grid2dRepresentation*  getSupportingRepresentation() {return supportingRepresentation;}
 
 		/**
 		* Get the index of the origin of the current geometry on the supporting representation.
 		* The index is given by means of the formula iOrigin + jOrigin*iNodeCountOnSupportingRepresentation
 		*/
-		int getIndexOriginOnSupportingRepresentation() const;
+		DLL_IMPORT_OR_EXPORT int getIndexOriginOnSupportingRepresentation() const;
 
 		/**
 		* Get the index of the origin of the current geometry on a particular dimension of the supporting representation.
 		*/
-		int getIndexOriginOnSupportingRepresentation(const unsigned int & dimension) const;
+		DLL_IMPORT_OR_EXPORT int getIndexOriginOnSupportingRepresentation(const unsigned int & dimension) const;
 
 		/**
 		* Get the number of nodes of the current geometry which is extracted from a particular dimension of the supporting representation.
 		*/
-		int getNodeCountOnSupportingRepresentation(const unsigned int & dimension) const;
+		DLL_IMPORT_OR_EXPORT int getNodeCountOnSupportingRepresentation(const unsigned int & dimension) const;
 
 		/**
 		* Get the index offset of the nodes of the current geometry on a particular dimension of the supporting representation.
 		*/
-		int getIndexOffsetOnSupportingRepresentation(const unsigned int & dimension) const;
+		DLL_IMPORT_OR_EXPORT int getIndexOffsetOnSupportingRepresentation(const unsigned int & dimension) const;
 
-		unsigned int getPatchCount() const {return 1;}
+		DLL_IMPORT_OR_EXPORT unsigned int getPatchCount() const {return 1;}
 
 	private:
 		std::vector<epc::Relationship> getAllEpcRelationships() const;
@@ -357,4 +357,3 @@ namespace RESQML2_0_1_NS
 		std::vector<AbstractRepresentation *> supportedRepresentationSet;
 	};
 }
-

--- a/src/resqml2_0_1/GridConnectionSetRepresentation.h
+++ b/src/resqml2_0_1/GridConnectionSetRepresentation.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT GridConnectionSetRepresentation : public RESQML2_NS::GridConnectionSetRepresentation
+	class GridConnectionSetRepresentation : public RESQML2_NS::GridConnectionSetRepresentation
 	{
 	protected:
 		void init(soap* soapContext, const std::string & guid, const std::string & title);
@@ -76,45 +76,45 @@ namespace RESQML2_0_1_NS
 		*/
 		~GridConnectionSetRepresentation() {}
 
-		std::string getHdfProxyUuid() const;
+		DLL_IMPORT_OR_EXPORT std::string getHdfProxyUuid() const;
 
 		/**
 		* Get the cell index pair count of this grid connection representation
 		*/
-		ULONG64 getCellIndexPairCount() const;
+		DLL_IMPORT_OR_EXPORT ULONG64 getCellIndexPairCount() const;
 
 		/**
 		* Get the cell index pair count of this grid connection representation
 		*/
-		ULONG64 getCellIndexPairs(ULONG64 * cellIndexPairs) const;
+		DLL_IMPORT_OR_EXPORT ULONG64 getCellIndexPairs(ULONG64 * cellIndexPairs) const;
 
 		/**
 		* Get the cell index pairs count which correspond to a particular interpretation.
 		* @param interpretationIndex The index of the interpretation in the collection of feature interpretation of this grid connection set.
 		*/
-		unsigned int getCellIndexPairCountFromInterpretationIndex(unsigned int interpretationIndex) const;
+		DLL_IMPORT_OR_EXPORT unsigned int getCellIndexPairCountFromInterpretationIndex(unsigned int interpretationIndex) const;
 
 		/**
 		* Indicates wether the cell connection are associated to interpretation or not.
 		*/
-		bool isAssociatedToInterpretations() const;
+		DLL_IMPORT_OR_EXPORT bool isAssociatedToInterpretations() const;
 
 		/**
 		* Get the interpretation index cumulative count of this grid connection representation
 		* The count of cumulativeCount must be getCellIndexPairCount().
 		*/
-		void getInterpretationIndexCumulativeCount(unsigned int * cumulativeCount) const;
+		DLL_IMPORT_OR_EXPORT void getInterpretationIndexCumulativeCount(unsigned int * cumulativeCount) const;
 
 		/**
 		* Get the interpretation indices of this grid connection representation
 		* The count of interpretationIndices is the last value of the array returning by getInterpretationIndexCumulativeCount.
 		*/
-		void getInterpretationIndices(unsigned int * interpretationIndices) const;
+		DLL_IMPORT_OR_EXPORT void getInterpretationIndices(unsigned int * interpretationIndices) const;
 
 		/**
 		* Returns the null value for interpretation index.
 		*/
-		LONG64 getInterpretationIndexNullValue() const;
+		DLL_IMPORT_OR_EXPORT LONG64 getInterpretationIndexNullValue() const;
 
 		/**
 		* Get the cell index pairs, the grid index pairs (optional) and the local face pairs (optional) which correspond to a particular  interpretation.
@@ -123,23 +123,23 @@ namespace RESQML2_0_1_NS
 		* @param localFaceIndexPairs	Optional (put null if you don't want it). Must be allocated with getCellIndexPairCountFromIndex first.
 		* @param interpretationIndex	The index of the interpretation in the collection of feature interpretation of this grid connection set.
 		*/
-		void getGridConnectionSetInformationFromInterpretationIndex(ULONG64 * cellIndexPairs, unsigned short * gridIndexPairs, int * localFaceIndexPairs, unsigned int interpretationIndex) const;
+		DLL_IMPORT_OR_EXPORT void getGridConnectionSetInformationFromInterpretationIndex(ULONG64 * cellIndexPairs, unsigned short * gridIndexPairs, int * localFaceIndexPairs, unsigned int interpretationIndex) const;
 
 		/**
 		* Get the UUID of a particular interpretation of this grid connection set.
 		* @param interpretationIndex The index of the interpretation in the collection of feature interpretation of this grid connection set.
 		*/
-		std::string getInterpretationUuidFromIndex(const unsigned int & interpretationIndex) const;
+		DLL_IMPORT_OR_EXPORT std::string getInterpretationUuidFromIndex(const unsigned int & interpretationIndex) const;
 
 		/**
 		* Get the count of interpretations in this grid connection set.
 		*/
-		unsigned int getInterpretationCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getInterpretationCount() const;
 
 		/**
 		* Indicates if the grid connection set representation contains information on the connected faces of the two cells.
 		*/
-		bool hasLocalFacePerCell() const;
+		DLL_IMPORT_OR_EXPORT bool hasLocalFacePerCell() const;
 
 		/**
 		* Get the local face cell index pairs of this grid connection representation.
@@ -147,18 +147,18 @@ namespace RESQML2_0_1_NS
 		* @param localFacePerCellIndexPairs Tis array must be pre allocated and won't be deallocated byt fesapi. The count of localFacePerCellIndexPairs must be getCellIndexPairCount()*2.
 		* @return The used null value in localFacePerCellIndexPairs
 		*/
-		LONG64 getLocalFacePerCellIndexPairs(int * localFacePerCellIndexPairs) const;
+		DLL_IMPORT_OR_EXPORT LONG64 getLocalFacePerCellIndexPairs(int * localFacePerCellIndexPairs) const;
 
 		/**
 		* Indicates if the grid connection set representation is based on several grids.
 		*/
-		bool isBasedOnMultiGrids() const;
+		DLL_IMPORT_OR_EXPORT bool isBasedOnMultiGrids() const;
 
 		/**
 		* Get the grid index pairs of this grid connection representation
 		* The count of gridIndexPairs must be getCellIndexPairCount()*2.
 		*/
-		void getGridIndexPairs(unsigned short * gridIndexPairs) const;
+		DLL_IMPORT_OR_EXPORT void getGridIndexPairs(unsigned short * gridIndexPairs) const;
 
 		/**
 		* Set the cell index pairs of the grid connections representation using some exisiting hdf5 datasets.
@@ -169,7 +169,7 @@ namespace RESQML2_0_1_NS
 		* @param gridIndexPairNullValue	The integer null value used in the hdf grid index pair dataset.
 		* @param gridIndexPair			The HDF dataset path where we can find all the grid index pair in a 1d Array where the grid indices go faster than the pair. The grid at an index must correspond to the cell at the same index in the cellIndexPair array.
 		*/
-		void setCellIndexPairsUsingExistingDataset(ULONG64 cellIndexPairCount, const std::string & cellIndexPair, LONG64 cellIndexPairNullValue, COMMON_NS::AbstractHdfProxy * proxy, LONG64 gridIndexPairNullValue = -1, const std::string & gridIndexPair = "");
+		DLL_IMPORT_OR_EXPORT void setCellIndexPairsUsingExistingDataset(ULONG64 cellIndexPairCount, const std::string & cellIndexPair, LONG64 cellIndexPairNullValue, COMMON_NS::AbstractHdfProxy * proxy, LONG64 gridIndexPairNullValue = -1, const std::string & gridIndexPair = "");
 
 		/**
 		* The numerical values
@@ -179,7 +179,7 @@ namespace RESQML2_0_1_NS
 		* @param localFacePerCellIndexPair	The HDF dataset path where we can find all the local Face Per CellIndex Pair in a 1d Array.
 		* @param proxy						The HDF proxy where the numerical values (cell indices) are stored.
 		*/
-		void setLocalFacePerCellIndexPairsUsingExistingDataset(const std::string & localFacePerCellIndexPair, LONG64 nullValue, COMMON_NS::AbstractHdfProxy * proxy);
+		DLL_IMPORT_OR_EXPORT void setLocalFacePerCellIndexPairsUsingExistingDataset(const std::string & localFacePerCellIndexPair, LONG64 nullValue, COMMON_NS::AbstractHdfProxy * proxy);
 
 		/**
 		* 2 x #Connections array of local face-per-cell indices for (Cell1,Cell2) for each connection. Local face-per-cell indices are used because global face indices need not have been defined.
@@ -189,7 +189,7 @@ namespace RESQML2_0_1_NS
 		* @param localFacePerCellIndexPair	The HDF dataset path where we can find all the local Face Per CellIndex Pair in a 1d Array.
 		* @param proxy						The HDF proxy where the numerical values (cell indices) are stored.
 		*/
-		void setLocalFacePerCellIndexPairs(ULONG64 cellIndexPairCount, int * localFacePerCellIndexPair, int nullValue, COMMON_NS::AbstractHdfProxy * proxy);
+		DLL_IMPORT_OR_EXPORT void setLocalFacePerCellIndexPairs(ULONG64 cellIndexPairCount, int * localFacePerCellIndexPair, int nullValue, COMMON_NS::AbstractHdfProxy * proxy);
 
 		/**
 		* For each connection in the grid connection set representation, allow to map zero or one feature interpretation. TODO: Resqml allows to map with more than one feature interpretation.
@@ -198,12 +198,12 @@ namespace RESQML2_0_1_NS
 		* @param nullValue					The null value must be used as the corresponding interpretation index for each connection which are not associated to any interpretation.
 		* @param proxy						The Hdf proxy where the numerical values will be stored.
 		*/
-		void setConnectionInterpretationIndices(unsigned int * interpretationIndices, unsigned int interpretationIndiceCount, unsigned int nullValue, COMMON_NS::AbstractHdfProxy * proxy);
+		DLL_IMPORT_OR_EXPORT void setConnectionInterpretationIndices(unsigned int * interpretationIndices, unsigned int interpretationIndiceCount, unsigned int nullValue, COMMON_NS::AbstractHdfProxy * proxy);
 		
 		/**
 		* Get the count of the supporting grid representations of this grid connection representation.
 		*/
-		unsigned int getSupportingGridRepresentationCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getSupportingGridRepresentationCount() const;
 		
 		/**
 		* Get one of the supporting grid representation dor of this grid connection representation.

--- a/src/resqml2_0_1/HdfProxy.h
+++ b/src/resqml2_0_1/HdfProxy.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT HdfProxy : public COMMON_NS::HdfProxy
+	class HdfProxy : public COMMON_NS::HdfProxy
 	{
 	public:
 		/**
@@ -55,4 +55,3 @@ namespace RESQML2_0_1_NS
 
 	};
 }
-

--- a/src/resqml2_0_1/Horizon.h
+++ b/src/resqml2_0_1/Horizon.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT Horizon : public GeneticBoundaryFeature
+	class Horizon : public GeneticBoundaryFeature
 	{
 	public:
 
@@ -50,4 +50,3 @@ namespace RESQML2_0_1_NS
 		~Horizon() {}
 	};
 }
-

--- a/src/resqml2_0_1/HorizonInterpretation.h
+++ b/src/resqml2_0_1/HorizonInterpretation.h
@@ -24,7 +24,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT HorizonInterpretation : public BoundaryFeatureInterpretation
+	class HorizonInterpretation : public BoundaryFeatureInterpretation
 	{
 	public:
 
@@ -54,8 +54,8 @@ namespace RESQML2_0_1_NS
 		*/
 		~HorizonInterpretation() {}
 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
     private:
         std::vector<epc::Relationship> getAllEpcRelationships() const;

--- a/src/resqml2_0_1/IjkGridExplicitRepresentation.h
+++ b/src/resqml2_0_1/IjkGridExplicitRepresentation.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT IjkGridExplicitRepresentation : public AbstractIjkGridRepresentation
+	class IjkGridExplicitRepresentation : public AbstractIjkGridRepresentation
 	{
 	public:
 
@@ -50,12 +50,12 @@ namespace RESQML2_0_1_NS
 		*/
 		virtual ~IjkGridExplicitRepresentation() {}
 
-		std::string getHdfProxyUuid() const;
+		DLL_IMPORT_OR_EXPORT std::string getHdfProxyUuid() const;
 
 		/**
 		* Get the xyz point count in a given patch.
 		*/
-		ULONG64 getXyzPointCountOfPatch(const unsigned int & patchIndex) const;
+		DLL_IMPORT_OR_EXPORT ULONG64 getXyzPointCountOfPatch(const unsigned int & patchIndex) const;
 
 		/**
 		* Get all the XYZ points of a particular sequence of K interfaces of a particular patch of this representation.
@@ -65,21 +65,21 @@ namespace RESQML2_0_1_NS
 		* @param patchIndex	The index of the patch. It is generally zero.
 		* @param xyzPoints 	A linearized 2d array where the first (quickest) dimension is coordinate dimension (XYZ) and second dimension is vertex dimension. It must be pre allocated with a size of 3*getXyzPointCountOfKInterfaceOfPatch*(kInterfaceEnd - kInterfaceStart + 1).
 		*/
-		void getXyzPointsOfKInterfaceSequenceOfPatch(const unsigned int & kInterfaceStart, const unsigned int & kInterfaceEnd, const unsigned int & patchIndex, double * xyzPoints);
+		DLL_IMPORT_OR_EXPORT void getXyzPointsOfKInterfaceSequenceOfPatch(const unsigned int & kInterfaceStart, const unsigned int & kInterfaceEnd, const unsigned int & patchIndex, double * xyzPoints);
 
 		/**
 		* Get all the XYZ points of the current block. XYZ points are given in the local CRS. Block information must be loaded.
 		* @param patchIndex			The index of the patch. It is generally zero.
 		* @param xyzPoints 			A linearized 2d array where the first (quickest) dimension is coordinate dimension (XYZ) and second dimension is vertex dimension. It must be pre allocated with a size of 3*getXyzPointCountOfBlock.
 		*/
-		void getXyzPointsOfBlockOfPatch(const unsigned int & patchIndex, double * xyzPoints);
+		DLL_IMPORT_OR_EXPORT void getXyzPointsOfBlockOfPatch(const unsigned int & patchIndex, double * xyzPoints);
 
 		/**
 		* Get all the XYZ points of a particular patch of this representation.
 		* XYZ points are given in the local CRS.
 		* @param xyzPoints XYZ double triplets ordered by i then j then split then k. It must be pre allocated with a count of ((iCellCount+1) * (jCellCount+1) + splitCoordinateLineCount) * kCellCount.
 		*/
-		void getXyzPointsOfPatch(const unsigned int & patchIndex, double * xyzPoints) const;
+		DLL_IMPORT_OR_EXPORT void getXyzPointsOfPatch(const unsigned int & patchIndex, double * xyzPoints) const;
 
 		/**
 		* Set the geometry of the IJK grid as explicit coordinate line nodes. See Resqml Usage, Technical guide and Enterprise Architect diagrams for details.
@@ -97,7 +97,7 @@ namespace RESQML2_0_1_NS
 		*													Columns are identified by their absolute 1d index (iColumn + jColumn*iColumnCount) where *Column* == *Cell*.
 		* @param definedPillars								For each pillar : 0 if pillar is not defined (i.e points equal to NaN) else the pillar is defined.  This information overrides any pillar geometry information. If null, then all pillars are assumed to be defined.
 		*/
-		void setGeometryAsCoordinateLineNodes(
+		DLL_IMPORT_OR_EXPORT void setGeometryAsCoordinateLineNodes(
 			const gsoap_resqml2_0_1::resqml2__PillarShape & mostComplexPillarGeometry, const gsoap_resqml2_0_1::resqml2__KDirection & kDirectionKind, const bool & isRightHanded,
 			double * points, COMMON_NS::AbstractHdfProxy* proxy,
 			const unsigned long & splitCoordinateLineCount = 0, unsigned int * pillarOfCoordinateLine = nullptr,
@@ -107,14 +107,13 @@ namespace RESQML2_0_1_NS
 		/**
 		* Same as setGeometryAsCoordinateLineNodes where the hdf datasets are already written in the the file.
 		*/
-		void setGeometryAsCoordinateLineNodesUsingExistingDatasets(
+		DLL_IMPORT_OR_EXPORT void setGeometryAsCoordinateLineNodesUsingExistingDatasets(
 			const gsoap_resqml2_0_1::resqml2__PillarShape & mostComplexPillarGeometry, const gsoap_resqml2_0_1::resqml2__KDirection & kDirectionKind, const bool & isRightHanded,
 			const std::string & points, COMMON_NS::AbstractHdfProxy* proxy,
 			const unsigned long & splitCoordinateLineCount = 0, const std::string & pillarOfCoordinateLine = "",
 			const std::string & splitCoordinateLineColumnCumulativeCount = "", const std::string & splitCoordinateLineColumns = "",
 			const std::string & definedPillars = "");
 
-		geometryKind getGeometryKind() const;
+		DLL_IMPORT_OR_EXPORT geometryKind getGeometryKind() const;
 	};
 }
-

--- a/src/resqml2_0_1/IjkGridLatticeRepresentation.h
+++ b/src/resqml2_0_1/IjkGridLatticeRepresentation.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT IjkGridLatticeRepresentation : public AbstractIjkGridRepresentation
+	class IjkGridLatticeRepresentation : public AbstractIjkGridRepresentation
 	{
 	private :
 		gsoap_resqml2_0_1::resqml2__Point3dLatticeArray* getArrayLatticeOfPoints3d() const;
@@ -50,66 +50,66 @@ namespace RESQML2_0_1_NS
 		/**
 		* Indicates wether the instance corresponds to a seismic cube or not.
 		*/
-		bool isASeismicCube() const;
+		DLL_IMPORT_OR_EXPORT bool isASeismicCube() const;
 
 		/**
 		* Indicates wether the instance corresponds to a facies cube or not.
 		*/
-		bool isAFaciesCube() const;
+		DLL_IMPORT_OR_EXPORT bool isAFaciesCube() const;
 
 		/**
 		* Get the xyz point count in a given patch.
 		*/
-		ULONG64 getXyzPointCountOfPatch(const unsigned int & patchIndex) const;
+		DLL_IMPORT_OR_EXPORT ULONG64 getXyzPointCountOfPatch(const unsigned int & patchIndex) const;
 
 		/**
 		* Get all the XYZ points of a particular patch of this representation.
 		* XYZ points are given in the local CRS.
 		* @param xyzPoints A linearized 2d array where the first (quickest) dimension is coordinate dimension (XYZ) and second dimension is vertex dimension. It must be pre allocated.
 		*/
-		void getXyzPointsOfPatch(const unsigned int & patchIndex, double * xyzPoints) const;
+		DLL_IMPORT_OR_EXPORT void getXyzPointsOfPatch(const unsigned int & patchIndex, double * xyzPoints) const;
 
 		/**
 		* Get the X origin of this geometry.
 		* X coordinate is given in the local CRS.
 		* @return double.NAN coordinate if something's wrong. The X origin point otherwise.
 		*/
-		double getXOrigin() const;
+		DLL_IMPORT_OR_EXPORT double getXOrigin() const;
 
 		/**
 		* Get the Y origin of this geometry.
 		* Y coordinate is given in the local CRS.
 		* @return double.NAN coordinate if something's wrong. The Y origin point otherwise.
 		*/
-		double getYOrigin() const;
+		DLL_IMPORT_OR_EXPORT double getYOrigin() const;
 
 	    /**
 		* Get the Z origin of this geometry.
 		* Z coordinate is given in the local CRS.
 		* @return double.NAN coordinate if something's wrong. The Z origin point otherwise.
 		*/
-		double getZOrigin() const;
+		DLL_IMPORT_OR_EXPORT double getZOrigin() const;
 
 		/**
 		* Get the X origin of this geometry.
 		* X coordinate is given in the global CRS.
 		* @return double.NAN coordinate if something's wrong. The X origin point otherwise.
 		*/
-		double getXOriginInGlobalCrs() const;
+		DLL_IMPORT_OR_EXPORT double getXOriginInGlobalCrs() const;
 
 		/**
 		* Get the Y origin of this geometry.
 		* Y coordinate is given in the global CRS.
 		* @return double.NAN coordinate if something's wrong. The Y origin point otherwise.
 		*/
-		double getYOriginInGlobalCrs() const;
+		DLL_IMPORT_OR_EXPORT double getYOriginInGlobalCrs() const;
 
 		/**
 		* Get the Z origin of this geometry.
 		* Z coordinate is given in the global CRS.
 		* @return double.NAN coordinate if something's wrong. The Z origin point otherwise.
 		*/
-		double getZOriginInGlobalCrs() const;
+		DLL_IMPORT_OR_EXPORT double getZOriginInGlobalCrs() const;
 
 		/*****************************************************
 		* Notice that, in seismic context, I is the slowest axis, J is the intermediate axis and K is the fastest axis.
@@ -122,126 +122,126 @@ namespace RESQML2_0_1_NS
         * X coordinate is given in the local CRS.
         * @return double.NAN coordinate if something's wrong. The X offset point otherwise.
         */
-        double getXIOffset() const;
+		DLL_IMPORT_OR_EXPORT double getXIOffset() const;
 
         /**
         * Get the Y i offset of this geometry.
         * Y coordinate is given in the local CRS.
         * @return double.NAN coordinate if something's wrong. The Y offset point otherwise.
         */
-        double getYIOffset() const;
+		DLL_IMPORT_OR_EXPORT double getYIOffset() const;
 
 		/**
         * Get the Z i offset of this geometry.
         * Z coordinate is given in the local CRS.
         * @return double.NAN coordinate if something's wrong. The Z offset point otherwise.
         */
-        double getZIOffset() const;
+		DLL_IMPORT_OR_EXPORT double getZIOffset() const;
 
 		/**
         * Get the X j offset of this geometry.
         * X coordinate is given in the local CRS.
         * @return double.NAN coordinate if something's wrong. The X offset point otherwise.
         */
-        double getXJOffset() const;
+		DLL_IMPORT_OR_EXPORT double getXJOffset() const;
 
         /**
         * Get the Y j offset of this geometry.
         * Y coordinate is given in the local CRS.
         * @return double.NAN coordinate if something's wrong. The Y offset point otherwise.
         */
-        double getYJOffset() const;
+		DLL_IMPORT_OR_EXPORT double getYJOffset() const;
 
 		/**
         * Get the Z j offset of this geometry.
         * Z coordinate is given in the local CRS.
         * @return double.NAN coordinate if something's wrong. The Z offset point otherwise.
         */
-        double getZJOffset() const;
+		DLL_IMPORT_OR_EXPORT double getZJOffset() const;
 
 		/**
         * Get the X k offset of this geometry.
         * X coordinate is given in the local CRS.
         * @return double.NAN coordinate if something's wrong. The X offset point otherwise.
         */
-        double getXKOffset() const;
+		DLL_IMPORT_OR_EXPORT double getXKOffset() const;
 
         /**
         * Get the Y k offset of this geometry.
         * Y coordinate is given in the local CRS.
         * @return double.NAN coordinate if something's wrong. The Y offset point otherwise.
         */
-        double getYKOffset() const;
+		DLL_IMPORT_OR_EXPORT double getYKOffset() const;
 
 		/**
         * Get the Z k offset of this geometry.
         * Z coordinate is given in the local CRS.
         * @return double.NAN coordinate if something's wrong. The Z offset point otherwise.
         */
-        double getZKOffset() const;
+		DLL_IMPORT_OR_EXPORT double getZKOffset() const;
 
 		/**
         * Get the I spacing of the regular (seismic) grid
         * @return double.NAN if something's wrong. The I spacing otherwise.
         */
-		double getISpacing() const;
+		DLL_IMPORT_OR_EXPORT double getISpacing() const;
 
         /**
         * Get the J spacing of the regular (seismic) grid
         * @return double.NAN if something's wrong. The J spacing otherwise.
         */
-        double getJSpacing() const;
+		DLL_IMPORT_OR_EXPORT double getJSpacing() const;
 
 		/**
         * Get the K spacing of the regular (seismic) grid
         * @return double.NAN if something's wrong. The K spacing otherwise.
         */
-        double getKSpacing() const;
+		DLL_IMPORT_OR_EXPORT double getKSpacing() const;
 
 		/**
         * Get the label of the first inline.
         */
-        int getOriginInline() const;
+		DLL_IMPORT_OR_EXPORT int getOriginInline() const;
 
 		/**
         * Get the label of the first crossline.
         */
-        int getOriginCrossline() const;
+		DLL_IMPORT_OR_EXPORT int getOriginCrossline() const;
 
 		/**
         * Get the inline I offset value.
         */
-        int getInlineIOffset() const;
+		DLL_IMPORT_OR_EXPORT int getInlineIOffset() const;
 
 		/**
         * Get the inline J offset value.
         */
-        int getInlineJOffset() const;
+		DLL_IMPORT_OR_EXPORT int getInlineJOffset() const;
 
 		/**
         * Get the inline K offset value.
         */
-        int getInlineKOffset() const;
+		DLL_IMPORT_OR_EXPORT int getInlineKOffset() const;
 
 		/**
         * Get the crossline I offset value.
         */
-        int getCrosslineIOffset() const;
+		DLL_IMPORT_OR_EXPORT int getCrosslineIOffset() const;
 
 		/**
         * Get the crossline J offset value.
         */
-        int getCrosslineJOffset() const;
+		DLL_IMPORT_OR_EXPORT int getCrosslineJOffset() const;
 
 		/**
         * Get the crossline K offset value.
         */
-        int getCrosslineKOffset() const;
+		DLL_IMPORT_OR_EXPORT int getCrosslineKOffset() const;
 
 		/**
 		* Set the geometry of the IJK grid as a regular IJK grid
 		*/
-		void setGeometryAsCoordinateLineNodes(	const gsoap_resqml2_0_1::resqml2__PillarShape & mostComplexPillarGeometry,
+		DLL_IMPORT_OR_EXPORT void setGeometryAsCoordinateLineNodes(	const gsoap_resqml2_0_1::resqml2__PillarShape & mostComplexPillarGeometry,
 												const gsoap_resqml2_0_1::resqml2__KDirection & kDirectionKind,
 												const bool & isRightHanded,
 												const double & originX, const double & originY, const double & originZ,
@@ -253,15 +253,14 @@ namespace RESQML2_0_1_NS
 		* Push back a patch of seismic 3D coordinates info.
 		* The index this patch will be located must be consistent with the index of the geometry patch it is related to.
 		*/
-		void addSeismic3dCoordinatesToPatch(
+		DLL_IMPORT_OR_EXPORT void addSeismic3dCoordinatesToPatch(
 						const unsigned int patchIndex,
 						const double & startInline, const double & incrInline, const unsigned int & countInline,
 						const double & startCrossline, const double & incrCrossline, const unsigned int & countCrossline,
 			            const unsigned int & countSample, AbstractRepresentation * seismicSupport);
 
-		std::string getHdfProxyUuid() const;
+		DLL_IMPORT_OR_EXPORT std::string getHdfProxyUuid() const;
 
-		geometryKind getGeometryKind() const;
+		DLL_IMPORT_OR_EXPORT geometryKind getGeometryKind() const;
 	};
 }
-

--- a/src/resqml2_0_1/IjkGridNoGeometryRepresentation.h
+++ b/src/resqml2_0_1/IjkGridNoGeometryRepresentation.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT IjkGridNoGeometryRepresentation : public AbstractIjkGridRepresentation
+	class IjkGridNoGeometryRepresentation : public AbstractIjkGridRepresentation
 	{
 	public:
 
@@ -50,16 +50,15 @@ namespace RESQML2_0_1_NS
 		/**
 		* Get the xyz point count in a given patch.
 		*/
-		ULONG64 getXyzPointCountOfPatch(const unsigned int & patchIndex) const;
+		DLL_IMPORT_OR_EXPORT ULONG64 getXyzPointCountOfPatch(const unsigned int & patchIndex) const;
 
 		/**
 		* Get all the XYZ points of a particular patch of this representation.
 		* XYZ points are given in the local CRS.
 		* @param xyzPoints A linearized 2d array where the first (quickest) dimension is coordinate dimension (XYZ) and second dimension is vertex dimension. It must be pre allocated.
 		*/
-		void getXyzPointsOfPatch(const unsigned int & patchIndex, double * xyzPoints) const;
+		DLL_IMPORT_OR_EXPORT void getXyzPointsOfPatch(const unsigned int & patchIndex, double * xyzPoints) const;
 
-		geometryKind getGeometryKind() const;
+		DLL_IMPORT_OR_EXPORT geometryKind getGeometryKind() const;
 	};
 }
-

--- a/src/resqml2_0_1/IjkGridParametricRepresentation.h
+++ b/src/resqml2_0_1/IjkGridParametricRepresentation.h
@@ -24,7 +24,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT IjkGridParametricRepresentation : public AbstractIjkGridRepresentation
+	class IjkGridParametricRepresentation : public AbstractIjkGridRepresentation
 	{
 	private:
 		void getXyzPointsOfPatchFromParametricPoints(gsoap_resqml2_0_1::resqml2__Point3dParametricArray* parametricPoint3d, double * xyzPoints) const;
@@ -95,12 +95,12 @@ namespace RESQML2_0_1_NS
 				delete pillarInformation; 
 		}
 
-		std::string getHdfProxyUuid() const;
+		DLL_IMPORT_OR_EXPORT std::string getHdfProxyUuid() const;
 
 		/**
 		* Get the xyz point count in a given patch.
 		*/
-		ULONG64 getXyzPointCountOfPatch(const unsigned int & patchIndex) const;
+		DLL_IMPORT_OR_EXPORT ULONG64 getXyzPointCountOfPatch(const unsigned int & patchIndex) const;
 
 		/**
 		* Get all the XYZ points of a particular sequence of K interfaces of a particular patch of this representation.
@@ -110,39 +110,39 @@ namespace RESQML2_0_1_NS
 		* @param patchIndex	The index of the patch. It is generally zero.
 		* @param xyzPoints 	A linearized 2d array where the first (quickest) dimension is coordinate dimension (XYZ) and second dimension is vertex dimension. It must be pre allocated with a size of 3*getXyzPointCountOfKInterfaceOfPatch.
 		*/
-		void getXyzPointsOfKInterfaceSequenceOfPatch(const unsigned int & kInterfaceStart, const unsigned int & kInterfaceEnd, const unsigned int & patchIndex, double * xyzPoints);
+		DLL_IMPORT_OR_EXPORT void getXyzPointsOfKInterfaceSequenceOfPatch(const unsigned int & kInterfaceStart, const unsigned int & kInterfaceEnd, const unsigned int & patchIndex, double * xyzPoints);
 
 		/**
 		* Get all the XYZ points of the current block. XYZ points are given in the local CRS. Block information must be loaded.
 		* @param patchIndex			The index of the patch. It is generally zero.
 		* @param xyzPoints 			A linearized 2d array where the first (quickest) dimension is coordinate dimension (XYZ) and second dimension is vertex dimension. It must be pre allocated with a size of 3*getXyzPointCountOfBlock.
 		*/
-		void getXyzPointsOfBlockOfPatch(const unsigned int & patchIndex, double * xyzPoints);
+		DLL_IMPORT_OR_EXPORT void getXyzPointsOfBlockOfPatch(const unsigned int & patchIndex, double * xyzPoints);
 
 		/**
 		* Get all the XYZ points of a particular patch of this representation.
 		* XYZ points are given in the local CRS.
 		* @param xyzPoints A linearized 2d array where the first (quickest) dimension is coordinate dimension (XYZ) and second dimension is vertex dimension. It must be pre allocated with a size of 3*getXyzPointCountOfPatch.
 		*/
-		void getXyzPointsOfPatch(const unsigned int & patchIndex, double * xyzPoints) const;
+		DLL_IMPORT_OR_EXPORT void getXyzPointsOfPatch(const unsigned int & patchIndex, double * xyzPoints) const;
 
 		/**
 		* Get the max control point count on a pillar of the grid.
 		*/
-		unsigned int getControlPointMaxCountPerPillar() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getControlPointMaxCountPerPillar() const;
 
 		/**
 		* Get all the control points of each pillar of the IJK parametric grid.
 		* They are ordered first (quickest) by pillar and then (slowest) by control point : cp0 of pillar0, cp0 of pillar1, cp0 of pillar3, ..., cp0 of pillarCount-1, cp1 of pillar0, cp1 of pillar1, etc... Pad with nan values if necessary.
 		* For information, pillars are ordered first (quicket) by I and then (slowest) by J.
 		*/
-		void getControlPoints(double * controlPoints, bool reverseIAxis = false, bool reverseJAxis= false, bool reverseKAxis= false) const;
+		DLL_IMPORT_OR_EXPORT void getControlPoints(double * controlPoints, bool reverseIAxis = false, bool reverseJAxis= false, bool reverseKAxis= false) const;
 
 		/**
 		* Check if the IJK grid contains some paraemeters on some control points.
 		* It happens when the grid contains at least one non vertical or a non Z linear parametric line.
 		*/
-		bool hasControlPointParameters() const;
+		DLL_IMPORT_OR_EXPORT bool hasControlPointParameters() const;
 
 		/**
 		* Get all the control point parameters of each pillar of the IJK parametric grid.
@@ -150,31 +150,31 @@ namespace RESQML2_0_1_NS
 		* For information, pillars are ordered first (quicket) by I and then (slowest) by J.
 		* Only relevant in case it contains at least one non vertical or non Z linear parametric line.
 		*/
-		void getControlPointParameters(double * controlPointParameters, bool reverseIAxis = false, bool reverseJAxis= false, bool reverseKAxis= false) const;
+		DLL_IMPORT_OR_EXPORT void getControlPointParameters(double * controlPointParameters, bool reverseIAxis = false, bool reverseJAxis= false, bool reverseKAxis= false) const;
 
 		/**
 		* Check if the parametric line kind is constant in the grid.
 		*/
-		bool isParametricLineKindConstant() const;
+		DLL_IMPORT_OR_EXPORT bool isParametricLineKindConstant() const;
 
 		/*
 		* Get the constant parametric line count in the grid.
 		*/
-		short getConstantParametricLineKind() const;
+		DLL_IMPORT_OR_EXPORT short getConstantParametricLineKind() const;
 
 		/**
 		* Get the kind of each parametric line representing a pillar :
 		*					0 = vertical, 1 = linear spline, 2 = natural cubic spline, 3 = cubic spline, 4 = Z linear cubic spline, 5 = minimum-curvature spline, (-1) = null: no line 
 		* Only relevant in case the IJK grid is a parametric one.
 		*/
-		void getParametricLineKind(short * pillarKind, bool reverseIAxis = false, bool reverseJAxis= false) const;
+		DLL_IMPORT_OR_EXPORT void getParametricLineKind(short * pillarKind, bool reverseIAxis = false, bool reverseJAxis= false) const;
 
 		/**
 		* Get all the parameters of each node of the IJK parametric grid.
 		* They are ordered first (quickest) by coordinate line and then (slowest) by K level.
 		* Only relevant in case the IJK grid is a parametric one.
 		*/
-		void getParametersOfNodes(double * parameters, bool reverseIAxis = false, bool reverseJAxis= false, bool reverseKAxis= false) const;
+		DLL_IMPORT_OR_EXPORT void getParametersOfNodes(double * parameters, bool reverseIAxis = false, bool reverseJAxis= false, bool reverseKAxis= false) const;
 
 		/**
 		* Set the geometry of the IJK grid as parametric pillar nodes where no pillar is splitted.
@@ -189,7 +189,7 @@ namespace RESQML2_0_1_NS
 		* @param proxy										The Hdf proxy where all numerical values will be stored.
 		* @param splitCoordinateLineCount					The count of split coordinate line in this grid. A pillar being splitted by a maximum of 3 split coordinate lines (one coordinate line is always non splitted)
 		*/
-		void setGeometryAsParametricNonSplittedPillarNodes(
+		DLL_IMPORT_OR_EXPORT void setGeometryAsParametricNonSplittedPillarNodes(
 			const gsoap_resqml2_0_1::resqml2__PillarShape & mostComplexPillarGeometry, const bool & isRightHanded,
 			double * parameters, double * controlPoints, double * controlPointParameters, const unsigned int & controlPointMaxCountPerPillar, short * pillarKind, COMMON_NS::AbstractHdfProxy* proxy);
 
@@ -197,7 +197,7 @@ namespace RESQML2_0_1_NS
 		* Same as setGeometryAsParametricNonSplittedPillarNodes where the hdf datasets are already written in the the file.
 		* @param definedPillars								The string to an hdf dataset where the defined pillars are identified : 0 value for not defined (i.e control points are NaN points, i.e pillarKind == -1) else the pillar is defined. This information overrides any pillar geometry information.
 		*/
-		void setGeometryAsParametricNonSplittedPillarNodesUsingExistingDatasets(
+		DLL_IMPORT_OR_EXPORT void setGeometryAsParametricNonSplittedPillarNodesUsingExistingDatasets(
 			const gsoap_resqml2_0_1::resqml2__PillarShape & mostComplexPillarGeometry, const gsoap_resqml2_0_1::resqml2__KDirection & kDirectionKind, const bool & isRightHanded,
 			const std::string & parameters, const std::string & controlPoints, const std::string & controlPointParameters, const unsigned int & controlPointMaxCountPerPillar, const std::string & pillarKind, const std::string & definedPillars, COMMON_NS::AbstractHdfProxy* proxy);
 
@@ -217,7 +217,7 @@ namespace RESQML2_0_1_NS
 		* @param splitCoordinateLineColumnCumulativeCount	For each split coordinate line, indicates the count of grid column which are splitted by this coordinate line.
 		* @param splitCoordinateLineColumns					For each split coordinate line, indicates the grid columns which are splitted by this coordinate line.
 		*/
-		void setGeometryAsParametricSplittedPillarNodes(
+		DLL_IMPORT_OR_EXPORT void setGeometryAsParametricSplittedPillarNodes(
 			const gsoap_resqml2_0_1::resqml2__PillarShape & mostComplexPillarGeometry, const bool & isRightHanded,
 			double * parameters, double * controlPoints, double * controlPointParameters, const unsigned int & controlPointMaxCountPerPillar, short * pillarKind, COMMON_NS::AbstractHdfProxy* proxy,
 			const unsigned long & splitCoordinateLineCount, unsigned int * pillarOfCoordinateLine,
@@ -227,7 +227,7 @@ namespace RESQML2_0_1_NS
 		* Same as setGeometryAsParametricSplittedPillarNodes where the hdf datasets are already written in the the file.
 		* @param definedPillars								The string to an hdf dataset where the defined pillars are identified : 0 value for not defined (i.e control points are NaN points, i.e pillarKind == -1) else the pillar is defined.  This information overrides any pillar geometry information.
 		*/
-		void setGeometryAsParametricSplittedPillarNodesUsingExistingDatasets(
+		DLL_IMPORT_OR_EXPORT void setGeometryAsParametricSplittedPillarNodesUsingExistingDatasets(
 			const gsoap_resqml2_0_1::resqml2__PillarShape & mostComplexPillarGeometry, const gsoap_resqml2_0_1::resqml2__KDirection & kDirectionKind, const bool & isRightHanded,
 			const std::string & parameters, const std::string & controlPoints, const std::string & controlPointParameters, const unsigned int & controlPointMaxCountPerPillar, const std::string & pillarKind, const std::string & definedPillars, COMMON_NS::AbstractHdfProxy* proxy,
 			const unsigned long & splitCoordinateLineCount, const std::string & pillarOfCoordinateLine,
@@ -248,7 +248,7 @@ namespace RESQML2_0_1_NS
 		* @param splitCoordinateLineColumnCumulativeCount	For each split coordinate line, indicates the count of grid column which are splitted by this coordinate line.
 		* @param splitCoordinateLineColumns					For each split coordinate line, indicates the grid columns which are splitted by this coordinate line.
 		*/
-		void setGeometryAsParametricSplittedPillarNodes(const bool & isRightHanded,
+		DLL_IMPORT_OR_EXPORT void setGeometryAsParametricSplittedPillarNodes(const bool & isRightHanded,
 			double * parameters, double * controlPoints, double * controlPointParameters, const unsigned int & controlPointCountPerPillar, short pillarKind, COMMON_NS::AbstractHdfProxy* proxy,
 			const unsigned long & splitCoordinateLineCount, unsigned int * pillarOfCoordinateLine,
 			unsigned int * splitCoordinateLineColumnCumulativeCount, unsigned int * splitCoordinateLineColumns);
@@ -256,13 +256,12 @@ namespace RESQML2_0_1_NS
 		/**
 		* Same as setGeometryAsParametricSplittedPillarNodes where the hdf datasets are already written in the the file.
 		*/
-		void setGeometryAsParametricSplittedPillarNodesUsingExistingDatasets(
+		DLL_IMPORT_OR_EXPORT void setGeometryAsParametricSplittedPillarNodesUsingExistingDatasets(
 			const gsoap_resqml2_0_1::resqml2__KDirection & kDirectionKind, const bool & isRightHanded,
 			const std::string & parameters, const std::string & controlPoints, const std::string & controlPointParameters, const unsigned int & controlPointCountPerPillar, short pillarKind, COMMON_NS::AbstractHdfProxy* proxy,
 			const unsigned long & splitCoordinateLineCount, const std::string & pillarOfCoordinateLine,
 			const std::string & splitCoordinateLineColumnCumulativeCount, const std::string & splitCoordinateLineColumns);
 
-		geometryKind getGeometryKind() const;
+		DLL_IMPORT_OR_EXPORT geometryKind getGeometryKind() const;
 	};
 }
-

--- a/src/resqml2_0_1/LocalTime3dCrs.h
+++ b/src/resqml2_0_1/LocalTime3dCrs.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT LocalTime3dCrs : public RESQML2_NS::AbstractLocal3dCrs
+	class LocalTime3dCrs : public RESQML2_NS::AbstractLocal3dCrs
 	{
 	private:
 		void init(soap* soapContext, const std::string & guid, const std::string & title,
@@ -144,16 +144,11 @@ namespace RESQML2_0_1_NS
 		*/
 		~LocalTime3dCrs() {}
 
-		gsoap_resqml2_0_1::eml20__TimeUom getUnit() const;
+		DLL_IMPORT_OR_EXPORT gsoap_resqml2_0_1::eml20__TimeUom getUnit() const;
 
-		std::string getUnitAsString() const;
+		DLL_IMPORT_OR_EXPORT std::string getUnitAsString() const;
 
-		//******************************************************************
-		//********** INHERITED FROM AbstractObjectWithDcMetadata ***********
-		//******************************************************************
-
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 	};
 }
-

--- a/src/resqml2_0_1/MdDatum.h
+++ b/src/resqml2_0_1/MdDatum.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT MdDatum : public RESQML2_NS::MdDatum
+	class MdDatum : public RESQML2_NS::MdDatum
 	{
 	public:
 
@@ -64,25 +64,25 @@ namespace RESQML2_0_1_NS
 		/**
 		* Getter of the first ordinal of the reference location.
 		*/
-		double getX() const;
-		double getXInGlobalCrs() const;
+		DLL_IMPORT_OR_EXPORT double getX() const;
+		DLL_IMPORT_OR_EXPORT double getXInGlobalCrs() const;
 
 		/**
 		* Getter of the second ordinal of the reference location.
 		*/
-		double getY() const;
-		double getYInGlobalCrs() const;
+		DLL_IMPORT_OR_EXPORT double getY() const;
+		DLL_IMPORT_OR_EXPORT double getYInGlobalCrs() const;
 
 		/**
 		* Getter of the third ordinal of the reference location.
 		*/
-		double getZ() const;
-		double getZInGlobalCrs() const;
+		DLL_IMPORT_OR_EXPORT double getZ() const;
+		DLL_IMPORT_OR_EXPORT double getZInGlobalCrs() const;
 
 		/**
 		* Getter of the origin kind of the MD.
 		*/
-		gsoap_resqml2_0_1::resqml2__MdReference getOriginKind() const;
+		DLL_IMPORT_OR_EXPORT gsoap_resqml2_0_1::resqml2__MdReference getOriginKind() const;
 
 	protected:
 
@@ -92,4 +92,3 @@ namespace RESQML2_0_1_NS
 		std::vector<class WellboreTrajectoryRepresentation*> wellboreTrajectoryRepresentationSet;
 	};
 }
-

--- a/src/resqml2_0_1/NonSealedSurfaceFrameworkRepresentation.h
+++ b/src/resqml2_0_1/NonSealedSurfaceFrameworkRepresentation.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT NonSealedSurfaceFrameworkRepresentation : public AbstractSurfaceFrameworkRepresentation
+	class NonSealedSurfaceFrameworkRepresentation : public AbstractSurfaceFrameworkRepresentation
 	{
     public:
 
@@ -54,7 +54,7 @@ namespace RESQML2_0_1_NS
 		/**
 		 * Pushes back a contact representation in the structural framework
 		 */
-		void pushBackNonSealedContactRepresentation(const unsigned int & pointCount, double * points, RESQML2_NS::AbstractLocal3dCrs* crs, COMMON_NS::AbstractHdfProxy* proxy);
+		DLL_IMPORT_OR_EXPORT void pushBackNonSealedContactRepresentation(const unsigned int & pointCount, double * points, RESQML2_NS::AbstractLocal3dCrs* crs, COMMON_NS::AbstractHdfProxy* proxy);
                 
         /**
 		* Pushes back a contact patch in a particular contact representation of the structural framework.
@@ -72,12 +72,12 @@ namespace RESQML2_0_1_NS
                 COMMON_NS::AbstractHdfProxy* proxy);
                 */
 
-		unsigned int getContactCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getContactCount() const;
 
-        static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
-		virtual std::string getHdfProxyUuid() const;
+		DLL_IMPORT_OR_EXPORT virtual std::string getHdfProxyUuid() const;
 
     private:
 
@@ -87,4 +87,3 @@ namespace RESQML2_0_1_NS
             
 	};
 }
-

--- a/src/resqml2_0_1/OrganizationFeature.h
+++ b/src/resqml2_0_1/OrganizationFeature.h
@@ -59,4 +59,3 @@ namespace RESQML2_0_1_NS
 		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 	};
 }
-

--- a/src/resqml2_0_1/PlaneSetRepresentation.h
+++ b/src/resqml2_0_1/PlaneSetRepresentation.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT PlaneSetRepresentation : public RESQML2_NS::AbstractRepresentation
+	class PlaneSetRepresentation : public RESQML2_NS::AbstractRepresentation
 	{
 	public:
 
@@ -51,10 +51,10 @@ namespace RESQML2_0_1_NS
 		*/
 		~PlaneSetRepresentation() {}
 
-		std::string getHdfProxyUuid() const {return "";};
+		DLL_IMPORT_OR_EXPORT std::string getHdfProxyUuid() const {return "";};
 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
 		/**
 		* Get the Local 3d CRS dor where the reference point ordinals are given
@@ -65,32 +65,31 @@ namespace RESQML2_0_1_NS
 		/**
 		* Get the xyz point count in a given patch.
 		*/
-		ULONG64 getXyzPointCountOfPatch(const unsigned int & patchIndex) const;
+		DLL_IMPORT_OR_EXPORT ULONG64 getXyzPointCountOfPatch(const unsigned int & patchIndex) const;
 
 		/**
 		* Get all the XYZ points of a particular patch of this representation.
 		* XYZ points are given in the local CRS.
 		* @param xyzPoints A linearized 2d array where the first (quickest) dimension is coordinate dimension (XYZ) and second dimension is vertex dimension. It must be pre allocated.
 		*/
-		void getXyzPointsOfPatch(const unsigned int & patchIndex, double * xyzPoints) const;
+		DLL_IMPORT_OR_EXPORT void getXyzPointsOfPatch(const unsigned int & patchIndex, double * xyzPoints) const;
 
 		/**
 		 * Get the number of triangle patch
 		 */
-		unsigned int getPatchCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getPatchCount() const;
 
 		/**
 		* Push back a new patch which is an horizontal plane
 		* @param zCoordinate	The Z coordinate of the horizontal plane
 		*/
-		void pushBackHorizontalPlaneGeometryPatch(const double & zCoordinate);
+		DLL_IMPORT_OR_EXPORT void pushBackHorizontalPlaneGeometryPatch(const double & zCoordinate);
 
 		/**
 		* Push back a new patch which is not a horizontal plane. It s geometry is given by means of 3 XYZ points.
 		*/
-		void pushBackTiltedPlaneGeometryPatch(const double & x1, const double & y1, const double & z1,
+		DLL_IMPORT_OR_EXPORT void pushBackTiltedPlaneGeometryPatch(const double & x1, const double & y1, const double & z1,
 			const double & x2, const double & y2, const double & z2,
 			const double & x3, const double & y3, const double & z3);
 	};
 }
-

--- a/src/resqml2_0_1/PointSetRepresentation.h
+++ b/src/resqml2_0_1/PointSetRepresentation.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT PointSetRepresentation : public RESQML2_NS::AbstractRepresentation
+	class PointSetRepresentation : public RESQML2_NS::AbstractRepresentation
 	{
 	private :
 		gsoap_resqml2_0_1::resqml2__PointGeometry* getPointGeometry2_0_1(const unsigned int & patchIndex) const;
@@ -54,27 +54,27 @@ namespace RESQML2_0_1_NS
 		*/
 		~PointSetRepresentation() {}
 
-		std::string getHdfProxyUuid() const;
+		DLL_IMPORT_OR_EXPORT std::string getHdfProxyUuid() const;
 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
 		/**
 		* Get the xyz point count in a given patch.
 		*/
-		ULONG64 getXyzPointCountOfPatch(const unsigned int & patchIndex) const;
+		DLL_IMPORT_OR_EXPORT ULONG64 getXyzPointCountOfPatch(const unsigned int & patchIndex) const;
 
 		/**
 		* Get all the XYZ points of a particular patch of this representation.
 		* XYZ points are given in the local CRS.
 		* @param xyzPoints A linearized 2d array where the first (quickest) dimension is coordinate dimension (XYZ) and second dimension is vertex dimension. It must be pre allocated.
 		*/
-		void getXyzPointsOfPatch(const unsigned int & patchIndex, double * xyzPoints) const;
+		DLL_IMPORT_OR_EXPORT void getXyzPointsOfPatch(const unsigned int & patchIndex, double * xyzPoints) const;
 
 		/**
 		 * Get the number of triangle patch
 		 */
-		unsigned int getPatchCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getPatchCount() const;
 
 		/**
 		* Push back a new patch of polylines
@@ -82,9 +82,8 @@ namespace RESQML2_0_1_NS
 		* @param xyzPoints		The XYZ values of the points of the patch. Ordered by XYZ and then by xyzPointCount. It must be three times xyzPointCount.
 		* @param proxy			The HDF proxy which defines where the XYZ points will be stored.
 		*/
-		void pushBackGeometryPatch(
+		DLL_IMPORT_OR_EXPORT void pushBackGeometryPatch(
 				const unsigned int & xyzPointCount, double * xyzPoints,
 				COMMON_NS::AbstractHdfProxy* proxy);
 	};
 }
-

--- a/src/resqml2_0_1/PolylineRepresentation.h
+++ b/src/resqml2_0_1/PolylineRepresentation.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT PolylineRepresentation : public RESQML2_NS::AbstractRepresentation
+	class PolylineRepresentation : public RESQML2_NS::AbstractRepresentation
 	{
 	private :
 		gsoap_resqml2_0_1::resqml2__PointGeometry* getPointGeometry2_0_1(const unsigned int & patchIndex) const;
@@ -98,65 +98,64 @@ namespace RESQML2_0_1_NS
 		*/
 		~PolylineRepresentation() {}
 
-		std::string getHdfProxyUuid() const;
+		DLL_IMPORT_OR_EXPORT std::string getHdfProxyUuid() const;
 
 		/**
 		* Get the xyz point count in a given patch.
 		*/
-		ULONG64 getXyzPointCountOfPatch(const unsigned int & patchIndex) const;
+		DLL_IMPORT_OR_EXPORT ULONG64 getXyzPointCountOfPatch(const unsigned int & patchIndex) const;
 
 		/**
 		* Get all the XYZ points of a particular patch of this representation.
 		* XYZ points are given in the local CRS.
 		* @param xyzPoints A linearized 2d array where the first (quickest) dimension is coordinate dimension (XYZ) and second dimension is vertex dimension. It must be pre allocated.
 		*/
-		void getXyzPointsOfPatch(const unsigned int & patchIndex, double * xyzPoints) const;
+		DLL_IMPORT_OR_EXPORT void getXyzPointsOfPatch(const unsigned int & patchIndex, double * xyzPoints) const;
 
 		/**
 		 * @param points		The points which constitute the polyline. Ordered by XYZ and then points.
 		 * @param pointCount	The count of points in the polyline. Must be three times the count of the array of doubles "points".
 		 * @param proxy			The HDf proxy defining the HDF file where the double array will be stored.
 		 */
-		void setGeometry(double * points, const unsigned int & pointCount, COMMON_NS::AbstractHdfProxy* proxy);
+		DLL_IMPORT_OR_EXPORT void setGeometry(double * points, const unsigned int & pointCount, COMMON_NS::AbstractHdfProxy* proxy);
 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
 		/**
 		* Indicates if the representaiton is a closed polyline or a non closed polyline.
 		*/
-		bool isClosed() const;
+		DLL_IMPORT_OR_EXPORT bool isClosed() const;
 
 		/**
 		* Indicates if the polyline is associated to a particular LineRole.
 		*/
-		bool hasALineRole() const;
+		DLL_IMPORT_OR_EXPORT bool hasALineRole() const;
 		
 		/**
 		* Indicates wether the instance corresponds to a seismic 2D line or not.
 		*/
-		bool isASeismicLine() const;
+		DLL_IMPORT_OR_EXPORT bool isASeismicLine() const;
 
 		/**
 		* Indicates wether the instance corresponds to a facies 2d line or not.
 		*/
-		bool isAFaciesLine() const;
+		DLL_IMPORT_OR_EXPORT bool isAFaciesLine() const;
 
 		/**
 		* Get the role of this polyline.
 		* Throw an exception if the polyline has no role (see method hasALineRole).
 		*/
-        gsoap_resqml2_0_1::resqml2__LineRole getLineRole() const;
+		DLL_IMPORT_OR_EXPORT gsoap_resqml2_0_1::resqml2__LineRole getLineRole() const;
 
 		/**
 		* Set the line role of this instance
 		*/
-		void setLineRole(const gsoap_resqml2_0_1::resqml2__LineRole & lineRole);
+		DLL_IMPORT_OR_EXPORT void setLineRole(const gsoap_resqml2_0_1::resqml2__LineRole & lineRole);
 
-		unsigned int getPatchCount() const {return 1;}
+		DLL_IMPORT_OR_EXPORT unsigned int getPatchCount() const {return 1;}
 
 	protected:
 		std::vector<epc::Relationship> getAllEpcRelationships() const;
 	};
 }
-

--- a/src/resqml2_0_1/PolylineSetRepresentation.h
+++ b/src/resqml2_0_1/PolylineSetRepresentation.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT PolylineSetRepresentation : public RESQML2_NS::AbstractRepresentation
+	class PolylineSetRepresentation : public RESQML2_NS::AbstractRepresentation
 	{
 	private :
 		gsoap_resqml2_0_1::resqml2__PointGeometry* getPointGeometry2_0_1(const unsigned int & patchIndex) const;
@@ -76,41 +76,41 @@ namespace RESQML2_0_1_NS
 		*/
 		~PolylineSetRepresentation() {}
 
-		std::string getHdfProxyUuid() const;
+		DLL_IMPORT_OR_EXPORT std::string getHdfProxyUuid() const;
 
 		/**
 		* Get the number of polylines in a given patch
 		*/
-		unsigned int getPolylineCountOfPatch(const unsigned int & patchIndex) const;
-		unsigned int getPolylineCountOfAllPatches() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getPolylineCountOfPatch(const unsigned int & patchIndex) const;
+		DLL_IMPORT_OR_EXPORT unsigned int getPolylineCountOfAllPatches() const;
 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
-		void getNodeCountPerPolylineInPatch(const unsigned int & patchIndex, unsigned int * NodeCountPerPolyline) const;
+		DLL_IMPORT_OR_EXPORT void getNodeCountPerPolylineInPatch(const unsigned int & patchIndex, unsigned int * NodeCountPerPolyline) const;
 
 		/**
 		 * Get all the node count par polyline for all teh aptches of the representation.
 		 * @param NodeCountPerPolyline It must be pre-allocated.
 		 */
-		void getNodeCountPerPolylineOfAllPatches(unsigned int * NodeCountPerPolyline) const;
+		DLL_IMPORT_OR_EXPORT void getNodeCountPerPolylineOfAllPatches(unsigned int * NodeCountPerPolyline) const;
 
 		/**
 		* Get the xyz point count in a given patch.
 		*/
-		ULONG64 getXyzPointCountOfPatch(const unsigned int & patchIndex) const;
+		DLL_IMPORT_OR_EXPORT ULONG64 getXyzPointCountOfPatch(const unsigned int & patchIndex) const;
 
 		/**
 		* Get all the XYZ points of a particular patch of this representation.
 		* XYZ points are given in the local CRS.
 		* @param xyzPoints A linearized 2d array where the first (quickest) dimension is coordinate dimension (XYZ) and second dimension is vertex dimension. It must be pre allocated.
 		*/
-		void getXyzPointsOfPatch(const unsigned int & patchIndex, double * xyzPoints) const;
+		DLL_IMPORT_OR_EXPORT void getXyzPointsOfPatch(const unsigned int & patchIndex, double * xyzPoints) const;
 
 		/**
 		 * Get the number of triangle patch
 		 */
-		unsigned int getPatchCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getPatchCount() const;
 
 		/**
 		* Push back a new patch of polylines
@@ -120,7 +120,7 @@ namespace RESQML2_0_1_NS
 		* @param allPolylinesClosedFlag	Indicates the closed flags of all the polylines.
 		* @param proxy					The HDF proxy which defines where the nodes and triangle indices will be stored.
 		*/
-		void pushBackGeometryPatch(
+		DLL_IMPORT_OR_EXPORT void pushBackGeometryPatch(
 				unsigned int * NodeCountPerPolyline, double * nodes,
 				const unsigned int & polylineCount, const bool & allPolylinesClosedFlag,
 				COMMON_NS::AbstractHdfProxy* proxy);
@@ -133,7 +133,7 @@ namespace RESQML2_0_1_NS
 		* @param polylineClosedFlags	Indicates the closed flags for each of the polyline. The count of this array must be polylineCount.
 		* @param proxy					The HDF proxy which defines where the nodes and triangle indices will be stored.
 		*/
-		void pushBackGeometryPatch(
+		DLL_IMPORT_OR_EXPORT void pushBackGeometryPatch(
 				unsigned int * NodeCountPerPolyline, double * nodes,
 				const unsigned int & polylineCount, bool * polylineClosedFlags,
 				COMMON_NS::AbstractHdfProxy* proxy);
@@ -144,8 +144,8 @@ namespace RESQML2_0_1_NS
 		* @param patchIndex	The index of the patch to check.
 		* @return			True if all polylines of the studied patch are closed.
 		*/
-		bool areAllPolylinesClosedOfPatch(const unsigned int & patchIndex) const;
-		bool areAllPolylinesClosedOfAllPatches() const;
+		DLL_IMPORT_OR_EXPORT bool areAllPolylinesClosedOfPatch(const unsigned int & patchIndex) const;
+		DLL_IMPORT_OR_EXPORT bool areAllPolylinesClosedOfAllPatches() const;
 
 		/**
 		* Check if all polylines contained in a single patch are closed or not.
@@ -153,32 +153,30 @@ namespace RESQML2_0_1_NS
 		* @param patchIndex	The index of the patch to check.
 		* @return			True if all polylines of the studied patch are not closed.
 		*/
-		bool areAllPolylinesNonClosedOfPatch(const unsigned int & patchIndex) const;
-		bool areAllPolylinesNonClosedOfAllPatches() const;
+		DLL_IMPORT_OR_EXPORT bool areAllPolylinesNonClosedOfPatch(const unsigned int & patchIndex) const;
+		DLL_IMPORT_OR_EXPORT bool areAllPolylinesNonClosedOfAllPatches() const;
 		
 		/**
 		 * Get all the node count par polyline for all teh aptches of the representation.
 		 * @param NodeCountPerPolyline It must be pre-allocated.
 		 */
-		void getClosedFlagPerPolylineOfPatch(const unsigned int & patchIndex, bool * closedFlagPerPolyline) const;
-		void getClosedFlagPerPolylineOfAllPatches(bool * closedFlagPerPolyline) const;
+		DLL_IMPORT_OR_EXPORT void getClosedFlagPerPolylineOfPatch(const unsigned int & patchIndex, bool * closedFlagPerPolyline) const;
+		DLL_IMPORT_OR_EXPORT void getClosedFlagPerPolylineOfAllPatches(bool * closedFlagPerPolyline) const;
 
 		/**
 		* Indicates if the polylineSet is associated to a particular LineRole.
 		*/
-		bool hasALineRole() const;
+		DLL_IMPORT_OR_EXPORT bool hasALineRole() const;
 
 		/**
 		* Get the role of this polylineSet.
 		* Throw an exception if the polylineSet has no role (see method hasALineRole).
 		*/
-        gsoap_resqml2_0_1::resqml2__LineRole getLineRole() const;
+		DLL_IMPORT_OR_EXPORT gsoap_resqml2_0_1::resqml2__LineRole getLineRole() const;
 
 		/**
 		* Set the line role of this instance
 		*/
-		void setLineRole(const gsoap_resqml2_0_1::resqml2__LineRole & lineRole);
-
+		DLL_IMPORT_OR_EXPORT void setLineRole(const gsoap_resqml2_0_1::resqml2__LineRole & lineRole);
 	};
 }
-

--- a/src/resqml2_0_1/PropertyKind.h
+++ b/src/resqml2_0_1/PropertyKind.h
@@ -23,7 +23,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT PropertyKind : public RESQML2_NS::PropertyKind
+	class PropertyKind : public RESQML2_NS::PropertyKind
 	{
 	private:
 
@@ -93,11 +93,11 @@ namespace RESQML2_0_1_NS
 		*/
 		~PropertyKind() {}
 
-		bool isChildOf(gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind standardPropKind) const;
+		DLL_IMPORT_OR_EXPORT bool isChildOf(gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind standardPropKind) const;
 
-		bool isAbstract() const;
+		DLL_IMPORT_OR_EXPORT bool isAbstract() const;
 
-		bool isParentPartial() const;
+		DLL_IMPORT_OR_EXPORT bool isParentPartial() const;
 
 	protected:
 		void setXmlParentPropertyKind(RESQML2_NS::PropertyKind* parentPropertyKind);
@@ -107,5 +107,3 @@ namespace RESQML2_0_1_NS
 		friend RESQML2_0_1_NS::PropertyKind* PropertyKindMapper::addResqmlLocalPropertyKindToEpcDocumentFromApplicationPropertyKindName(const std::string & applicationPropertyKindName, const std::string & application);
 	};
 }
-
-

--- a/src/resqml2_0_1/PropertyKindMapper.h
+++ b/src/resqml2_0_1/PropertyKindMapper.h
@@ -28,7 +28,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT PropertyKindMapper
+	class PropertyKindMapper
 	{
 	public:
 		PropertyKindMapper(COMMON_NS::EpcDocument* epcDoc):epcDocument(epcDoc) {}
@@ -41,7 +41,7 @@ namespace RESQML2_0_1_NS
 		* All others xml files must be local property kinds mapping.
 		* @param directory The directory must not end with any slash
 		*/
-		std::string loadMappingFilesFromDirectory(const std::string & directory);
+		DLL_IMPORT_OR_EXPORT std::string loadMappingFilesFromDirectory(const std::string & directory);
 
 		/**
 		 * Get the name of a resqml standard property kind into a particular application.
@@ -50,53 +50,53 @@ namespace RESQML2_0_1_NS
 		 * @apram	application						The name of the application
 		 * @return	The property kind name in the particular application. Or an empty string if not found.
 		 */
-		std::string getApplicationPropertyKindNameFromResqmlStandardPropertyKindName(const gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind & resqmlStandardPropertyKindName, const std::string & application) const;
+		DLL_IMPORT_OR_EXPORT std::string getApplicationPropertyKindNameFromResqmlStandardPropertyKindName(const gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind & resqmlStandardPropertyKindName, const std::string & application) const;
 
 		/**
 		 * @apram	application						The name of the application
 		 * @return	The abstract Resqml root property name if no resqml standard property name have been found for this particular application property kind name.
 		 */
-		gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind getResqmlStandardPropertyKindNameFromApplicationPropertyKindName(const std::string & applicationPropertyKindName, const std::string & application) const;
+		DLL_IMPORT_OR_EXPORT gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind getResqmlStandardPropertyKindNameFromApplicationPropertyKindName(const std::string & applicationPropertyKindName, const std::string & application) const;
 
 		/**
 		 * @apram	application						The name of the application
 		 * @return	empty string if not found
 		 */
-		std::string getApplicationPropertyKindNameFromResqmlLocalPropertyKindUuid(const std::string & resqmlLocalPropertyKindUuid, const std::string & application) const;
+		DLL_IMPORT_OR_EXPORT std::string getApplicationPropertyKindNameFromResqmlLocalPropertyKindUuid(const std::string & resqmlLocalPropertyKindUuid, const std::string & application) const;
 
 		/**
 		* @return empty string if not found
 		*/
-		std::string getResqmlLocalPropertyKindUuidFromApplicationPropertyKindName(const std::string & applicationPropertyKindName, const std::string & application) const;
+		DLL_IMPORT_OR_EXPORT std::string getResqmlLocalPropertyKindUuidFromApplicationPropertyKindName(const std::string & applicationPropertyKindName, const std::string & application) const;
 
 		/**
 		* Add a resqml local property type into the EPC document given in constructor if not already present in EPC document.
 		* This addition will also add all needed resqml local property type parent into the EPC document.
 		*/
-		class PropertyKind* addResqmlLocalPropertyKindToEpcDocumentFromApplicationPropertyKindName(const std::string & applicationPropertyKindName, const std::string & application);
+		DLL_IMPORT_OR_EXPORT class PropertyKind* addResqmlLocalPropertyKindToEpcDocumentFromApplicationPropertyKindName(const std::string & applicationPropertyKindName, const std::string & application);
 
 		/**
 		 * Get the title of the parent of a Resqml Standard PropertyKind.
 		 */
-		gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind getPropertyKindParentOfResqmlStandardPropertyKindName(const gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind & resqmlStandardPropertyKindName) const;
+		DLL_IMPORT_OR_EXPORT gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind getPropertyKindParentOfResqmlStandardPropertyKindName(const gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind & resqmlStandardPropertyKindName) const;
 
 		/**
 		 * Get the description of a Resqml Standard PropertyKind.
 		 */
-		std::string getDescriptionOfResqmlStandardPropertyKindName(const gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind & resqmlStandardPropertyKindName) const;
+		DLL_IMPORT_OR_EXPORT std::string getDescriptionOfResqmlStandardPropertyKindName(const gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind & resqmlStandardPropertyKindName) const;
 
 		/**
 		* Check if a resqml property kind is a child of another one.
 		* @param child	The resqml property kind which is supposed to be the child
 		* @param parent	The resqml property kind which is supposed to be the parent
 		*/
-		bool isChildOf(gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind child, gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind parent) const;
+		DLL_IMPORT_OR_EXPORT bool isChildOf(gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind child, gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind parent) const;
 
 		/**
 		* Check if a resqml property kind is an abstract one or not.
 		* @param resqmlStandardPropertyKindName	The resqml property kind to test
 		*/
-		bool isAbstract(gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind resqmlStandardPropertyKindName) const;
+		DLL_IMPORT_OR_EXPORT bool isAbstract(gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind resqmlStandardPropertyKindName) const;
 
 	private:
 		COMMON_NS::EpcDocument * epcDocument;
@@ -130,4 +130,3 @@ namespace RESQML2_0_1_NS
 
 	};
 }
-

--- a/src/resqml2_0_1/RepresentationSetRepresentation.h
+++ b/src/resqml2_0_1/RepresentationSetRepresentation.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT RepresentationSetRepresentation : public RESQML2_NS::RepresentationSetRepresentation
+	class RepresentationSetRepresentation : public RESQML2_NS::RepresentationSetRepresentation
 	{
 	protected:
 		RepresentationSetRepresentation(RESQML2_NS::AbstractFeatureInterpretation* interp) : RESQML2_NS::RepresentationSetRepresentation(interp) {}
@@ -55,4 +55,3 @@ namespace RESQML2_0_1_NS
 		~RepresentationSetRepresentation() {}
 	};
 }
-

--- a/src/resqml2_0_1/SealedSurfaceFrameworkRepresentation.cpp
+++ b/src/resqml2_0_1/SealedSurfaceFrameworkRepresentation.cpp
@@ -261,9 +261,20 @@ gsoap_resqml2_0_1::resqml2__ContactPatch* SealedSurfaceFrameworkRepresentation::
 	return contactRep->Contact[cpIndex];
 }
 
-RESQML2_NS::AbstractRepresentation* SealedSurfaceFrameworkRepresentation::getRepresentationOfContactPatch(unsigned int crIndex, unsigned int cpIndex) const
+RESQML2_NS::AbstractRepresentation* SealedSurfaceFrameworkRepresentation::getRepresentationOfContactPatch(unsigned int contactIdx, unsigned int cpIndex) const
 {
-	return getRepresentation(getContactPatch(crIndex, cpIndex)->RepresentationIndex);
+	return getRepresentation(getRepresentationIndexOfContactPatch(contactIdx, cpIndex));
+}
+
+unsigned int SealedSurfaceFrameworkRepresentation::getRepresentationIndexOfContactPatch(unsigned int contactIdx, unsigned int cpIndex) const
+{
+	const ULONG64 index = getContactPatch(contactIdx, cpIndex)->RepresentationIndex;
+
+	if (index > (std::numeric_limits<unsigned int>::max)()) {
+		throw range_error("The index of the representation is too big.");
+	}
+
+	return static_cast<unsigned int>(index);
 }
 
 unsigned int SealedSurfaceFrameworkRepresentation::getContactPatchNodeCount(unsigned int crIndex, unsigned int cpIndex) const

--- a/src/resqml2_0_1/SealedSurfaceFrameworkRepresentation.h
+++ b/src/resqml2_0_1/SealedSurfaceFrameworkRepresentation.h
@@ -183,6 +183,15 @@ namespace RESQML2_0_1_NS
 		DLL_IMPORT_OR_EXPORT RESQML2_NS::AbstractRepresentation* getRepresentationOfContactPatch(unsigned int contactIdx, unsigned int cpIndex) const;
 
 		/**
+		* Get the representation index where a particular contact patch has been defined. The index is in the range [0..getRepresentationCount()[.
+		*
+		* @param contactIdx	The index of the contact in the contact list. It must be in the interval [0..getContactCount()[.
+		* @param cpIndex	The index of the contact patch in the contact. It must be in the interval [0..getContactPatchCount()[.
+		* @return			The representation index where the contact patch has been defined.
+		*/
+		DLL_IMPORT_OR_EXPORT unsigned int getRepresentationIndexOfContactPatch(unsigned int contactIdx, unsigned int cpIndex) const;
+
+		/**
 		* Get the count of nodes of a particular contact patch.
 		*
 		* @param contactIdx	The index of the contact in the contact list. It must be in the interval [0..getContactCount()[.

--- a/src/resqml2_0_1/SeismicLatticeFeature.h
+++ b/src/resqml2_0_1/SeismicLatticeFeature.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT SeismicLatticeFeature : public AbstractTechnicalFeature
+	class SeismicLatticeFeature : public AbstractTechnicalFeature
 	{
 	public:
 
@@ -66,25 +66,24 @@ namespace RESQML2_0_1_NS
 		/**
 		* Get the crossline index increment between two consecutive crosslines.
 		*/
-		int getCrosslineIncrement() const;
+		DLL_IMPORT_OR_EXPORT int getCrosslineIncrement() const;
 		
 		/**
 		* Get the inline index increment between two consecutive inlines.
 		*/
-		int getInlineIncrement() const;
+		DLL_IMPORT_OR_EXPORT int getInlineIncrement() const;
 		
 		/**
 		* Get the index of the first crossline.
 		*/
-		int getOriginCrossline() const;
+		DLL_IMPORT_OR_EXPORT int getOriginCrossline() const;
 		
 		/**
 		* Get the index of the first inline.
 		*/
-		int getOriginInline() const;
+		DLL_IMPORT_OR_EXPORT int getOriginInline() const;
 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 	};
 }
-

--- a/src/resqml2_0_1/SeismicLineFeature.h
+++ b/src/resqml2_0_1/SeismicLineFeature.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT SeismicLineFeature : public AbstractTechnicalFeature
+	class SeismicLineFeature : public AbstractTechnicalFeature
 	{
 	public:
 
@@ -59,24 +59,24 @@ namespace RESQML2_0_1_NS
 		/**
 		* Get the trace index increment between two consecutive traces.
 		*/
-		int getTraceIndexIncrement() const;
+		DLL_IMPORT_OR_EXPORT int getTraceIndexIncrement() const;
 		
 		/**
 		* Get the first trace index.
 		*/
-		int getFirstTraceIndex() const;
+		DLL_IMPORT_OR_EXPORT int getFirstTraceIndex() const;
 		
-		void setSeismicLineSet(class SeismicLineSetFeature * seisLineSet);
+		DLL_IMPORT_OR_EXPORT void setSeismicLineSet(class SeismicLineSetFeature * seisLineSet);
 
-		class SeismicLineSetFeature* getSeismicLineSet() {return seismicLineSet;}
+		DLL_IMPORT_OR_EXPORT class SeismicLineSetFeature* getSeismicLineSet() {return seismicLineSet;}
 
 		/**
 		* Get the total count of traces in this seismic line.
 		*/
-		unsigned int getTraceCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getTraceCount() const;
 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
 	private:
 
@@ -86,4 +86,3 @@ namespace RESQML2_0_1_NS
 		class SeismicLineSetFeature* seismicLineSet;
 	};
 }
-

--- a/src/resqml2_0_1/SeismicLineSetFeature.h
+++ b/src/resqml2_0_1/SeismicLineSetFeature.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT SeismicLineSetFeature : public AbstractTechnicalFeature
+	class SeismicLineSetFeature : public AbstractTechnicalFeature
 	{
 	public:
 
@@ -49,8 +49,8 @@ namespace RESQML2_0_1_NS
 		*/
 		~SeismicLineSetFeature() {}
 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
 	private:
         std::vector<epc::Relationship> getAllEpcRelationships() const;
@@ -61,4 +61,3 @@ namespace RESQML2_0_1_NS
 		friend void SeismicLineFeature::setSeismicLineSet(SeismicLineSetFeature * seisLineSet);
 	};
 }
-

--- a/src/resqml2_0_1/StratigraphicColumn.h
+++ b/src/resqml2_0_1/StratigraphicColumn.h
@@ -25,7 +25,7 @@ namespace RESQML2_0_1_NS
 	/**
 	* This class is a container for other organizations that are consistent to each others.
 	*/
-	class DLL_IMPORT_OR_EXPORT StratigraphicColumn : public COMMON_NS::AbstractObject
+	class StratigraphicColumn : public COMMON_NS::AbstractObject
 	{
 	public:
 
@@ -53,15 +53,15 @@ namespace RESQML2_0_1_NS
 		*/
 		~StratigraphicColumn() {}
 
-		void pushBackStratiColumnRank(class StratigraphicColumnRankInterpretation * stratiColumnRank);
+		DLL_IMPORT_OR_EXPORT void pushBackStratiColumnRank(class StratigraphicColumnRankInterpretation * stratiColumnRank);
 
 		/**
 		 * Get all the stratigraphic column rank interpretations which are contained in this stratigraphic column.
 		 */
-		std::vector<class StratigraphicColumnRankInterpretation*> getStratigraphicColumnRankInterpretationSet() const {return stratigraphicColumnRankSet;}
+		DLL_IMPORT_OR_EXPORT std::vector<class StratigraphicColumnRankInterpretation*> getStratigraphicColumnRankInterpretationSet() const {return stratigraphicColumnRankSet;}
                 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
     private:
         std::vector<epc::Relationship> getAllEpcRelationships() const;
@@ -76,4 +76,3 @@ namespace RESQML2_0_1_NS
 		friend void EarthModelInterpretation::setStratiColumn(StratigraphicColumn * stratiColumn); 
 	};
 }
-

--- a/src/resqml2_0_1/StratigraphicColumnRankInterpretation.h
+++ b/src/resqml2_0_1/StratigraphicColumnRankInterpretation.h
@@ -27,7 +27,7 @@ namespace RESQML2_0_1_NS
 	/**
 	* This class is a container for other organizations that are consistent to each others.
 	*/
-	class DLL_IMPORT_OR_EXPORT StratigraphicColumnRankInterpretation : public AbstractStratigraphicOrganizationInterpretation
+	class StratigraphicColumnRankInterpretation : public AbstractStratigraphicOrganizationInterpretation
 	{
 	public:
 
@@ -61,14 +61,14 @@ namespace RESQML2_0_1_NS
         * Add a StratiUnitInterp to this StratigraphicColumnRankInterpretation.
         * Does add the inverse relationship i.e. from the included StratiUnitInterp to this StratigraphicColumnRankInterpretation.
         */
-        void pushBackStratiUnitInterpretation(class StratigraphicUnitInterpretation * stratiUnitInterpretation);
+		DLL_IMPORT_OR_EXPORT void pushBackStratiUnitInterpretation(class StratigraphicUnitInterpretation * stratiUnitInterpretation);
 		
-		void setHorizonOfLastContact(class HorizonInterpretation * partOf);
+		DLL_IMPORT_OR_EXPORT void setHorizonOfLastContact(class HorizonInterpretation * partOf);
 
 		/**
 		 * Add a stratigraphic binary contact to the organization interpretation.
 		 */
-		void pushBackStratigraphicBinaryContact(StratigraphicUnitInterpretation* subject, const gsoap_resqml2_0_1::resqml2__ContactMode & subjectContactMode,
+		DLL_IMPORT_OR_EXPORT void pushBackStratigraphicBinaryContact(StratigraphicUnitInterpretation* subject, const gsoap_resqml2_0_1::resqml2__ContactMode & subjectContactMode,
 			StratigraphicUnitInterpretation* directObject, const gsoap_resqml2_0_1::resqml2__ContactMode & directObjectMode,
 			class HorizonInterpretation * partOf = nullptr);
 
@@ -76,64 +76,64 @@ namespace RESQML2_0_1_NS
 		* Indicates if this strati column rank interp is wether a chrono one or not.
 		* One of the consequence is that in a chrono strati column rank interp, each strati unit interp have only one top and only one bottom.
 		*/
-		bool isAChronoStratiRank() const;
+		DLL_IMPORT_OR_EXPORT bool isAChronoStratiRank() const;
 
 		/**
 		* Get the count of contacts in this strati column rank interp.
 		*/
-		unsigned int getContactCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getContactCount() const;
 
 		/**
 		* Get the contact mode between the subject strati unit and the contact located at a particular index.
 		* Most of time the subject strati unit is the strati unit on top of the contact.
 		* @return	proportional contact mode by default or the contact mode of the subject.
 		*/
-		gsoap_resqml2_0_1::resqml2__ContactMode getSubjectContactModeOfContact(const unsigned int & contactIndex) const;
+		DLL_IMPORT_OR_EXPORT gsoap_resqml2_0_1::resqml2__ContactMode getSubjectContactModeOfContact(const unsigned int & contactIndex) const;
 
 		/**
 		* Get the strati unt interpretation which is the subject of a particular contact.
 		*/
-		class StratigraphicUnitInterpretation* getSubjectOfContact(const unsigned int & contactIndex) const;
+		DLL_IMPORT_OR_EXPORT class StratigraphicUnitInterpretation* getSubjectOfContact(const unsigned int & contactIndex) const;
 
 		/**
 		* Get the contact mode between the direct object strati unit and the contact located at a particular index.
 		* Most of time the subject strati unit is the strati unit below the contact.
 		* @return	proportional contact mode by default or the contact mode of the direct object.
 		*/
-		gsoap_resqml2_0_1::resqml2__ContactMode getDirectObjectContactModeOfContact(const unsigned int & contactIndex) const;
+		DLL_IMPORT_OR_EXPORT gsoap_resqml2_0_1::resqml2__ContactMode getDirectObjectContactModeOfContact(const unsigned int & contactIndex) const;
 
 		/**
 		* Get the strati unt interpretation which is the direct object of a particular contact.
 		*/
-		class StratigraphicUnitInterpretation* getDirectObjectOfContact(const unsigned int & contactIndex) const;
+		DLL_IMPORT_OR_EXPORT class StratigraphicUnitInterpretation* getDirectObjectOfContact(const unsigned int & contactIndex) const;
 
 		/**
 		* Get the horizon interpretation which is the contact between two strati units.
 		*/
-		class HorizonInterpretation* getHorizonInterpretationOfContact(const unsigned int & contactIndex) const;
+		DLL_IMPORT_OR_EXPORT class HorizonInterpretation* getHorizonInterpretationOfContact(const unsigned int & contactIndex) const;
 
 		/**
 		* Get all the stratigraphic unit interpretations contained in this StratigraphicColumnRankInterpretation.
 		*/
-		const std::vector<class StratigraphicUnitInterpretation*> & getStratigraphicUnitInterpretationSet() const;
+		DLL_IMPORT_OR_EXPORT const std::vector<class StratigraphicUnitInterpretation*> & getStratigraphicUnitInterpretationSet() const;
 
 		/**
 		* Get all the stratigraphic occurence interpretations associated with this StratigraphicColumnRankInterpretation.
 		*/
-		const std::vector<class StratigraphicOccurrenceInterpretation*> & getStratigraphicOccurrenceInterpretationSet() const;
+		DLL_IMPORT_OR_EXPORT const std::vector<class StratigraphicOccurrenceInterpretation*> & getStratigraphicOccurrenceInterpretationSet() const;
 
 		/**
 		* Get all the horizon interpretations contained in this StratigraphicColumnRankInterpretation.
 		*/
-		const std::vector<class HorizonInterpretation*> & getHorizonInterpretationSet() const;
+		DLL_IMPORT_OR_EXPORT const std::vector<class HorizonInterpretation*> & getHorizonInterpretationSet() const;
 
 		/**
 		* Get all the stratigraphic column this strati column rank belongs to.
 		*/
-		const std::vector<StratigraphicColumn*> & getStratigraphicColumnSet() const;
+		DLL_IMPORT_OR_EXPORT const std::vector<StratigraphicColumn*> & getStratigraphicColumnSet() const;
 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
 	private:
 

--- a/src/resqml2_0_1/StratigraphicOccurrenceInterpretation.h
+++ b/src/resqml2_0_1/StratigraphicOccurrenceInterpretation.h
@@ -27,7 +27,7 @@ namespace RESQML2_0_1_NS
 	/**
 	* This class is a container for other organizations that are consistent to each others.
 	*/
-	class DLL_IMPORT_OR_EXPORT StratigraphicOccurrenceInterpretation : public AbstractStratigraphicOrganizationInterpretation
+	class StratigraphicOccurrenceInterpretation : public AbstractStratigraphicOrganizationInterpretation
 	{
 	public:
 
@@ -54,19 +54,19 @@ namespace RESQML2_0_1_NS
 		*/
 		~StratigraphicOccurrenceInterpretation() {}
 
-		void setStratigraphicColumnRankInterpretation(class StratigraphicColumnRankInterpretation * stratiColumnRankInterp);
+		DLL_IMPORT_OR_EXPORT void setStratigraphicColumnRankInterpretation(class StratigraphicColumnRankInterpretation * stratiColumnRankInterp);
 
-		class StratigraphicColumnRankInterpretation * getStratigraphicColumnRankInterpretation() const {return stratigraphicColumnRankInterpretation;}
+		DLL_IMPORT_OR_EXPORT class StratigraphicColumnRankInterpretation * getStratigraphicColumnRankInterpretation() const {return stratigraphicColumnRankInterpretation;}
 
 		/**
 		* Get all the stratigraphic occurence interpretations associated with this StratigraphicColumnRankInterpretation.
 		*/
-		std::vector<class WellboreMarkerFrameRepresentation*> getWellboreMarkerFrameRepresentationSet() const { return wellboreMarkerFrameRepresentationSet; }
+		DLL_IMPORT_OR_EXPORT std::vector<class WellboreMarkerFrameRepresentation*> getWellboreMarkerFrameRepresentationSet() const { return wellboreMarkerFrameRepresentationSet; }
 
-		std::string getStratigraphicColumnRankInterpretationUuid() const;
+		DLL_IMPORT_OR_EXPORT std::string getStratigraphicColumnRankInterpretationUuid() const;
                 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
 	private:
 

--- a/src/resqml2_0_1/StringTableLookup.h
+++ b/src/resqml2_0_1/StringTableLookup.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT StringTableLookup : public COMMON_NS::AbstractObject
+	class StringTableLookup : public COMMON_NS::AbstractObject
 	{
 	public:
 
@@ -54,70 +54,70 @@ namespace RESQML2_0_1_NS
 		*/
 		~StringTableLookup() {}
 		
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
 		/**
 		* Add a categorical property values object which uses this string lookup.
 		* Does not add the inverse relationship i.e. from the categorical property values object to this string lookup.
 		*/
-		void addCategoricalPropertyValues(class CategoricalProperty* categVal) {categoricalPropertyValuesSet.push_back(categVal);}
+		DLL_IMPORT_OR_EXPORT void addCategoricalPropertyValues(class CategoricalProperty* categVal) {categoricalPropertyValuesSet.push_back(categVal);}
 
 		/**
 		* Check wether a key value is contained within this string lookup or not.
 		*/
-		bool containsKey(const long & longValue);
+		DLL_IMPORT_OR_EXPORT bool containsKey(const long & longValue);
 
 		/**
 		* Get the count of item in the stringTableLookup (in the map).
 		*/
-		unsigned int getItemCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getItemCount() const;
 
 		/**
 		* Get the key of a string value pair at a particular index in the string table lookup (in the map)
 		*/
-		long getKeyAtIndex(const unsigned int & index) const;
+		DLL_IMPORT_OR_EXPORT long getKeyAtIndex(const unsigned int & index) const;
 
 		/**
 		* Get the string value of a string value pair at a particular index in the string table lookup (in the map)
 		*/
-		std::string getStringValueAtIndex(const unsigned int & index) const;
+		DLL_IMPORT_OR_EXPORT std::string getStringValueAtIndex(const unsigned int & index) const;
 
 		/**
 		* Get a string value from its associated key (long) value.
 		* If the key value does not exist, an empty string is returned.
 		*/
-		std::string getStringValue(const long & longValue);
+		DLL_IMPORT_OR_EXPORT std::string getStringValue(const long & longValue);
 
 		/**
 		* Add a pair value to the string lookup.
 		* No verification that the key value (or string value) already exists
 		*/
-		void addValue(const std::string & strValue, const long & longValue);
+		DLL_IMPORT_OR_EXPORT void addValue(const std::string & strValue, const long & longValue);
 
 		/**
 		* Modify the associated string value according to the key (long) value.
 		* If the key value does not exist, nothing is done.
 		*/
-		void setValue(const std::string & strValue, const long & longValue);
+		DLL_IMPORT_OR_EXPORT void setValue(const std::string & strValue, const long & longValue);
 
 		/*
 		* Get the minimum value in this discrete properties. It reads it from file.
 		* @return the minimum value if present in the file otherwise long.max.
 		*/
-		LONG64 getMinimumValue();
+		DLL_IMPORT_OR_EXPORT LONG64 getMinimumValue();
 
 		/*
 		* Get the maximum value in this discrete properties. It reads it from file.
 		* @return the maximum value if present in the file otherwise long.min.
 		*/
-		LONG64 getMaximumValue();
+		DLL_IMPORT_OR_EXPORT LONG64 getMaximumValue();
 
 		/*
 		* Getter for the underlying map of the string lookup.
 		*/
 #if (defined(_WIN32) && _MSC_VER >= 1600) || defined(__APPLE__)
-		std::unordered_map<long, std::string> getMap() const;
+		DLL_IMPORT_OR_EXPORT std::unordered_map<long, std::string> getMap() const;
 #else
 		std::tr1::unordered_map<long, std::string> getMap() const;
 #endif

--- a/src/resqml2_0_1/StructuralOrganizationInterpretation.h
+++ b/src/resqml2_0_1/StructuralOrganizationInterpretation.h
@@ -23,7 +23,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT StructuralOrganizationInterpretation : public AbstractOrganizationInterpretation
+	class StructuralOrganizationInterpretation : public AbstractOrganizationInterpretation
 	{
 	public:
 
@@ -51,18 +51,18 @@ namespace RESQML2_0_1_NS
 		*/
 		~StructuralOrganizationInterpretation() {}
 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
         /**
         * Add a FaultInterpretation to this StructuralOrganizationInterpretation.
         * Does add the inverse relationship i.e. from the included FaultInterpretation to this StructuralOrganizationInterpretation.
         */
-        void pushBackFaultInterpretation(class FaultInterpretation * faultInterpretation);
+		DLL_IMPORT_OR_EXPORT void pushBackFaultInterpretation(class FaultInterpretation * faultInterpretation);
 
-		unsigned int getFaultInterpretationCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getFaultInterpretationCount() const;
 
-		class FaultInterpretation* getFaultInterpretation(unsigned int index);
+		DLL_IMPORT_OR_EXPORT class FaultInterpretation* getFaultInterpretation(unsigned int index);
 
         /**
         * Add an HorizonInterpretation to this StructuralOrganizationInterpretation.
@@ -70,41 +70,41 @@ namespace RESQML2_0_1_NS
         * @param horizonInterpretation the HorizonInterpretation to add
         * @param stratigraphicRank the rank of the horizon interpretation within this structural organization
         **/
-		void pushBackHorizonInterpretation(class HorizonInterpretation * horizonInterpretation, const int & stratigraphicRank);
+		DLL_IMPORT_OR_EXPORT void pushBackHorizonInterpretation(class HorizonInterpretation * horizonInterpretation, const int & stratigraphicRank);
 
-		unsigned int getHorizonInterpretationCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getHorizonInterpretationCount() const;
 
-		HorizonInterpretation* getHorizonInterpretation(unsigned int index) const;
+		DLL_IMPORT_OR_EXPORT HorizonInterpretation* getHorizonInterpretation(unsigned int index) const;
 
 		/**
         * Add a Frontier interpretation to this StructuralOrganizationInterpretation as a top.
         * Does add the inverse relationship i.e. from the included Frontier interpretation to this StructuralOrganizationInterpretation.
         */
-		void pushBackTopFrontierInterpretation(AbstractFeatureInterpretation * topFrontierInterpretation);
+		DLL_IMPORT_OR_EXPORT void pushBackTopFrontierInterpretation(AbstractFeatureInterpretation * topFrontierInterpretation);
 
-		unsigned int getTopFrontierInterpretationCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getTopFrontierInterpretationCount() const;
 
-		AbstractFeatureInterpretation* getTopFrontierInterpretation(unsigned int index) const;
+		DLL_IMPORT_OR_EXPORT AbstractFeatureInterpretation* getTopFrontierInterpretation(unsigned int index) const;
 
 		/**
         * Add a Frontier interpretation to this StructuralOrganizationInterpretation as a bottom.
         * Does add the inverse relationship i.e. from the included Frontier interpretation to this StructuralOrganizationInterpretation.
         */
-        void pushBackBottomFrontierInterpretation(AbstractFeatureInterpretation * bottomFrontierInterpretation);
+		DLL_IMPORT_OR_EXPORT  void pushBackBottomFrontierInterpretation(AbstractFeatureInterpretation * bottomFrontierInterpretation);
 
-		unsigned int getBottomFrontierInterpretationCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getBottomFrontierInterpretationCount() const;
 
-		AbstractFeatureInterpretation* getBottomFrontierInterpretation(unsigned int index) const;
+		DLL_IMPORT_OR_EXPORT AbstractFeatureInterpretation* getBottomFrontierInterpretation(unsigned int index) const;
 
 		/**
         * Add a Frontier interpretation to this StructuralOrganizationInterpretation as a side.
         * Does add the inverse relationship i.e. from the included Frontier interpretation to this StructuralOrganizationInterpretation.
         */
-        void pushBackSideFrontierInterpretation(AbstractFeatureInterpretation * sideFrontierInterpretation);
+		DLL_IMPORT_OR_EXPORT void pushBackSideFrontierInterpretation(AbstractFeatureInterpretation * sideFrontierInterpretation);
 
-		unsigned int getSideFrontierInterpretationCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getSideFrontierInterpretationCount() const;
 
-		AbstractFeatureInterpretation* getSideFrontierInterpretation(unsigned int index) const;
+		DLL_IMPORT_OR_EXPORT AbstractFeatureInterpretation* getSideFrontierInterpretation(unsigned int index) const;
 
     private:
 

--- a/src/resqml2_0_1/SubRepresentation.h
+++ b/src/resqml2_0_1/SubRepresentation.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT SubRepresentation : public RESQML2_NS::SubRepresentation
+	class SubRepresentation : public RESQML2_NS::SubRepresentation
 	{
 	private:
 		/*
@@ -82,46 +82,46 @@ namespace RESQML2_0_1_NS
 		*/
 		~SubRepresentation() {}
 
-		std::string getHdfProxyUuid() const;
+		DLL_IMPORT_OR_EXPORT std::string getHdfProxyUuid() const;
 
 		/**
 		* Get the kind of the selected elements for a particular patch of this subrepresentation.
 		*/
-		RESQML2_NS::AbstractRepresentation::indexableElement getElementKindOfPatch(const unsigned int & patchIndex, const unsigned int & elementIndicesIndex) const;
+		DLL_IMPORT_OR_EXPORT RESQML2_NS::AbstractRepresentation::indexableElement getElementKindOfPatch(const unsigned int & patchIndex, const unsigned int & elementIndicesIndex) const;
 
 		/**
 		* Get the count of the selected elements for a particular patch of this subrepresentation.
 		*/
-		ULONG64 getElementCountOfPatch(const unsigned int & patchIndex) const;
+		DLL_IMPORT_OR_EXPORT ULONG64 getElementCountOfPatch(const unsigned int & patchIndex) const;
 
 		/**
 		* Get the indices of the selected elements in the supporting representation for a particular patch of this subrepresentation.
 		* @param	elementIndicesIndex	Must be equal to 0 if the element indices are not pairwise.
 		* @param	elementIndices		This array must be preallocated with getElementCountOfPatch() size.
 		*/
-		void getElementIndicesOfPatch(const unsigned int & patchIndex, const unsigned int & elementIndicesIndex, ULONG64 * elementIndices) const;
+		DLL_IMPORT_OR_EXPORT void getElementIndicesOfPatch(const unsigned int & patchIndex, const unsigned int & elementIndicesIndex, ULONG64 * elementIndices) const;
 
 		/**
 		* Get the indices of the supporting representations of the selected elements for a particular patch of this subrepresentation.
 		* @param	supportingRepresentationIndices	This array must be preallocated with getElementCountOfPatch() size.
 		*/
-		void getSupportingRepresentationIndicesOfPatch(const unsigned int & patchIndex, short * supportingRepresentationIndices) const;
+		DLL_IMPORT_OR_EXPORT void getSupportingRepresentationIndicesOfPatch(const unsigned int & patchIndex, short * supportingRepresentationIndices) const;
 
 		/**
 		* Check if the element of a particular patch are pairwise or not.
 		*/
-		bool areElementIndicesPairwise(const unsigned int & patchIndex) const;
+		DLL_IMPORT_OR_EXPORT bool areElementIndicesPairwise(const unsigned int & patchIndex) const;
 
 		/**
 		* Check if the element indices of a particular patch are based on a lattice or not.
 		* @param elementIndicesIndex	In case of pairwise element, allow to select the first or second element indice of the pair.
 		*/
-		bool areElementIndicesBasedOnLattice(const unsigned int & patchIndex, const unsigned int & elementIndicesIndex = 0) const;
+		DLL_IMPORT_OR_EXPORT bool areElementIndicesBasedOnLattice(const unsigned int & patchIndex, const unsigned int & elementIndicesIndex = 0) const;
 
-		LONG64 getLatticeElementIndicesStartValue(const unsigned int & patchIndex, const unsigned int & elementIndicesIndex = 0) const;
-		unsigned int getLatticeElementIndicesDimensionCount(const unsigned int & patchIndex, const unsigned int & elementIndicesIndex = 0) const;
-		LONG64 getLatticeElementIndicesOffsetValue(const unsigned int & latticeDimensionIndex, const unsigned int & patchIndex, const unsigned int & elementIndicesIndex = 0) const;
-		ULONG64 getLatticeElementIndicesOffsetCount(const unsigned int & latticeDimensionIndex, const unsigned int & patchIndex, const unsigned int & elementIndicesIndex = 0) const;
+		DLL_IMPORT_OR_EXPORT LONG64 getLatticeElementIndicesStartValue(const unsigned int & patchIndex, const unsigned int & elementIndicesIndex = 0) const;
+		DLL_IMPORT_OR_EXPORT unsigned int getLatticeElementIndicesDimensionCount(const unsigned int & patchIndex, const unsigned int & elementIndicesIndex = 0) const;
+		DLL_IMPORT_OR_EXPORT LONG64 getLatticeElementIndicesOffsetValue(const unsigned int & latticeDimensionIndex, const unsigned int & patchIndex, const unsigned int & elementIndicesIndex = 0) const;
+		DLL_IMPORT_OR_EXPORT ULONG64 getLatticeElementIndicesOffsetCount(const unsigned int & latticeDimensionIndex, const unsigned int & patchIndex, const unsigned int & elementIndicesIndex = 0) const;
 
 		/**
 		* Push back a new patch in the subrepresentation which is based on a lattice definition.
@@ -130,7 +130,7 @@ namespace RESQML2_0_1_NS
 		* @param elementCountInMiddleDimension		Commonly in J dimensionn.
 		* @param elementCountInFastestDimension		Commonly in I dimension.
 		*/
-		void pushBackSubRepresentationPatch(const gsoap_resqml2_0_1::resqml2__IndexableElements & elementKind, const ULONG64 & originIndex, 
+		DLL_IMPORT_OR_EXPORT void pushBackSubRepresentationPatch(const gsoap_resqml2_0_1::resqml2__IndexableElements & elementKind, const ULONG64 & originIndex,
 			const unsigned int & elementCountInSlowestDimension,
 			const unsigned int & elementCountInMiddleDimension,
 			const unsigned int & elementCountInFastestDimension);
@@ -143,7 +143,7 @@ namespace RESQML2_0_1_NS
         * @param	proxy					The HDF proxy where the numerical values (indices) are stored.
 		* @param	supportingRepIndices	The indices of the supporting represenation for each elment in the supporting representation. The count must be elementCount.
 		*/
-		void pushBackSubRepresentationPatch(const gsoap_resqml2_0_1::resqml2__IndexableElements & elementKind, const ULONG64 & elementCount, ULONG64 * elementIndices, COMMON_NS::AbstractHdfProxy* proxy, short * supportingRepIndices = nullptr);
+		DLL_IMPORT_OR_EXPORT void pushBackSubRepresentationPatch(const gsoap_resqml2_0_1::resqml2__IndexableElements & elementKind, const ULONG64 & elementCount, ULONG64 * elementIndices, COMMON_NS::AbstractHdfProxy* proxy, short * supportingRepIndices = nullptr);
 
 		/**
 		* Push back a new patch in the subrepresentation which is constituted by means of pairwise elements.
@@ -154,7 +154,7 @@ namespace RESQML2_0_1_NS
 		* @param elementIndices1	The indices of the second part of the element pair in the supporting representation.
         * @param proxy				The HDF proxy where the numerical values (indices) are stored.
 		*/
-		void pushBackSubRepresentationPatch(const gsoap_resqml2_0_1::resqml2__IndexableElements & elementKind0, const gsoap_resqml2_0_1::resqml2__IndexableElements & elementKind1,
+		DLL_IMPORT_OR_EXPORT void pushBackSubRepresentationPatch(const gsoap_resqml2_0_1::resqml2__IndexableElements & elementKind0, const gsoap_resqml2_0_1::resqml2__IndexableElements & elementKind1,
 			const ULONG64 & elementCount,
 			ULONG64 * elementIndices0, ULONG64 * elementIndices1,
 			COMMON_NS::AbstractHdfProxy* proxy);
@@ -169,15 +169,15 @@ namespace RESQML2_0_1_NS
 		* @param	hdfProxy				The HDF5 proxy where the values are already or will be stored.
 		* @param	supportingRepDataset	The HDF5 dataset name where the element indices are stored. If empty, it won't be exported any information about suppporting rep relying on the fact there is only one suppporting rep for this whole patch.
 		*/
-		void pushBackRefToExistingDataset(const gsoap_resqml2_0_1::resqml2__IndexableElements & elementKind, const ULONG64 & elementCount, const std::string & elementDataset,
+		DLL_IMPORT_OR_EXPORT void pushBackRefToExistingDataset(const gsoap_resqml2_0_1::resqml2__IndexableElements & elementKind, const ULONG64 & elementCount, const std::string & elementDataset,
 			const LONG64 & nullValue, COMMON_NS::AbstractHdfProxy * proxy, const std::string & supportingRepDataset = "");
 
-		unsigned int getPatchCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getPatchCount() const;
 
 		/**
 		* Get the count of the supporting representations of this subrepresentation.
 		*/
-		unsigned int getSupportingRepresentationCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getSupportingRepresentationCount() const;
 
 		/**
 		* Get the supporting representation dor located at a specific index of this subrepresentation.

--- a/src/resqml2_0_1/TectonicBoundaryFeature.h
+++ b/src/resqml2_0_1/TectonicBoundaryFeature.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT TectonicBoundaryFeature : public BoundaryFeature
+	class TectonicBoundaryFeature : public BoundaryFeature
 	{
 	public:
 
@@ -50,10 +50,9 @@ namespace RESQML2_0_1_NS
 		virtual ~TectonicBoundaryFeature() {}
 	
 		// Indicates wether the instance is a fracture (or a fault). This public method is especially needed for SWIG reason.
-		bool isAFracture() const;
+		DLL_IMPORT_OR_EXPORT bool isAFracture() const;
 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 	};
 }
-

--- a/src/resqml2_0_1/TimeSeries.h
+++ b/src/resqml2_0_1/TimeSeries.h
@@ -22,7 +22,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT TimeSeries : public RESQML2_NS::TimeSeries
+	class TimeSeries : public RESQML2_NS::TimeSeries
 	{
 	public:
 		/**
@@ -55,4 +55,3 @@ namespace RESQML2_0_1_NS
 		gsoap_resqml2_0_1::_resqml2__TimeSeries* getSpecializedGsoapProxy() const;
 	};
 }
-

--- a/src/resqml2_0_1/TriangulatedSetRepresentation.h
+++ b/src/resqml2_0_1/TriangulatedSetRepresentation.h
@@ -26,7 +26,7 @@ namespace RESQML2_0_1_NS
 	 * A triangulated representation is a representation (most of time a surface) which is constituted by triangles.
 	 * Usually all triangles are connected to each others by means of their nodes and edges.
 	 */
-	class DLL_IMPORT_OR_EXPORT TriangulatedSetRepresentation : public AbstractSurfaceRepresentation
+	class TriangulatedSetRepresentation : public AbstractSurfaceRepresentation
 	{
 	private :
 		gsoap_resqml2_0_1::resqml2__PointGeometry* getPointGeometry2_0_1(const unsigned int & patchIndex) const;
@@ -57,7 +57,7 @@ namespace RESQML2_0_1_NS
 		*/
 		~TriangulatedSetRepresentation() {}
         
-		std::string getHdfProxyUuid() const;
+		DLL_IMPORT_OR_EXPORT std::string getHdfProxyUuid() const;
 
 		/**
 		* Push back a new patch of triangles
@@ -69,31 +69,31 @@ namespace RESQML2_0_1_NS
 		*								The three following values define the 3 vertices of the second triangle and so on...
 		* @param proxy					The HDF proxy which defines where the nodes and triangle indices will be stored.
 		*/
-		void pushBackTrianglePatch(const unsigned int & nodeCount, double * nodes, const unsigned int & triangleCount, unsigned int * triangleNodeIndices, COMMON_NS::AbstractHdfProxy* proxy);
+		DLL_IMPORT_OR_EXPORT void pushBackTrianglePatch(const unsigned int & nodeCount, double * nodes, const unsigned int & triangleCount, unsigned int * triangleNodeIndices, COMMON_NS::AbstractHdfProxy* proxy);
 
 		/**
 		* Get the xyz point count in a given patch.
 		* @param patchIndex	The index of the patch of the representation.
 		*/
-		ULONG64 getXyzPointCountOfPatch(const unsigned int & patchIndex) const;
+		DLL_IMPORT_OR_EXPORT ULONG64 getXyzPointCountOfPatch(const unsigned int & patchIndex) const;
 
 		/**
 		* Get all the XYZ points of a particular patch of this representation.
 		* XYZ points are given in the local CRS.
 		* @param xyzPoints A linearized 2d array where the first (quickest) dimension is coordinate dimension (XYZ) and second dimension is vertex dimension. It must be pre allocated.
 		*/
-		void getXyzPointsOfPatch(const unsigned int & patchIndex, double * xyzPoints) const;
+		DLL_IMPORT_OR_EXPORT void getXyzPointsOfPatch(const unsigned int & patchIndex, double * xyzPoints) const;
 
         /**
 		* Get the triangle count in a given patch
 		* @param patchIndex	The index of the patch of the representation.
 		*/
-		unsigned int getTriangleCountOfPatch(const unsigned int & patchIndex) const;
+		DLL_IMPORT_OR_EXPORT unsigned int getTriangleCountOfPatch(const unsigned int & patchIndex) const;
 
         /**
 		* Get the triangle count of all patches of this representation.
 		*/
-		unsigned int getTriangleCountOfAllPatches() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getTriangleCountOfAllPatches() const;
 
 		/**
 		 * Get all the triangle node indices of a particular patch of this representation.
@@ -101,22 +101,21 @@ namespace RESQML2_0_1_NS
 		 * @param patchIndex 			The index of the patch which contains the triangle node indices we want.
 		 * @param triangleNodeIndices	Must be pre-allocated. The count/size of this array should be equal to getTriangleCountOfPatch(patchIndex)*3.
 		 */
-		void getTriangleNodeIndicesOfPatch(const unsigned int & patchIndex, unsigned int * triangleNodeIndices) const;
+		DLL_IMPORT_OR_EXPORT void getTriangleNodeIndicesOfPatch(const unsigned int & patchIndex, unsigned int * triangleNodeIndices) const;
 
 		/**
 		 * Get all the triangle node indices of all patches of this representation.
 		 * See getXyzPointsOfAllPatches method inherited from AbstractRepresentation to read the XYZ coordinates of the triangle nodes.
 		 * @param triangleNodeIndices	Must be pre-allocated. The count/size of this array should be equal to getTriangleCountOfAllPatches()*3.
 		 */
-		void getTriangleNodeIndicesOfAllPatches(unsigned int * triangleNodeIndices) const;
+		DLL_IMPORT_OR_EXPORT void getTriangleNodeIndicesOfAllPatches(unsigned int * triangleNodeIndices) const;
         
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 		
 		/**
 		* Get the patch count in this representation.
 		*/
-		unsigned int getPatchCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getPatchCount() const;
 	};
 }
-

--- a/src/resqml2_0_1/UnstructuredGridRepresentation.h
+++ b/src/resqml2_0_1/UnstructuredGridRepresentation.h
@@ -23,7 +23,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT UnstructuredGridRepresentation : public RESQML2_NS::AbstractGridRepresentation
+	class UnstructuredGridRepresentation : public RESQML2_NS::AbstractGridRepresentation
 	{
 	private :
 
@@ -118,27 +118,27 @@ namespace RESQML2_0_1_NS
 		/**
 		* Indicates wether the grid has a geometry or not.
 		*/
-		bool hasGeometry() const;
+		DLL_IMPORT_OR_EXPORT bool hasGeometry() const;
 
-		std::string getHdfProxyUuid() const;
+		DLL_IMPORT_OR_EXPORT std::string getHdfProxyUuid() const;
 
 		/**
 		* Get the xyz point count in a given patch.
 		*/
-		ULONG64 getXyzPointCountOfPatch(const unsigned int & patchIndex) const;
+		DLL_IMPORT_OR_EXPORT ULONG64 getXyzPointCountOfPatch(const unsigned int & patchIndex) const;
 
 		/**
 		* Get all the XYZ points of a particular patch of this representation.
 		* XYZ points are given in the local CRS.
 		* @param xyzPoints A linearized 2d array where the first (quickest) dimension is coordinate dimension (XYZ) and second dimension is vertex dimension. It must be pre allocated.
 		*/
-		void getXyzPointsOfPatch(const unsigned int & patchIndex, double * xyzPoints) const;
+		DLL_IMPORT_OR_EXPORT void getXyzPointsOfPatch(const unsigned int & patchIndex, double * xyzPoints) const;
 
 		/**
 		 * Get all the face indices of all the cells.
 		 * @param faceIndices 			It must be pre allocated with the last value returned by getCumulativeFaceCountPerCell()
 		 */
-		void getFaceIndicesOfCells(ULONG64 * faceIndices) const;
+		DLL_IMPORT_OR_EXPORT void getFaceIndicesOfCells(ULONG64 * faceIndices) const;
 
 		/**
 		* Get the cumulative face count per cell. First value is the count of faces in the first cell.
@@ -147,7 +147,7 @@ namespace RESQML2_0_1_NS
 		* A single face count should be at least 4.
 		* @param cumulativeFaceCountPerCellIndex	It must be pre allocated with getCellCount()
 		*/
-		void getCumulativeFaceCountPerCell(ULONG64 * cumulativeFaceCountPerCell) const;
+		DLL_IMPORT_OR_EXPORT void getCumulativeFaceCountPerCell(ULONG64 * cumulativeFaceCountPerCell) const;
 
 		/**
 		* Less efficient than getCumulativeFaceCountPerCell.
@@ -155,23 +155,23 @@ namespace RESQML2_0_1_NS
 		* Second value is the count of faces in the second cell. etc...
 		* @param faceCountPerCell	It must be pre allocated with getCellCount()
 		*/
-		void getFaceCountPerCell(ULONG64 * faceCountPerCell) const;
+		DLL_IMPORT_OR_EXPORT void getFaceCountPerCell(ULONG64 * faceCountPerCell) const;
 
 		/**
 		* Detect if the face count per cell is constant in the grid.
 		*/
-		bool isFaceCountOfCellsConstant() const;
+		DLL_IMPORT_OR_EXPORT bool isFaceCountOfCellsConstant() const;
 
 		/*
 		* Get the constant face count per cell in the grid.
 		*/
-		unsigned int getConstantFaceCountOfCells() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getConstantFaceCountOfCells() const;
 
 		/**
 		 * Get all the node indices of all the faces.
 		 * @param nodeIndices	It must be pre allocated with the last value returned by getCumulativeNodeCountPerFace().
 		 */
-		void getNodeIndicesOfFaces(ULONG64 * nodeIndices) const;
+		DLL_IMPORT_OR_EXPORT void getNodeIndicesOfFaces(ULONG64 * nodeIndices) const;
 
 		/**
 		* Get the cumulative node count per face. First value is the count of nodes in the first face.
@@ -180,7 +180,7 @@ namespace RESQML2_0_1_NS
 		* A single node count should be at least 3.
 		* @param nodeCountPerFace	It must be pre allocated with the last value of getFaceCount().
 		*/
-		void getCumulativeNodeCountPerFace(ULONG64 * nodeCountPerFace) const;
+		DLL_IMPORT_OR_EXPORT void getCumulativeNodeCountPerFace(ULONG64 * nodeCountPerFace) const;
 
 		/**
 		* Less efficient than getCumulativeNodeCountPerFace.
@@ -188,66 +188,66 @@ namespace RESQML2_0_1_NS
 		* Second value is the count of nodes in the second face. etc...
 		* @param nodeCountPerFace	It must be pre allocated with the last value of getFaceCount().
 		*/
-		void getNodeCountPerFace(ULONG64 * nodeCountPerFace) const;
+		DLL_IMPORT_OR_EXPORT void getNodeCountPerFace(ULONG64 * nodeCountPerFace) const;
 
 		/**
 		* Detect if the node count per face is constant in the grid.
 		*/
-		bool isNodeCountOfFacesConstant() const;
+		DLL_IMPORT_OR_EXPORT bool isNodeCountOfFacesConstant() const;
 
 		/*
 		* Get the constant node count per face in the grid.
 		*/
-		unsigned int getConstantNodeCountOfFaces() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getConstantNodeCountOfFaces() const;
 
 		/**
 		* Load the geoemtry into memory in order to ease access.
 		* Be aware that you must unload by yourself this memory.
 		*/
-		void loadGeometry();
+		DLL_IMPORT_OR_EXPORT void loadGeometry();
 
 		/**
 		* Unload the split information from memory.
 		*/
-		void unloadGeometry();
+		DLL_IMPORT_OR_EXPORT void unloadGeometry();
 
 		/**
 		* This method requires your have already loaded the geometry.
 		* @return The count of faces in a particular cell.
 		*/
-		unsigned int getFaceCountOfCell(const ULONG64 & cellIndex) const;
+		DLL_IMPORT_OR_EXPORT unsigned int getFaceCountOfCell(const ULONG64 & cellIndex) const;
 	
 		/**
 		* This method requires your have already loaded the geometry.
 		* @return The count of nodes in a particular face of a particular cell.
 		*/
-		unsigned int getNodeCountOfFaceOfCell(const ULONG64 & cellIndex, const unsigned int & localFaceIndex) const;
+		DLL_IMPORT_OR_EXPORT unsigned int getNodeCountOfFaceOfCell(const ULONG64 & cellIndex, const unsigned int & localFaceIndex) const;
 
 		/**
 		* This method requires your have already loaded the geometry.
 		* It gets all the node indices of a particular face of a particular cell
 		*/
-		ULONG64 * getNodeIndicesOfFaceOfCell(const ULONG64 & cellIndex, const unsigned int & localFaceIndex) const;
+		DLL_IMPORT_OR_EXPORT ULONG64 * getNodeIndicesOfFaceOfCell(const ULONG64 & cellIndex, const unsigned int & localFaceIndex) const;
 
 		/**
 		 * Get the cell count
 		 */
-		ULONG64 getCellCount() const;
+		DLL_IMPORT_OR_EXPORT ULONG64 getCellCount() const;
 
 		/**
 		 * Get the face count
 		 */
-		ULONG64 getFaceCount() const;
+		DLL_IMPORT_OR_EXPORT ULONG64 getFaceCount() const;
 
 		/**
 		 * Get the node count
 		 */
-		ULONG64 getNodeCount() const;
+		DLL_IMPORT_OR_EXPORT ULONG64 getNodeCount() const;
 
     	/**
 	    * Retrieves orientation i.e. if each cell face is right handed or not
     	*/
-    	void getCellFaceIsRightHanded(unsigned char* cellFaceIsRightHanded) const;
+		DLL_IMPORT_OR_EXPORT void getCellFaceIsRightHanded(unsigned char* cellFaceIsRightHanded) const;
 
 		/**
 		* Set the geometry using some existing hdf5 dataset
@@ -262,7 +262,7 @@ namespace RESQML2_0_1_NS
 		* @param nodeIndicesCumulativeCountPerFace	The path to the hdf5 dataset in the hdf proxy where each item defines the cumulative count of nodes. The count of this array must be eqaul to faceCount.
 		* @param cellShape							A denormalization of the information which gives quick access to the most complex shape of polyhedron encountered in this unstructured grid.
 		*/
-		void setGeometryUsingExistingDatasets(const std::string& cellFaceIsRightHanded, const std::string& points, ULONG64 pointCount, COMMON_NS::AbstractHdfProxy* proxy,
+		DLL_IMPORT_OR_EXPORT void setGeometryUsingExistingDatasets(const std::string& cellFaceIsRightHanded, const std::string& points, ULONG64 pointCount, COMMON_NS::AbstractHdfProxy* proxy,
 			const std::string& faceIndicesPerCell, const std::string&faceIndicesCumulativeCountPerCell,
 			ULONG64 faceCount, const std::string& nodeIndicesPerFace, const std::string& nodeIndicesCumulativeCountPerFace,
 			const gsoap_resqml2_0_1::resqml2__CellShape & cellShape);
@@ -280,7 +280,7 @@ namespace RESQML2_0_1_NS
 		 * @param nodeIndicesCumulativeCountPerFace	Each item defines the cumulative count of nodes. The count of this array must be eqaul to faceCount.
 		 * @param cellShape							A denormalization of the information which gives quick access to the most complex shape of polyhedron encountered in this unstructured grid.
 		 */
-		void setGeometry(unsigned char * cellFaceIsRightHanded, double * points, ULONG64 pointCount, COMMON_NS::AbstractHdfProxy* proxy,
+		DLL_IMPORT_OR_EXPORT void setGeometry(unsigned char * cellFaceIsRightHanded, double * points, ULONG64 pointCount, COMMON_NS::AbstractHdfProxy* proxy,
 			ULONG64 * faceIndicesPerCell, ULONG64 * faceIndicesCumulativeCountPerCell,
 			ULONG64 faceCount, ULONG64 * nodeIndicesPerFace, ULONG64 * nodeIndicesCumulativeCountPerFace,
 			const gsoap_resqml2_0_1::resqml2__CellShape & cellShape);
@@ -295,7 +295,7 @@ namespace RESQML2_0_1_NS
 		* @param faceIndicesPerCell					The path to the hdf5 dataset in the hdf proxy where each item defines the index of the face of a cell. There must be a count of faceCountPerCell * cellCount.
 		* @param nodeIndicesPerFace					The path to the hdf5 dataset in the hdf proxy where each item defines the index of the node of a face. There must be a count of nodeCountPerFace * faceCount.
 		*/
-		void setTetrahedraOnlyGeometryUsingExistingDatasets(const std::string& cellFaceIsRightHanded, const std::string& points,
+		DLL_IMPORT_OR_EXPORT void setTetrahedraOnlyGeometryUsingExistingDatasets(const std::string& cellFaceIsRightHanded, const std::string& points,
 			ULONG64 pointCount, ULONG64 faceCount, COMMON_NS::AbstractHdfProxy* proxy,
 			const std::string& faceIndicesPerCell, const std::string& nodeIndicesPerFace);
 
@@ -309,7 +309,7 @@ namespace RESQML2_0_1_NS
 		* @param faceIndicesPerCell					Each item defines the index of the face of a cell. There must be a count of faceCountPerCell * cellCount.
 		* @param nodeIndicesPerFace					Each item defines the index of the node of a face. There must be a count of nodeCountPerFace * faceCount.
 		*/
-		void setTetrahedraOnlyGeometry(unsigned char * cellFaceIsRightHanded, double * points,
+		DLL_IMPORT_OR_EXPORT void setTetrahedraOnlyGeometry(unsigned char * cellFaceIsRightHanded, double * points,
 			ULONG64 pointCount, ULONG64 faceCount, COMMON_NS::AbstractHdfProxy* proxy,
 			ULONG64 * faceIndicesPerCell, ULONG64 * nodeIndicesPerFace);
 
@@ -323,7 +323,7 @@ namespace RESQML2_0_1_NS
 		* @param faceIndicesPerCell					The path to the hdf5 dataset in the hdf proxy where each item defines the index of the face of a cell. There must be a count of faceCountPerCell * cellCount.
 		* @param nodeIndicesPerFace					The path to the hdf5 dataset in the hdf proxy where each item defines the index of the node of a face. There must be a count of nodeCountPerFace * faceCount.
 		*/
-		void setHexahedraOnlyGeometryUsingExistingDatasets(const std::string& cellFaceIsRightHanded, const std::string& points,
+		DLL_IMPORT_OR_EXPORT void setHexahedraOnlyGeometryUsingExistingDatasets(const std::string& cellFaceIsRightHanded, const std::string& points,
 			ULONG64 pointCount, ULONG64 faceCount, COMMON_NS::AbstractHdfProxy* proxy,
 			const std::string& faceIndicesPerCell, const std::string& nodeIndicesPerFace);
 
@@ -337,14 +337,13 @@ namespace RESQML2_0_1_NS
 		* @param faceIndicesPerCell					Each item defines the index of the face of a cell. There must be a count of faceCountPerCell * cellCount.
 		* @param nodeIndicesPerFace					Each item defines the index of the node of a face. There must be a count of nodeCountPerFace * faceCount.
 		*/
-		void setHexahedraOnlyGeometry(unsigned char * cellFaceIsRightHanded, double * points,
+		DLL_IMPORT_OR_EXPORT void setHexahedraOnlyGeometry(unsigned char * cellFaceIsRightHanded, double * points,
 			ULONG64 pointCount, ULONG64 faceCount, COMMON_NS::AbstractHdfProxy* proxy,
 			ULONG64 * faceIndicesPerCell, ULONG64 * nodeIndicesPerFace);
 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
-		unsigned int getPatchCount() const {return 1;}
+		DLL_IMPORT_OR_EXPORT unsigned int getPatchCount() const {return 1;}
 	};
 }
-

--- a/src/resqml2_0_1/WellboreFeature.h
+++ b/src/resqml2_0_1/WellboreFeature.h
@@ -27,7 +27,7 @@ namespace WITSML2_0_NS
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT WellboreFeature : public AbstractTechnicalFeature
+	class WellboreFeature : public AbstractTechnicalFeature
 	{
 	public:
 
@@ -59,11 +59,11 @@ namespace RESQML2_0_1_NS
 		*/
 		~WellboreFeature() {}
 		
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 		
-		WITSML2_0_NS::Wellbore* getWitsmlWellbore() {return witsmlWellbore;}
-		void setWitsmlWellbore(WITSML2_0_NS::Wellbore * wellbore);
+		DLL_IMPORT_OR_EXPORT WITSML2_0_NS::Wellbore* getWitsmlWellbore() {return witsmlWellbore;}
+		DLL_IMPORT_OR_EXPORT void setWitsmlWellbore(WITSML2_0_NS::Wellbore * wellbore);
 
 	protected:
 
@@ -74,4 +74,3 @@ namespace RESQML2_0_1_NS
 		WITSML2_0_NS::Wellbore * witsmlWellbore;
 	};
 }
-

--- a/src/resqml2_0_1/WellboreFrameRepresentation.h
+++ b/src/resqml2_0_1/WellboreFrameRepresentation.h
@@ -23,7 +23,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT WellboreFrameRepresentation : public RESQML2_NS::AbstractRepresentation
+	class WellboreFrameRepresentation : public RESQML2_NS::AbstractRepresentation
 	{
 	protected:
 		WellboreFrameRepresentation(RESQML2_NS::AbstractFeatureInterpretation* interp, RESQML2_NS::AbstractLocal3dCrs * crs) : AbstractRepresentation(interp, crs), trajectory(nullptr)
@@ -62,7 +62,7 @@ namespace RESQML2_0_1_NS
 		* @param mdValueCount	The MD values count.
 		* @param proxy			The HDF proxy where to write the MD values. It must be already opened for writing and won't be closed in this method.
 		*/
-		void setMdValues(double * mdValues, const unsigned int & mdValueCount, COMMON_NS::AbstractHdfProxy* proxy);
+		DLL_IMPORT_OR_EXPORT void setMdValues(double * mdValues, const unsigned int & mdValueCount, COMMON_NS::AbstractHdfProxy* proxy);
 
 		/**
 		* Set the MD values of this WellboreFrameRepresentation frame as a regular discretization along the wellbore trajectory.
@@ -70,75 +70,75 @@ namespace RESQML2_0_1_NS
 		* @param incrementMdValue	The increment value between two Measured depth.
 		* @param mdValueCount		The count of md values in this WellboreFrameRepresentation.
 		*/
-		void setMdValues(const double & firstMdValue, const double & incrementMdValue, const unsigned int & mdValueCount);
+		DLL_IMPORT_OR_EXPORT void setMdValues(const double & firstMdValue, const double & incrementMdValue, const unsigned int & mdValueCount);
 
 		/**
 		* Indicates either the MDs are regularly spaced or not (useful for optimization)
 		* Does not verify if the writer has used a generic array to store regular mds.
 		*/
-		bool areMdValuesRegularlySpaced() const;
+		DLL_IMPORT_OR_EXPORT bool areMdValuesRegularlySpaced() const;
 		
 		/**
 		* Indicates the incremetn value between two MDs only if the MDs are regualrly spaced.
 		* Please use areMdValuesRegularlySpaced before using this method.
 		*/
-		double getMdConstantIncrementValue() const;
+		DLL_IMPORT_OR_EXPORT double getMdConstantIncrementValue() const;
 
 		/**
 		* Returns the first MD value of this WellboreFrameRepresentation
 		*/
-		double getMdFirstValue() const;
+		DLL_IMPORT_OR_EXPORT double getMdFirstValue() const;
 		
 		/**
 		* Get the number of Md values in this WellboreFeature frame.
 		*/
-		unsigned int getMdValuesCount() const;
+		DLL_IMPORT_OR_EXPORT unsigned int getMdValuesCount() const;
 
 		/**
 		* Get the xyz point count in a given patch.
 		*/
-		ULONG64 getXyzPointCountOfPatch(const unsigned int & patchIndex) const;
+		DLL_IMPORT_OR_EXPORT ULONG64 getXyzPointCountOfPatch(const unsigned int & patchIndex) const;
 
 		/**
 		* Get all the XYZ points of a particular patch of this representation.
 		* XYZ points are given in the local CRS.
 		* @param xyzPoints A linearized 2d array where the first (quickest) dimension is coordinate dimension (XYZ) and second dimension is vertex dimension. It must be pre allocated.
 		*/
-		void getXyzPointsOfPatch(const unsigned int & patchIndex, double * xyzPoints) const;
+		DLL_IMPORT_OR_EXPORT void getXyzPointsOfPatch(const unsigned int & patchIndex, double * xyzPoints) const;
 
 		/**
 		* Get the Measured Depth datatype in the HDF dataset
 		*/
-		RESQML2_NS::AbstractValuesProperty::hdfDatatypeEnum getMdHdfDatatype() const;
+		DLL_IMPORT_OR_EXPORT RESQML2_NS::AbstractValuesProperty::hdfDatatypeEnum getMdHdfDatatype() const;
 
 		/**
 		* Get all the md values of the instance which are supposed to be double ones.
 		*/
-		void getMdAsDoubleValues(double * values);
+		DLL_IMPORT_OR_EXPORT void getMdAsDoubleValues(double * values);
 
 		/**
 		* Get all the md values of the instance which are supposed to be float ones.
 		*/
-		void getMdAsFloatValues(float * values);
+		DLL_IMPORT_OR_EXPORT void getMdAsFloatValues(float * values);
 
 		/**
 		* Get the associated resqml wellbore trajectory uuid
 		*/
-		std::string getWellboreTrajectoryUuid() const;
+		DLL_IMPORT_OR_EXPORT std::string getWellboreTrajectoryUuid() const;
 
 		/**
 		* Get the associated resqml wellbore trajector
 		*/
-		class WellboreTrajectoryRepresentation* getWellboreTrajectory() {return trajectory;}
+		DLL_IMPORT_OR_EXPORT class WellboreTrajectoryRepresentation* getWellboreTrajectory() {return trajectory;}
 
 		gsoap_resqml2_0_1::eml20__DataObjectReference* getLocalCrsDor() const;
 
-		std::string getHdfProxyUuid() const;
+		DLL_IMPORT_OR_EXPORT std::string getHdfProxyUuid() const;
 
-		unsigned int getPatchCount() const {return 1;}
+		DLL_IMPORT_OR_EXPORT unsigned int getPatchCount() const {return 1;}
 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
 	protected:
 

--- a/src/resqml2_0_1/WellboreInterpretation.h
+++ b/src/resqml2_0_1/WellboreInterpretation.h
@@ -23,7 +23,7 @@ under the License.
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT WellboreInterpretation : public RESQML2_NS::AbstractFeatureInterpretation
+	class WellboreInterpretation : public RESQML2_NS::AbstractFeatureInterpretation
 	{
 	public:
 
@@ -62,10 +62,9 @@ namespace RESQML2_0_1_NS
 		/**
 		* Get all the trajectory representations of this interpretation
 		*/
-		std::vector<class WellboreTrajectoryRepresentation*> getWellboreTrajectoryRepresentationSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<class WellboreTrajectoryRepresentation*> getWellboreTrajectoryRepresentationSet() const;
 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 	};
 }
-

--- a/src/resqml2_0_1/WellboreMarker.h
+++ b/src/resqml2_0_1/WellboreMarker.h
@@ -26,7 +26,7 @@ namespace RESQML2_0_1_NS
 	* This class is one of the only one to be a ResqmlDataObject which is not exported into a single file i.e. not a top level element.
 	* Consequently its behaviour is slightly different than other class. Especially there is no integration of the instances into an EPC document.
 	*/
-	class DLL_IMPORT_OR_EXPORT WellboreMarker : public COMMON_NS::AbstractObject
+	class WellboreMarker : public COMMON_NS::AbstractObject
 	{
 	public:
 
@@ -60,34 +60,34 @@ namespace RESQML2_0_1_NS
 		/**
 		* Indicates if the marker is associated to a particular GeologicBoundaryKind.
 		*/
-		bool hasAGeologicBoundaryKind();
+		DLL_IMPORT_OR_EXPORT bool hasAGeologicBoundaryKind();
 
 		/**
 		* Get the type of the intersected feature of the marker.
 		* Throw an exception if the marker has no GeologicBoundaryKind (see method hasAGeologicBoundaryKind).
 		*/
-		gsoap_resqml2_0_1::resqml2__GeologicBoundaryKind getGeologicBoundaryKind();
+		DLL_IMPORT_OR_EXPORT gsoap_resqml2_0_1::resqml2__GeologicBoundaryKind getGeologicBoundaryKind();
 
-		class WellboreMarkerFrameRepresentation * getWellMarkerFrameRepresentation() const {return wellboreMarkerFrameRepresentation;}
+		DLL_IMPORT_OR_EXPORT class WellboreMarkerFrameRepresentation * getWellMarkerFrameRepresentation() const {return wellboreMarkerFrameRepresentation;}
 
 		/**
 		* Get the boundary feature interpretation linked to this well marker.
 		*/
-		class BoundaryFeatureInterpretation* getBoundaryFeatureInterpretation() const;
+		DLL_IMPORT_OR_EXPORT class BoundaryFeatureInterpretation* getBoundaryFeatureInterpretation() const;
 
 		/**
 		* Get the UUID of the boundary feature interpretation linked to this well marker.
 		* Especially useful in partial transfer mode.
 		*/
-		std::string getBoundaryFeatureInterpretationUuid() const;
+		DLL_IMPORT_OR_EXPORT std::string getBoundaryFeatureInterpretationUuid() const;
 
 		/**
 		* Set the boundary feature interpretation linked to this well marker.
 		*/
-		void setBoundaryFeatureInterpretation(class BoundaryFeatureInterpretation* interp);
+		DLL_IMPORT_OR_EXPORT void setBoundaryFeatureInterpretation(class BoundaryFeatureInterpretation* interp);
 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
 	private:
 

--- a/src/resqml2_0_1/WellboreMarkerFrameRepresentation.h
+++ b/src/resqml2_0_1/WellboreMarkerFrameRepresentation.h
@@ -27,7 +27,7 @@ namespace WITSML1_4_1_1_NS
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT WellboreMarkerFrameRepresentation : public WellboreFrameRepresentation
+	class WellboreMarkerFrameRepresentation : public WellboreFrameRepresentation
 	{
 	public:
 
@@ -60,37 +60,37 @@ namespace RESQML2_0_1_NS
 		* Pushes back a new WellboreFeature marker to this WellboreFeature marker frame.
 		* One WellboreFeature marker must be added per MD of the WellboreFeature marker frame.
 		*/
-		class WellboreMarker* pushBackNewWellboreMarker(const std::string & guid, const std::string & title);
+		DLL_IMPORT_OR_EXPORT class WellboreMarker* pushBackNewWellboreMarker(const std::string & guid, const std::string & title);
 
 		/**
 		* Add a WellboreFeature marker to this WellboreFeature marker frame with a geologic information on the intersected feature.
 		* One WellboreFeature marker must be added per MD of the WellboreFeature marker frame.
 		*/
-		class WellboreMarker* pushBackNewWellboreMarker(const std::string & guid, const std::string & title, const gsoap_resqml2_0_1::resqml2__GeologicBoundaryKind & geologicBoundaryKind);
+		DLL_IMPORT_OR_EXPORT class WellboreMarker* pushBackNewWellboreMarker(const std::string & guid, const std::string & title, const gsoap_resqml2_0_1::resqml2__GeologicBoundaryKind & geologicBoundaryKind);
 
 		/**
 		* Return the number of wellbore marker for this Wellbore marker frame representation
 		*/
-		unsigned int getWellboreMarkerCount();
+		DLL_IMPORT_OR_EXPORT unsigned int getWellboreMarkerCount();
 
 		/**
 		* Get all the wellbore markers of this well marker frame representation.
 		*/
-		const std::vector<class WellboreMarker*> & getWellboreMarkerSet() const;
+		DLL_IMPORT_OR_EXPORT const std::vector<class WellboreMarker*> & getWellboreMarkerSet() const;
 
-		void setStratigraphicOccurrenceInterpretation(class StratigraphicOccurrenceInterpretation * stratiOccurenceInterp);
+		DLL_IMPORT_OR_EXPORT void setStratigraphicOccurrenceInterpretation(class StratigraphicOccurrenceInterpretation * stratiOccurenceInterp);
 
 		/**
 		* Set the correspondance between the interval of the wellbore marker frame rep and the units of a stratiColRankInterp
 		* @param stratiUnitIndices	The count must be equal to the count of contacts in stratiColRankInterp
 		* @param nullValue			The value which is used to indicate we don't know the related strati units against a particular interval.
 		*/
-		void setIntervalStratigraphicUnits(unsigned int * stratiUnitIndices, const unsigned int & nullValue, class StratigraphicOccurrenceInterpretation* stratiOccurenceInterp);
+		DLL_IMPORT_OR_EXPORT void setIntervalStratigraphicUnits(unsigned int * stratiUnitIndices, const unsigned int & nullValue, class StratigraphicOccurrenceInterpretation* stratiOccurenceInterp);
 
-		class StratigraphicOccurrenceInterpretation* getStratigraphicOccurrenceInterpretation() { return stratigraphicOccurrenceInterpretation; }
+		DLL_IMPORT_OR_EXPORT class StratigraphicOccurrenceInterpretation* getStratigraphicOccurrenceInterpretation() { return stratigraphicOccurrenceInterpretation; }
 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
 	protected:
 

--- a/src/resqml2_0_1/WellboreTrajectoryRepresentation.h
+++ b/src/resqml2_0_1/WellboreTrajectoryRepresentation.h
@@ -27,7 +27,7 @@ namespace WITSML1_4_1_1_NS
 
 namespace RESQML2_0_1_NS
 {
-	class DLL_IMPORT_OR_EXPORT WellboreTrajectoryRepresentation : public RESQML2_NS::AbstractRepresentation
+	class WellboreTrajectoryRepresentation : public RESQML2_NS::AbstractRepresentation
 	{
 	private:
 		gsoap_resqml2_0_1::_resqml2__WellboreTrajectoryRepresentation* getSpecializedGsoapProxy() const;
@@ -62,8 +62,8 @@ namespace RESQML2_0_1_NS
 
 		~WellboreTrajectoryRepresentation() {}
 
-		static const char* XML_TAG;
-		virtual std::string getXmlTag() const {return XML_TAG;}
+		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
+		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
 		/*
 		*  Set the geometry of the representation by means of a parametric line without MD information.
@@ -73,7 +73,7 @@ namespace RESQML2_0_1_NS
 		* @param proxy							The HDF proxy which indicates in which HDF5 file the control points and its parameters will be stored.
 		*										It must be already opened for writing and won't be closed.
 		*/
-		void setGeometry(double * controlPoints, const double & startMd, const double & endMd, const unsigned int & controlPointCount, const int & lineKind, COMMON_NS::AbstractHdfProxy* proxy);
+		DLL_IMPORT_OR_EXPORT void setGeometry(double * controlPoints, const double & startMd, const double & endMd, const unsigned int & controlPointCount, const int & lineKind, COMMON_NS::AbstractHdfProxy* proxy);
 
 		/*
 		*  Set the geometry of the representation by means of one natural cubic parametric line.
@@ -83,7 +83,7 @@ namespace RESQML2_0_1_NS
 		* @param proxy							The HDF proxy which indicates in which HDF5 file the control points and its parameters will be stored.
 		*										It must be already opened for writing and won't be closed.
 		*/
-		void setGeometry(double * controlPoints, double* controlPointParameters, const unsigned int & controlPointCount,
+		DLL_IMPORT_OR_EXPORT void setGeometry(double * controlPoints, double* controlPointParameters, const unsigned int & controlPointCount,
 			COMMON_NS::AbstractHdfProxy* proxy);
 
 		/*
@@ -95,143 +95,143 @@ namespace RESQML2_0_1_NS
 		* @param proxy							The HDF proxy which indicates in which HDF5 file the parameters and the tangent vectors will be stored.
 		*										It must be already opened for writing and won't be closed.
 		*/
-		void setGeometry(double * controlPoints,
+		DLL_IMPORT_OR_EXPORT void setGeometry(double * controlPoints,
 			double * tangentVectors, double* controlPointParameters, const unsigned int & controlPointCount,
 			COMMON_NS::AbstractHdfProxy* proxy);
 
 		/**
 		* 0 for vertical, 1 for linear spline, 2 for natural cubic spline, 3 for cubic spline, 4 for z linear cubic spline, 5 for minimum-curvature spline, (-1) for null: no line
 		*/
-		int getGeometryKind() const;
+		DLL_IMPORT_OR_EXPORT int getGeometryKind() const;
 
 		/**
 		* Set the Md datum of this trajectory
 		*/
-		void setMdDatum(RESQML2_NS::MdDatum* mdDatum);
+		DLL_IMPORT_OR_EXPORT void setMdDatum(RESQML2_NS::MdDatum* mdDatum);
 
 		/**
 		* Getter of the md information associated to this WellboreFeature trajectory representation.
 		*/
-		RESQML2_NS::MdDatum * getMdDatum() const;
+		DLL_IMPORT_OR_EXPORT RESQML2_NS::MdDatum * getMdDatum() const;
 
 		/**
 		* Getter of the md information uuid associated to this WellboreFeature trajectory representation.
 		*/
-		std::string getMdDatumUuid() const;
+		DLL_IMPORT_OR_EXPORT std::string getMdDatumUuid() const;
 
 		/**
 		* Get the xyz point count in a given patch.
 		*/
-		ULONG64 getXyzPointCountOfPatch(const unsigned int & patchIndex) const;
+		DLL_IMPORT_OR_EXPORT ULONG64 getXyzPointCountOfPatch(const unsigned int & patchIndex) const;
 
 		/**
 		* Get all the XYZ points of a particular patch of this representation.
 		* XYZ points are given in the local CRS.
 		* @param xyzPoints A linearized 2d array where the first (quickest) dimension is coordinate dimension (XYZ) and second dimension is vertex dimension. It must be pre allocated.
 		*/
-		void getXyzPointsOfPatch(const unsigned int & patchIndex, double * xyzPoints) const;
+		DLL_IMPORT_OR_EXPORT void getXyzPointsOfPatch(const unsigned int & patchIndex, double * xyzPoints) const;
 
 		/**
 		* Indicates if the wellbore trajectory has got md values attached to each trajectory station.
 		*/
-		bool hasMdValues() const;
+		DLL_IMPORT_OR_EXPORT bool hasMdValues() const;
 
 		/**
 		* Units of measure of the measured depths along this trajectory.
 		*/
-		gsoap_resqml2_0_1::eml20__LengthUom getMdUom() const;
+		DLL_IMPORT_OR_EXPORT gsoap_resqml2_0_1::eml20__LengthUom getMdUom() const;
 
 		/**
 		* Getter of the md double values associated to each trajectory station of this WellboreFeature trajectory representation.
 		*/
-		void getMdValues(double* values);
+		DLL_IMPORT_OR_EXPORT void getMdValues(double* values);
 
 		/**
 		* Get the measured depth for the start of the wellbore trajectory. Range may often be from kickoff to TD, but this is not necessary.
 		*/
-		double getStartMd() const;
+		DLL_IMPORT_OR_EXPORT double getStartMd() const;
 
 		/**
 		* Get the ending depth for the start of the wellbore trajectory. Range may often be from kickoff to TD, but this is not necessary.
 		*/
-		double getFinishMd() const;
+		DLL_IMPORT_OR_EXPORT double getFinishMd() const;
 
 		/**
 		* Indicates if the wellbore trajectory has got tangent vectors attached to each trajectory station.
 		*/
-		bool hasTangentVectors() const;
+		DLL_IMPORT_OR_EXPORT bool hasTangentVectors() const;
 
 		/**
 		* Getter of the tangent vectors associated to each trajectory station of this WellboreFeature trajectory representation.
 		*/
-		void getTangentVectors(double* tangentVectors);
+		DLL_IMPORT_OR_EXPORT void getTangentVectors(double* tangentVectors);
 
 		/**
 		* Add a trajectory parent to this trajectory in case of trajectory branching.
 		* Does add the inverse relationship i.e. from the parent trajectory to this trajecotry
 		*/
-		void addParentTrajectory(const double & kickoffMd, const double & parentMd, WellboreTrajectoryRepresentation* parentTrajRep);
+		DLL_IMPORT_OR_EXPORT void addParentTrajectory(const double & kickoffMd, const double & parentMd, WellboreTrajectoryRepresentation* parentTrajRep);
 
 		/**
 		* Get the parent trajectory of this trajectory
 		* @return nullptr if the trajectory has no parent trajectory.
 		*/
-		WellboreTrajectoryRepresentation* getParentTrajectory() const;
+		DLL_IMPORT_OR_EXPORT WellboreTrajectoryRepresentation* getParentTrajectory() const;
 
 		/**
 		* Get the MD on the parent wellbore trajectory where this trajectory is starting.
 		*/
-		const double& getParentTrajectoryMd() const;
+		DLL_IMPORT_OR_EXPORT const double& getParentTrajectoryMd() const;
 
 		/**
 		* Get a set of all children trajectories of this trajectory
 		*/
-		const std::vector<WellboreTrajectoryRepresentation*> & getChildrenTrajectorySet() const;
+		DLL_IMPORT_OR_EXPORT const std::vector<WellboreTrajectoryRepresentation*> & getChildrenTrajectorySet() const;
 
 		/**
 		* Add a Wellbore frame representation to this trajectory.
 		* Does not add the inverse relationship i.e. from the WellboreFeature frame to this trajectory
 		*/
-		void addWellboreFrameRepresentation(class WellboreFrameRepresentation* WellboreFrameRepresentation) {wellboreFrameRepresentationSet.push_back(WellboreFrameRepresentation);}
+		DLL_IMPORT_OR_EXPORT void addWellboreFrameRepresentation(class WellboreFrameRepresentation* WellboreFrameRepresentation) {wellboreFrameRepresentationSet.push_back(WellboreFrameRepresentation);}
 
 		/**
 		* Getter (in read only mode) of all the associated Wellbore frame representations
 		*/
-		const std::vector<class WellboreFrameRepresentation*>& getWellboreFrameRepresentationSet() const {return wellboreFrameRepresentationSet;}
+		DLL_IMPORT_OR_EXPORT const std::vector<class WellboreFrameRepresentation*>& getWellboreFrameRepresentationSet() const {return wellboreFrameRepresentationSet;}
 
 		/**
 		* Get the count of wellbore frame representation which are associated with this wellbore trajectory.
 		* Necessary for now in SWIG context because I am not sure if I can always wrap a vector of polymorphic class yet.
 		*/
-		unsigned int getWellboreFrameRepresentationCount() const {return static_cast<unsigned int>(wellboreFrameRepresentationSet.size());}
+		DLL_IMPORT_OR_EXPORT unsigned int getWellboreFrameRepresentationCount() const {return static_cast<unsigned int>(wellboreFrameRepresentationSet.size());}
 
 		/**
 		* Get a particular wellbore frame representation of this wellbore trajectory representation according to its position in the EPC document.
 		* Necessary for now in SWIG context because I mm not sure if I can always wrap a vector of polymorphic class yet.
 		* Throw an out of bound exception if the index is superior or equal to the count of wellbore frame representation.
 		*/
-		class WellboreFrameRepresentation* getWellboreFrameRepresentation(const unsigned int & index) const {return wellboreFrameRepresentationSet[index];}
+		DLL_IMPORT_OR_EXPORT class WellboreFrameRepresentation* getWellboreFrameRepresentation(const unsigned int & index) const {return wellboreFrameRepresentationSet[index];}
 
 		/**
 		* Set the deviation survey which is the source of this trajectory.
 		*/
-		void setDeviationSurvey(class DeviationSurveyRepresentation* deviationSurvey);
+		DLL_IMPORT_OR_EXPORT void setDeviationSurvey(class DeviationSurveyRepresentation* deviationSurvey);
 
 		/**
 		* Get the deviation survey which is the source of this trajectory. It can return a null pointer.
 		*/
-		class DeviationSurveyRepresentation* getDeviationSurvey() const;
+		DLL_IMPORT_OR_EXPORT class DeviationSurveyRepresentation* getDeviationSurvey() const;
 
 		/**
 		* Get the information to resolve the associated local CRS.
 		*/
 		gsoap_resqml2_0_1::eml20__DataObjectReference* getLocalCrsDor() const;
 
-		std::string getHdfProxyUuid() const;
+		DLL_IMPORT_OR_EXPORT std::string getHdfProxyUuid() const;
 
-		unsigned int getPatchCount() const {return 1;}
+		DLL_IMPORT_OR_EXPORT unsigned int getPatchCount() const {return 1;}
 
-		bool hasGeometry() const;
+		DLL_IMPORT_OR_EXPORT bool hasGeometry() const;
 
 	private:
 		/**

--- a/swig/swigWitsml2_0Include.i
+++ b/swig/swigWitsml2_0Include.i
@@ -18,9 +18,11 @@ under the License.
 -----------------------------------------------------------------------*/
 %{
 #include "witsml2_0/Well.h"
-#include "witsml2_0/Wellbore.h"
 #include "witsml2_0/WellCompletion.h"
+#include "witsml2_0/Wellbore.h"
+#include "witsml2_0/WellboreObject.h"
 #include "witsml2_0/WellboreCompletion.h"
+#include "witsml2_0/Trajectory.h"
 %}
 
 //************************
@@ -48,6 +50,56 @@ namespace gsoap_eml2_1
 	enum witsml2__WellboreShape { witsml2__WellboreShape__build_x0020and_x0020hold = 0, witsml2__WellboreShape__deviated = 1, witsml2__WellboreShape__double_x0020kickoff = 2, witsml2__WellboreShape__horizontal = 3, witsml2__WellboreShape__S_shaped = 4, witsml2__WellboreShape__vertical = 5 };
 	enum witsml2__PerforationStatus { witsml2__PerforationStatus__open = 0, witsml2__PerforationStatus__proposed = 1, witsml2__PerforationStatus__squeezed = 2 };
 	enum witsml2__ElevCodeEnum { witsml2__ElevCodeEnum__CF = 0, witsml2__ElevCodeEnum__CV = 1, witsml2__ElevCodeEnum__DF = 2, witsml2__ElevCodeEnum__GL = 3, witsml2__ElevCodeEnum__KB = 4, witsml2__ElevCodeEnum__RB = 5, witsml2__ElevCodeEnum__RT = 6, witsml2__ElevCodeEnum__SF = 7, witsml2__ElevCodeEnum__LAT = 8, witsml2__ElevCodeEnum__SL = 9, witsml2__ElevCodeEnum__MHHW = 10, witsml2__ElevCodeEnum__MHW = 11, witsml2__ElevCodeEnum__MLLW = 12, witsml2__ElevCodeEnum__MLW = 13, witsml2__ElevCodeEnum__MTL = 14, witsml2__ElevCodeEnum__KO = 15, witsml2__ElevCodeEnum__unknown = 16};
+	enum witsml2__TrajStationType {
+		witsml2__TrajStationType__azimuth_x0020on_x0020plane = 0,
+		witsml2__TrajStationType__buildrate_x0020to_x0020delta_MD = 1,
+		witsml2__TrajStationType__buildrate_x0020to_x0020INCL = 2,
+		witsml2__TrajStationType__buildrate_x0020to_x0020MD = 3,
+		witsml2__TrajStationType__buildrate_x0020and_x0020turnrate_x0020to_x0020AZI = 4,
+		witsml2__TrajStationType__buildrate_x0020and_x0020turnrate_x0020to_x0020delta_MD = 5,
+		witsml2__TrajStationType__buildrate_x0020and_x0020turnrate_x0020to_x0020INCL = 6,
+		witsml2__TrajStationType__buildrate_x0020and_x0020turnrate_x0020to_x0020INCL_x0020and_x0020AZI = 7,
+		witsml2__TrajStationType__buildrate_x0020and_x0020turnrate_x0020to_x0020MD = 8,
+		witsml2__TrajStationType__buildrate_x0020and_x0020turnrate_x0020to_x0020TVD = 9,
+		witsml2__TrajStationType__buildrate_x0020TVD = 10,
+		witsml2__TrajStationType__casing_x0020MD = 11,
+		witsml2__TrajStationType__casing_x0020TVD = 12,
+		witsml2__TrajStationType__DLS = 13,
+		witsml2__TrajStationType__DLS_x0020to_x0020AZI_x0020and_x0020MD = 14,
+		witsml2__TrajStationType__DLS_x0020to_x0020AZI_TVD = 15,
+		witsml2__TrajStationType__DLS_x0020to_x0020INCL = 16,
+		witsml2__TrajStationType__DLS_x0020to_x0020INCL_x0020and_x0020AZI = 17,
+		witsml2__TrajStationType__DLS_x0020to_x0020INCL_x0020and_x0020MD = 18,
+		witsml2__TrajStationType__DLS_x0020to_x0020INCL_x0020and_x0020TVD = 19,
+		witsml2__TrajStationType__DLS_x0020to_x0020NS = 20,
+		witsml2__TrajStationType__DLS_x0020and_x0020toolface_x0020to_x0020AZI = 21,
+		witsml2__TrajStationType__DLS_x0020and_x0020toolface_x0020to_x0020delta_MD = 22,
+		witsml2__TrajStationType__DLS_x0020and_x0020toolface_x0020to_x0020INCL = 23,
+		witsml2__TrajStationType__DLS_x0020and_x0020toolface_x0020to_x0020INCL_AZI = 24,
+		witsml2__TrajStationType__DLS_x0020and_x0020toolface_x0020to_x0020MD = 25,
+		witsml2__TrajStationType__DLS_x0020and_x0020toolface_x0020to_x0020TVD = 26,
+		witsml2__TrajStationType__formation_x0020MD = 27,
+		witsml2__TrajStationType__formation_x0020TVD = 28,
+		witsml2__TrajStationType__hold_x0020to_x0020delta_MD = 29,
+		witsml2__TrajStationType__hold_x0020to_x0020MD = 30,
+		witsml2__TrajStationType__hold_x0020to_x0020TVD = 31,
+		witsml2__TrajStationType__INCL_x0020AZI_x0020and_x0020TVD = 32,
+		witsml2__TrajStationType__interpolated = 33,
+		witsml2__TrajStationType__marker_x0020MD = 34,
+		witsml2__TrajStationType__marker_x0020TVD = 35,
+		witsml2__TrajStationType__MD_x0020and_x0020INCL = 36,
+		witsml2__TrajStationType__MD_x0020INCL_x0020and_x0020AZI = 37,
+		witsml2__TrajStationType__N_x0020E_x0020and_x0020TVD = 38,
+		witsml2__TrajStationType__NS_x0020EW_x0020and_x0020TVD = 39,
+		witsml2__TrajStationType__target_x0020center = 40,
+		witsml2__TrajStationType__target_x0020offset = 41,
+		witsml2__TrajStationType__tie_x0020in_x0020point = 42,
+		witsml2__TrajStationType__turnrate_x0020to_x0020AZI = 43,
+		witsml2__TrajStationType__turnrate_x0020to_x0020delta_MD = 44,
+		witsml2__TrajStationType__turnrate_x0020to_x0020MD = 45,
+		witsml2__TrajStationType__turnrate_x0020to_x0020TVD = 46,
+		witsml2__TrajStationType__unknown = 47
+	};
 }
 
 //#ifdef SWIGJAVA
@@ -68,6 +120,7 @@ namespace gsoap_eml2_1
 	%nspace WITSML2_0_NS::Wellbore;
 	%nspace WITSML2_0_NS::WellboreObject;
 	%nspace WITSML2_0_NS::WellboreCompletion;
+	%nspace WITSML2_0_NS::Trajectory;
 #endif
 
 namespace WITSML2_0_NS
@@ -254,6 +307,8 @@ namespace WITSML2_0_NS
 	class Trajectory : public WellboreObject
 	{
 	public:
+		void pushBackTrajectoryStation(gsoap_eml2_1::witsml2__TrajStationType kind, double mdValue, gsoap_eml2_1::eml21__LengthUom uom, const std::string & uid = "");
+		unsigned int getTrajectoryStationCount() const;
 	};
 }
 

--- a/test/resqml2_0_1test/AbstractFeatureInterpretationTest.cpp
+++ b/test/resqml2_0_1test/AbstractFeatureInterpretationTest.cpp
@@ -40,13 +40,6 @@ void AbstractFeatureInterpretationTest::readEpcDoc()
 
 	// remark: following REQUIRE directives are not redundant with "cascade testing" since they cover the partial reference case.
 	AbstractFeatureInterpretation* interpretation = static_cast<AbstractFeatureInterpretation*>(epcDoc->getDataObjectByUuid(this->uuid));
-	REQUIRE( interpretation->getInterpretedFeature()->getUuid() == this->uuidFeature );
-	REQUIRE( interpretation->getInterpretedFeature()->getTitle() == this->titleFeature );
-
-	// partial case handling
-	if (interpretation->getInterpretedFeature()->getGsoapProxy() == nullptr)
-		REQUIRE( interpretation->getInterpretedFeature()->isPartial() );
-	else
-		REQUIRE_FALSE( interpretation->getInterpretedFeature()->isPartial() );
+	REQUIRE( interpretation->getInterpretedFeature()->getUuid() == uuidFeature );
+	REQUIRE( interpretation->getInterpretedFeature()->getTitle() == titleFeature );
 }
-

--- a/test/resqml2_0_1test/InterpretationDomain.cpp
+++ b/test/resqml2_0_1test/InterpretationDomain.cpp
@@ -42,9 +42,9 @@ InterpretationDomain::InterpretationDomain(EpcDocument* epcDoc, bool init)
 	: AbstractTest(epcDoc)
 {
 	if (init)
-		this->initEpcDoc();
+		initEpcDoc();
 	else
-		this->readEpcDoc();
+		readEpcDoc();
 }
 
 void InterpretationDomain::initEpcDoc() {
@@ -72,4 +72,3 @@ void InterpretationDomain::initEpcDoc() {
 void InterpretationDomain::readEpcDoc() {
 
 }
-


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- Remove Compiler Warning C4251 for Visual Studio
- Provide getRepresentationINDEXOfContactPatch method in SealedSurfaceFramework

Does this close any currently open issues?
------------------------------------------
Fix #113 
Fix #124 

Where has this been tested?
---------------------------
**Operating System:** Win 10 64bits

**Platform:** VS 2015 64 bits
