### PR TITLE
Changed prototypes of three member functions to match .cpp files.

### DIFF
--- a/src/common/HdfProxy.h
+++ b/src/common/HdfProxy.h
@@ -18,6 +18,8 @@ under the License.
 -----------------------------------------------------------------------*/
 #pragma once
 
+#include "H5Ipublic.h"
+
 #include "common/AbstractHdfProxy.h"
 
 namespace COMMON_NS
@@ -46,7 +48,7 @@ namespace COMMON_NS
 		* @param datatype 		The hdf datatype of the values to read.
 		* 						If the values are not stored in this particular datatype, then hdf library will try to do a conversion.
 		*/
-		void readArrayNdOfValues(const std::string & datasetName, void* values, const int & datatype);
+		void readArrayNdOfValues(const std::string & datasetName, void* values, const hid_t & datatype);
 
 		/**
 		* Find the array associated with @p datasetName and read a portion of it.
@@ -64,7 +66,7 @@ namespace COMMON_NS
 			unsigned long long * numValuesInEachDimension,
 			unsigned long long * offsetInEachDimension,
 			const unsigned int & numDimensions,
-			const int & datatype);
+			const hid_t & datatype);
 
 		/**
 		* Find the array associated with @p datasetName and read from it.
@@ -86,7 +88,7 @@ namespace COMMON_NS
 			unsigned long long * strideInEachDimension,
 			unsigned long long * blockSizeInEachDimension,
 			const unsigned int & numDimensions,
-			const int & datatype);
+			const hid_t & datatype);
 
 		/**
 		* Considering a given dataset, this method selects an hyperslab region to add to an existing selected region or to add to a new selected region.


### PR DESCRIPTION

What does this implement/fix? Explain your changes.
---------------------------------------------------
HdfProxy class was using hid_t in .cpp but int in .h files for the datatype member.

I am doing some investigation of using HDF5 1.10 and discovered this problem because hid_t is now a 64-bit int.  (I could imagine this was originally done as a hack to prevent the .h file having to include any HDF5 headers, but it won't work any longer!)

See https://support.hdfgroup.org/HDF5/doc/ADGuide/Changes.html under "Release 1.10.0 of March 2016 versus Release 1.8.16"

Does this close any currently open issues?
------------------------------------------
No

Any relevant logs, error output, etc?
-------------------------------------

Any other comments?
-------------------
If I discover other required changes for HDF5 1.10.5, I'll submit separately.

Where has this been tested?
---------------------------
**Operating System:** Windows 10

**Platform:** VS 2015
