### PR TITLE
Performance : Bufferize opened HDF5 groups

### DIFF
--- a/src/common/HdfProxy.h
+++ b/src/common/HdfProxy.h
@@ -20,6 +20,8 @@ under the License.
 
 #include "common/AbstractHdfProxy.h"
 
+#include <unordered_map>
+
 namespace COMMON_NS
 {
 	class HdfProxy : public AbstractHdfProxy
@@ -27,10 +29,10 @@ namespace COMMON_NS
 	protected:
 
 		HdfProxy(gsoap_resqml2_0_1::_eml20__EpcExternalPartReference* fromGsoap) :
-			COMMON_NS::AbstractHdfProxy(fromGsoap), hdfFile(-1), compressionLevel(0) {}
+			COMMON_NS::AbstractHdfProxy(fromGsoap), hdfFile(-1), compressionLevel(0), openedGroups() {}
 
 		HdfProxy(gsoap_eml2_1::_eml21__EpcExternalPartReference* fromGsoap) :
-			COMMON_NS::AbstractHdfProxy(fromGsoap), hdfFile(-1), compressionLevel(0) {}
+			COMMON_NS::AbstractHdfProxy(fromGsoap), hdfFile(-1), compressionLevel(0), openedGroups() {}
 
 		/**
 		* Creates an instance of this class in a gsoap context.
@@ -134,7 +136,7 @@ namespace COMMON_NS
 		* Destructor.
 		* Close the hdf file.
 		*/
-		~HdfProxy() {close();}
+		virtual ~HdfProxy() {close();}
 
 		/**
 		* Open the file for reading and writing.
@@ -599,12 +601,14 @@ namespace COMMON_NS
 		/**
 		* Check if an hdf group named as groupName exists in the root group.
 		* If it exists, it returns the latter. If not, it creates this group and then returns it.
-		* Please close the group after having called and used this group.
+		* Do not close opened or created HDF5 group. They are automatically managed by fesapi.
 		*/
 		hdf5_hid_t openOrCreateGroupInRootGroup(const std::string & groupName);
 
 	    hdf5_hid_t hdfFile;
 
 		unsigned int compressionLevel;
+
+		std::unordered_map< std::string, hdf5_hid_t > openedGroups;
 	};
 }

--- a/src/resqml2_0_1/HdfProxy.cpp
+++ b/src/resqml2_0_1/HdfProxy.cpp
@@ -25,6 +25,7 @@ under the License.
 using namespace std;
 using namespace RESQML2_0_1_NS;
 
+const char* HdfProxy::RESQML_ROOT_GROUP = "/RESQML";
 
 HdfProxy::HdfProxy(COMMON_NS::DataObjectRepository * repo, const std::string & guid, const std::string & title, const std::string & packageDirAbsolutePath, const std::string & externalFilePath, COMMON_NS::DataObjectRepository::openingMode hdfPermissionAccess) :
 	COMMON_NS::HdfProxy(packageDirAbsolutePath, externalFilePath, hdfPermissionAccess)
@@ -42,9 +43,16 @@ hid_t HdfProxy::openOrCreateRootGroup()
 	if (!isOpened()) {
 		open();
 	}
-
+	
+	if (openedGroups.find(RESQML_ROOT_GROUP) != openedGroups.end()) {
+		return openedGroups.at(RESQML_ROOT_GROUP);
+	}
+	
 	H5O_info_t info;
-	herr_t status = H5Oget_info_by_name(hdfFile, "/RESQML", &info, H5P_DEFAULT);
-
-	return status >= 0 ? H5Gopen(hdfFile, "/RESQML", H5P_DEFAULT) : H5Gcreate(hdfFile, "/RESQML", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+	herr_t status = H5Oget_info_by_name(hdfFile, RESQML_ROOT_GROUP, &info, H5P_DEFAULT);
+	
+	hid_t result =  status >= 0 ? H5Gopen(hdfFile, RESQML_ROOT_GROUP, H5P_DEFAULT) : H5Gcreate(hdfFile, RESQML_ROOT_GROUP, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+	openedGroups[RESQML_ROOT_GROUP] = result;
+	return result;
+	
 }

--- a/src/resqml2_0_1/HdfProxy.h
+++ b/src/resqml2_0_1/HdfProxy.h
@@ -46,6 +46,8 @@ namespace RESQML2_0_1_NS
 		std::string getXmlNamespace() const;
 
 	private:
+		static const char * RESQML_ROOT_GROUP;
+
 		/**
 		* Check if a hdf group named "RESQML" exists as a child of the root of the HDF file.
 		* If it exists, it returns the latter. If not, it creates this group and then returns it.

--- a/src/resqml2_0_1/SealedSurfaceFrameworkRepresentation.h
+++ b/src/resqml2_0_1/SealedSurfaceFrameworkRepresentation.h
@@ -20,8 +20,6 @@ under the License.
 
 #include "resqml2_0_1/AbstractSurfaceFrameworkRepresentation.h"
 
-#include "resqml2_0_1/SealedVolumeFrameworkRepresentation.h"
-
 namespace RESQML2_NS {
 	class AbstractHdfProxy;
 }

--- a/src/resqml2_0_1/UnstructuredGridRepresentation.cpp
+++ b/src/resqml2_0_1/UnstructuredGridRepresentation.cpp
@@ -174,7 +174,7 @@ void UnstructuredGridRepresentation::getFaceIndicesOfCells(ULONG64 * faceIndices
 	}
 }
 
-void UnstructuredGridRepresentation::getCumulativeFaceCountPerCell(ULONG64 * cumulativeFaceCountPerCell) const
+void UnstructuredGridRepresentation::getCumulativeFaceCountPerCell(ULONG64 * cumulativeFaceCountPerCell_) const
 {
 	_resqml2__UnstructuredGridRepresentation* grid = getSpecializedGsoapProxy();
 	if (grid->Geometry == nullptr)
@@ -183,23 +183,23 @@ void UnstructuredGridRepresentation::getCumulativeFaceCountPerCell(ULONG64 * cum
 	{
 		eml20__Hdf5Dataset const * dataset = static_cast<resqml2__IntegerHdf5Array*>(grid->Geometry->FacesPerCell->CumulativeLength)->Values;
 		COMMON_NS::AbstractHdfProxy * hdfProxy = getHdfProxyFromDataset(dataset);
-		hdfProxy->readArrayNdOfGSoapULong64Values(dataset->PathInHdfFile, cumulativeFaceCountPerCell);
+		hdfProxy->readArrayNdOfGSoapULong64Values(dataset->PathInHdfFile, cumulativeFaceCountPerCell_);
 	}
 	else if (grid->Geometry->FacesPerCell->CumulativeLength->soap_type() == SOAP_TYPE_gsoap_resqml2_0_1_resqml2__IntegerLatticeArray)
 	{
-		cumulativeFaceCountPerCell[0] = static_cast<resqml2__IntegerLatticeArray*>(grid->Geometry->FacesPerCell->CumulativeLength)->StartValue;
+		cumulativeFaceCountPerCell_[0] = static_cast<resqml2__IntegerLatticeArray*>(grid->Geometry->FacesPerCell->CumulativeLength)->StartValue;
 		const LONG64 offsetValue = static_cast<resqml2__IntegerLatticeArray*>(grid->Geometry->FacesPerCell->CumulativeLength)->Offset[0]->Value;
 		const ULONG64 cellCount = getCellCount();
 		for (ULONG64 cumulativeFaceCountPerCellIndex = 1; cumulativeFaceCountPerCellIndex < cellCount; ++cumulativeFaceCountPerCellIndex)
 		{
-			cumulativeFaceCountPerCell[cumulativeFaceCountPerCellIndex] = cumulativeFaceCountPerCell[cumulativeFaceCountPerCellIndex - 1] + offsetValue;
+			cumulativeFaceCountPerCell_[cumulativeFaceCountPerCellIndex] = cumulativeFaceCountPerCell_[cumulativeFaceCountPerCellIndex - 1] + offsetValue;
 		}
 	}
 	else if (grid->Geometry->FacesPerCell->CumulativeLength->soap_type() == SOAP_TYPE_gsoap_resqml2_0_1_resqml2__IntegerConstantArray)
 	{
 		if (getCellCount() > 1)
 			throw range_error("The cumulative length of faces count per cells cannot be constant if there is more than one cell in the grid");
-		cumulativeFaceCountPerCell[0] = static_cast<resqml2__IntegerConstantArray*>(grid->Geometry->FacesPerCell->CumulativeLength)->Value;
+		cumulativeFaceCountPerCell_[0] = static_cast<resqml2__IntegerConstantArray*>(grid->Geometry->FacesPerCell->CumulativeLength)->Value;
 	}
 }
 

--- a/src/resqml2_0_1/UnstructuredGridRepresentation.h
+++ b/src/resqml2_0_1/UnstructuredGridRepresentation.h
@@ -147,7 +147,7 @@ namespace RESQML2_0_1_NS
 		* A single face count should be at least 4.
 		* @param cumulativeFaceCountPerCellIndex	It must be pre allocated with getCellCount()
 		*/
-		DLL_IMPORT_OR_EXPORT void getCumulativeFaceCountPerCell(ULONG64 * cumulativeFaceCountPerCell) const;
+		DLL_IMPORT_OR_EXPORT void getCumulativeFaceCountPerCell(ULONG64 * cumulativeFaceCountPerCell_) const;
 
 		/**
 		* Less efficient than getCumulativeFaceCountPerCell.

--- a/swig/swigModule.i
+++ b/swig/swigModule.i
@@ -222,8 +222,6 @@ namespace RESQML2_NS
 
 namespace COMMON_NS
 {
-	%typemap(javafinalize) DataObjectRepository %{
-	%}
 	class DataObjectRepository
 	{
 	public:


### PR DESCRIPTION
Fix a missing virtual HDF destructor

What does this implement/fix? Explain your changes.
---------------------------------------------------
HDF group were searched and opened each time it was needed. It resulted in very low performance.
By buffering opened hdf groups, we allow accessing them in constant time and we have not to reopen them each time needed.

Does this close any currently open issues?
------------------------------------------
See https://discourse.f2i-consulting.com/t/how-to-represent-a-fracture-network/119

Where has this been tested?
---------------------------
**Operating System:** Win64 10

**Platform:** VS 2015 64
