### PR TITLE
Work back const correctness

### DIFF
--- a/cmake/swigModule.i
+++ b/cmake/swigModule.i
@@ -183,7 +183,7 @@ namespace COMMON_NS
 		std::string getExtraMetadataStringValueAtIndex(unsigned int index) const;
 
 		unsigned int getActivityCount() const;
-		RESQML2_NS::Activity const * getActivity (unsigned int index) const;
+		RESQML2_NS::Activity * getActivity (unsigned int index) const;
 	};
 	
 	//************************************
@@ -254,15 +254,15 @@ namespace COMMON_NS
 
 		std::vector<RESQML2_0_1_NS::TectonicBoundaryFeature*> getFractureSet() const;
 
-		std::vector<RESQML2_0_1_NS::PolylineSetRepresentation const *> getFaultPolylineSetRepSet() const;
+		std::vector<RESQML2_0_1_NS::PolylineSetRepresentation *> getFaultPolylineSetRepSet() const;
 
-		std::vector<RESQML2_0_1_NS::PolylineSetRepresentation const *> getFracturePolylineSetRepSet() const;
+		std::vector<RESQML2_0_1_NS::PolylineSetRepresentation *> getFracturePolylineSetRepSet() const;
 
-		std::vector<RESQML2_0_1_NS::PolylineSetRepresentation const *> getFrontierPolylineSetRepSet() const;
+		std::vector<RESQML2_0_1_NS::PolylineSetRepresentation *> getFrontierPolylineSetRepSet() const;
 
-		std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation const *> getFaultTriangulatedSetRepSet() const;
+		std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation *> getFaultTriangulatedSetRepSet() const;
 
-		std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation const *> getFractureTriangulatedSetRepSet() const;
+		std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation *> getFractureTriangulatedSetRepSet() const;
 
 		std::vector<RESQML2_0_1_NS::Horizon*> getHorizonSet() const;
 
@@ -272,13 +272,13 @@ namespace COMMON_NS
 
 		std::vector<RESQML2_0_1_NS::GeobodyFeature*> getGeobodySet() const;
 
-		std::vector<RESQML2_0_1_NS::Grid2dRepresentation const *> getHorizonGrid2dRepSet() const;
+		std::vector<RESQML2_0_1_NS::Grid2dRepresentation *> getHorizonGrid2dRepSet() const;
 
-		std::vector<RESQML2_0_1_NS::PolylineRepresentation const *> getHorizonPolylineRepSet() const;
+		std::vector<RESQML2_0_1_NS::PolylineRepresentation *> getHorizonPolylineRepSet() const;
 
-		std::vector<RESQML2_0_1_NS::PolylineSetRepresentation const *> getHorizonPolylineSetRepSet() const;
+		std::vector<RESQML2_0_1_NS::PolylineSetRepresentation *> getHorizonPolylineSetRepSet() const;
 
-		std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation const *> getHorizonTriangulatedSetRepSet() const;
+		std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation *> getHorizonTriangulatedSetRepSet() const;
 
 		std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation*> getAllTriangulatedSetRepSet() const;
 
@@ -292,9 +292,9 @@ namespace COMMON_NS
 
 		std::vector<RESQML2_0_1_NS::WellboreFeature*> getWellboreSet();
 
-		std::vector<RESQML2_0_1_NS::WellboreTrajectoryRepresentation const *> getWellboreTrajectoryRepresentationSet() const;
+		std::vector<RESQML2_0_1_NS::WellboreTrajectoryRepresentation *> getWellboreTrajectoryRepresentationSet() const;
 
-		std::vector<RESQML2_0_1_NS::DeviationSurveyRepresentation const *> getDeviationSurveyRepresentationSet() const;
+		std::vector<RESQML2_0_1_NS::DeviationSurveyRepresentation *> getDeviationSurveyRepresentationSet() const;
 
 		std::vector<RESQML2_NS::RepresentationSetRepresentation*> getRepresentationSetRepresentationSet() const;
 
@@ -519,17 +519,17 @@ namespace COMMON_NS
 		RESQML2_0_1_NS::Grid2dRepresentation* createGrid2dRepresentation(RESQML2_NS::AbstractFeatureInterpretation* interp,
 			const std::string & guid, const std::string & title);
 
-		RESQML2_0_1_NS::WellboreTrajectoryRepresentation* createWellboreTrajectoryRepresentation(RESQML2_0_1_NS::WellboreInterpretation const * interp, const std::string & guid, const std::string & title, RESQML2_NS::MdDatum const * mdInfo);
-		RESQML2_0_1_NS::WellboreTrajectoryRepresentation* createWellboreTrajectoryRepresentation(RESQML2_0_1_NS::WellboreInterpretation const * interp, const std::string & guid, const std::string & title, RESQML2_0_1_NS::DeviationSurveyRepresentation const * deviationSurvey);
+		RESQML2_0_1_NS::WellboreTrajectoryRepresentation* createWellboreTrajectoryRepresentation(RESQML2_0_1_NS::WellboreInterpretation * interp, const std::string & guid, const std::string & title, RESQML2_NS::MdDatum * mdInfo);
+		RESQML2_0_1_NS::WellboreTrajectoryRepresentation* createWellboreTrajectoryRepresentation(RESQML2_0_1_NS::WellboreInterpretation * interp, const std::string & guid, const std::string & title, RESQML2_0_1_NS::DeviationSurveyRepresentation * deviationSurvey);
 
-		RESQML2_0_1_NS::DeviationSurveyRepresentation* createDeviationSurveyRepresentation(RESQML2_0_1_NS::WellboreInterpretation const * interp, const std::string & guid, const std::string & title, const bool & isFinal, RESQML2_NS::MdDatum const * mdInfo);
+		RESQML2_0_1_NS::DeviationSurveyRepresentation* createDeviationSurveyRepresentation(RESQML2_0_1_NS::WellboreInterpretation * interp, const std::string & guid, const std::string & title, const bool & isFinal, RESQML2_NS::MdDatum * mdInfo);
 
-		RESQML2_0_1_NS::WellboreFrameRepresentation* createWellboreFrameRepresentation(RESQML2_0_1_NS::WellboreInterpretation const * interp, const std::string & guid, const std::string & title, RESQML2_0_1_NS::WellboreTrajectoryRepresentation const * traj);
+		RESQML2_0_1_NS::WellboreFrameRepresentation* createWellboreFrameRepresentation(RESQML2_0_1_NS::WellboreInterpretation * interp, const std::string & guid, const std::string & title, RESQML2_0_1_NS::WellboreTrajectoryRepresentation * traj);
 
-		RESQML2_0_1_NS::WellboreMarkerFrameRepresentation* createWellboreMarkerFrameRepresentation(RESQML2_0_1_NS::WellboreInterpretation const * interp, const std::string & guid, const std::string & title, RESQML2_0_1_NS::WellboreTrajectoryRepresentation const * traj);
+		RESQML2_0_1_NS::WellboreMarkerFrameRepresentation* createWellboreMarkerFrameRepresentation(RESQML2_0_1_NS::WellboreInterpretation * interp, const std::string & guid, const std::string & title, RESQML2_0_1_NS::WellboreTrajectoryRepresentation * traj);
 
-		RESQML2_0_1_NS::BlockedWellboreRepresentation* createBlockedWellboreRepresentation(RESQML2_0_1_NS::WellboreInterpretation const * interp,
-			const std::string & guid, const std::string & title, RESQML2_0_1_NS::WellboreTrajectoryRepresentation const * traj);
+		RESQML2_0_1_NS::BlockedWellboreRepresentation* createBlockedWellboreRepresentation(RESQML2_0_1_NS::WellboreInterpretation * interp,
+			const std::string & guid, const std::string & title, RESQML2_0_1_NS::WellboreTrajectoryRepresentation * traj);
 
 		RESQML2_NS::RepresentationSetRepresentation* createRepresentationSetRepresentation(
 			RESQML2_0_1_NS::AbstractOrganizationInterpretation* interp,

--- a/cmake/swigModule_experimental.i
+++ b/cmake/swigModule_experimental.i
@@ -184,7 +184,7 @@ namespace COMMON_NS
 		std::string getExtraMetadataStringValueAtIndex(unsigned int index) const;
 
 		unsigned int getActivityCount() const;
-		RESQML2_NS::Activity const * getActivity (unsigned int index) const;
+		RESQML2_NS::Activity * getActivity (unsigned int index) const;
 	};
 	
 	//************************************
@@ -250,22 +250,22 @@ namespace COMMON_NS
 		void getDefaultRgbColor(AbstractObject const* targetObject, unsigned int& red, unsigned int& green, unsigned int& blue) const;
 		bool hasDefaultColorTitle(AbstractObject const* targetObject) const;
 		std::string getDefaultColorTitle(AbstractObject const* targetObject) const;
-		void setDefaultHsvColor(AbstractObject const* targetObject, double hue, double saturation, double value, double alpha = 1.0, std::string const& colorTitle = "");
-		void setDefaultRgbColor(AbstractObject const* targetObject, double red, double green, double blue, double alpha = 1.0, std::string const& colorTitle = "");
-		void setDefaultRgbColor(AbstractObject const* targetObject, unsigned int red, unsigned int green, unsigned int blue, double alpha = 1.0, std::string const& colorTitle = "");
+		void setDefaultHsvColor(AbstractObject * targetObject, double hue, double saturation, double value, double alpha = 1.0, std::string const& colorTitle = "");
+		void setDefaultRgbColor(AbstractObject * targetObject, double red, double green, double blue, double alpha = 1.0, std::string const& colorTitle = "");
+		void setDefaultRgbColor(AbstractObject * targetObject, unsigned int red, unsigned int green, unsigned int blue, double alpha = 1.0, std::string const& colorTitle = "");
 
 		bool hasDiscreteColorMap(AbstractObject const* targetObject) const;
 		gsoap_eml2_2::eml22__DataObjectReference* getDiscreteColorMapDor(AbstractObject const* targetObject) const;
 		std::string getDiscreteColorMapUuid(AbstractObject const* targetObject) const;
 		RESQML2_2_NS::DiscreteColorMap* getDiscreteColorMap(AbstractObject const* targetObject) const;
-		void setDiscreteColorMap(AbstractObject const* targetObject, RESQML2_2_NS::DiscreteColorMap* discreteColorMap,
+		void setDiscreteColorMap(AbstractObject * targetObject, RESQML2_2_NS::DiscreteColorMap* discreteColorMap,
 			LONG64 valueVectorIndex = 0, bool useReverseMapping = false, bool useLogarithmicMapping = false);
 
 		bool hasContinuousColorMap(AbstractObject const* targetObject) const;
 		gsoap_eml2_2::eml22__DataObjectReference* getContinuousColorMapDor(AbstractObject const* targetObject) const;
 		std::string getContinuousColorMapUuid(AbstractObject const* targetObject) const;
 		RESQML2_2_NS::ContinuousColorMap* getContinuousColorMap(AbstractObject const* targetObject) const;
-		void setContinuousColorMap(AbstractObject const* targetObject, RESQML2_2_NS::ContinuousColorMap* continuousColorMap,
+		void setContinuousColorMap(AbstractObject * targetObject, RESQML2_2_NS::ContinuousColorMap* continuousColorMap,
 			LONG64 valueVectorIndex = 0, bool useReverseMapping = false, bool useLogarithmicMapping = false);
 
 		double getColorMapMinIndex(AbstractObject const* targetObject) const;
@@ -301,15 +301,15 @@ namespace COMMON_NS
 
 		std::vector<RESQML2_0_1_NS::TectonicBoundaryFeature*> getFractureSet() const;
 
-		std::vector<RESQML2_0_1_NS::PolylineSetRepresentation const *> getFaultPolylineSetRepSet() const;
+		std::vector<RESQML2_0_1_NS::PolylineSetRepresentation *> getFaultPolylineSetRepSet() const;
 
-		std::vector<RESQML2_0_1_NS::PolylineSetRepresentation const *> getFracturePolylineSetRepSet() const;
+		std::vector<RESQML2_0_1_NS::PolylineSetRepresentation *> getFracturePolylineSetRepSet() const;
 
-		std::vector<RESQML2_0_1_NS::PolylineSetRepresentation const *> getFrontierPolylineSetRepSet() const;
+		std::vector<RESQML2_0_1_NS::PolylineSetRepresentation *> getFrontierPolylineSetRepSet() const;
 
-		std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation const *> getFaultTriangulatedSetRepSet() const;
+		std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation *> getFaultTriangulatedSetRepSet() const;
 
-		std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation const *> getFractureTriangulatedSetRepSet() const;
+		std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation *> getFractureTriangulatedSetRepSet() const;
 
 		std::vector<RESQML2_0_1_NS::Horizon*> getHorizonSet() const;
 
@@ -319,13 +319,13 @@ namespace COMMON_NS
 
 		std::vector<RESQML2_0_1_NS::GeobodyFeature*> getGeobodySet() const;
 
-		std::vector<RESQML2_0_1_NS::Grid2dRepresentation const *> getHorizonGrid2dRepSet() const;
+		std::vector<RESQML2_0_1_NS::Grid2dRepresentation *> getHorizonGrid2dRepSet() const;
 
-		std::vector<RESQML2_0_1_NS::PolylineRepresentation const *> getHorizonPolylineRepSet() const;
+		std::vector<RESQML2_0_1_NS::PolylineRepresentation *> getHorizonPolylineRepSet() const;
 
-		std::vector<RESQML2_0_1_NS::PolylineSetRepresentation const *> getHorizonPolylineSetRepSet() const;
+		std::vector<RESQML2_0_1_NS::PolylineSetRepresentation *> getHorizonPolylineSetRepSet() const;
 
-		std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation const *> getHorizonTriangulatedSetRepSet() const;
+		std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation *> getHorizonTriangulatedSetRepSet() const;
 
 		std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation*> getAllTriangulatedSetRepSet() const;
 
@@ -339,9 +339,9 @@ namespace COMMON_NS
 
 		std::vector<RESQML2_0_1_NS::WellboreFeature*> getWellboreSet();
 
-		std::vector<RESQML2_0_1_NS::WellboreTrajectoryRepresentation const *> getWellboreTrajectoryRepresentationSet() const;
+		std::vector<RESQML2_0_1_NS::WellboreTrajectoryRepresentation *> getWellboreTrajectoryRepresentationSet() const;
 
-		std::vector<RESQML2_0_1_NS::DeviationSurveyRepresentation const *> getDeviationSurveyRepresentationSet() const;
+		std::vector<RESQML2_0_1_NS::DeviationSurveyRepresentation *> getDeviationSurveyRepresentationSet() const;
 
 		std::vector<RESQML2_NS::RepresentationSetRepresentation*> getRepresentationSetRepresentationSet() const;
 
@@ -566,17 +566,17 @@ namespace COMMON_NS
 		RESQML2_0_1_NS::Grid2dRepresentation* createGrid2dRepresentation(RESQML2_NS::AbstractFeatureInterpretation* interp,
 			const std::string & guid, const std::string & title);
 
-		RESQML2_0_1_NS::WellboreTrajectoryRepresentation* createWellboreTrajectoryRepresentation(RESQML2_0_1_NS::WellboreInterpretation const * interp, const std::string & guid, const std::string & title, RESQML2_NS::MdDatum const * mdInfo);
-		RESQML2_0_1_NS::WellboreTrajectoryRepresentation* createWellboreTrajectoryRepresentation(RESQML2_0_1_NS::WellboreInterpretation const * interp, const std::string & guid, const std::string & title, RESQML2_0_1_NS::DeviationSurveyRepresentation const * deviationSurvey);
+		RESQML2_0_1_NS::WellboreTrajectoryRepresentation* createWellboreTrajectoryRepresentation(RESQML2_0_1_NS::WellboreInterpretation * interp, const std::string & guid, const std::string & title, RESQML2_NS::MdDatum * mdInfo);
+		RESQML2_0_1_NS::WellboreTrajectoryRepresentation* createWellboreTrajectoryRepresentation(RESQML2_0_1_NS::WellboreInterpretation * interp, const std::string & guid, const std::string & title, RESQML2_0_1_NS::DeviationSurveyRepresentation * deviationSurvey);
 
-		RESQML2_0_1_NS::DeviationSurveyRepresentation* createDeviationSurveyRepresentation(RESQML2_0_1_NS::WellboreInterpretation const * interp, const std::string & guid, const std::string & title, const bool & isFinal, RESQML2_NS::MdDatum const * mdInfo);
+		RESQML2_0_1_NS::DeviationSurveyRepresentation* createDeviationSurveyRepresentation(RESQML2_0_1_NS::WellboreInterpretation * interp, const std::string & guid, const std::string & title, const bool & isFinal, RESQML2_NS::MdDatum * mdInfo);
 
-		RESQML2_0_1_NS::WellboreFrameRepresentation* createWellboreFrameRepresentation(RESQML2_0_1_NS::WellboreInterpretation const * interp, const std::string & guid, const std::string & title, RESQML2_0_1_NS::WellboreTrajectoryRepresentation const * traj);
+		RESQML2_0_1_NS::WellboreFrameRepresentation* createWellboreFrameRepresentation(RESQML2_0_1_NS::WellboreInterpretation * interp, const std::string & guid, const std::string & title, RESQML2_0_1_NS::WellboreTrajectoryRepresentation * traj);
 
-		RESQML2_0_1_NS::WellboreMarkerFrameRepresentation* createWellboreMarkerFrameRepresentation(RESQML2_0_1_NS::WellboreInterpretation const * interp, const std::string & guid, const std::string & title, RESQML2_0_1_NS::WellboreTrajectoryRepresentation const * traj);
+		RESQML2_0_1_NS::WellboreMarkerFrameRepresentation* createWellboreMarkerFrameRepresentation(RESQML2_0_1_NS::WellboreInterpretation * interp, const std::string & guid, const std::string & title, RESQML2_0_1_NS::WellboreTrajectoryRepresentation * traj);
 
-		RESQML2_0_1_NS::BlockedWellboreRepresentation* createBlockedWellboreRepresentation(RESQML2_0_1_NS::WellboreInterpretation const * interp,
-			const std::string & guid, const std::string & title, RESQML2_0_1_NS::WellboreTrajectoryRepresentation const * traj);
+		RESQML2_0_1_NS::BlockedWellboreRepresentation* createBlockedWellboreRepresentation(RESQML2_0_1_NS::WellboreInterpretation * interp,
+			const std::string & guid, const std::string & title, RESQML2_0_1_NS::WellboreTrajectoryRepresentation * traj);
 
 		RESQML2_NS::RepresentationSetRepresentation* createRepresentationSetRepresentation(
 			RESQML2_0_1_NS::AbstractOrganizationInterpretation* interp,

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -1866,7 +1866,7 @@ void showAllMetadata(COMMON_NS::AbstractObject const * obj, const std::string & 
 
 void showAllProperties(RESQML2_NS::AbstractRepresentation const * rep, bool* enabledCells = nullptr)
 {
-	std::vector<RESQML2_NS::AbstractValuesProperty const *> propertyValuesSet = rep->getValuesPropertySet();
+	std::vector<RESQML2_NS::AbstractValuesProperty *> propertyValuesSet = rep->getValuesPropertySet();
 	if (propertyValuesSet.empty() == false)
 		cout << "PROPERTIES" << std::endl;
 	for (size_t propIndex = 0; propIndex < propertyValuesSet.size(); ++propIndex)
@@ -1985,7 +1985,7 @@ void showAllProperties(RESQML2_NS::AbstractRepresentation const * rep, bool* ena
 	std::cout << "\t--------------------------------------------------" << std::endl;
 }
 
-void showAllSubRepresentations(const vector<RESQML2_NS::SubRepresentation const *> & subRepSet)
+void showAllSubRepresentations(const vector<RESQML2_NS::SubRepresentation *> & subRepSet)
 {
 	if (!subRepSet.empty()) {
 		cout << "SUBREPRESENTATIONS" << std::endl;
@@ -2042,13 +2042,13 @@ void deserializeStratiColumn(StratigraphicColumn * stratiColumn)
 			showAllMetadata(stratiColumnRankInterp->getDirectObjectOfContact(contactIndex));
 		}
 
-		vector<StratigraphicOccurrenceInterpretation const*> soiSet = stratiColumnRankInterp->getStratigraphicOccurrenceInterpretationSet();
+		vector<StratigraphicOccurrenceInterpretation*> soiSet = stratiColumnRankInterp->getStratigraphicOccurrenceInterpretationSet();
 		for (size_t soiIndex = 0; soiIndex < soiSet.size(); ++soiIndex) {
-			vector<WellboreMarkerFrameRepresentation const *> markerFrameSet = soiSet[soiIndex]->getWellboreMarkerFrameRepresentationSet();
+			vector<WellboreMarkerFrameRepresentation *> markerFrameSet = soiSet[soiIndex]->getWellboreMarkerFrameRepresentationSet();
 			for (size_t markerFrameIndex = 0; markerFrameIndex < markerFrameSet.size(); ++markerFrameIndex) {
-				WellboreMarkerFrameRepresentation const * markerFrame = markerFrameSet[markerFrameIndex];
+				WellboreMarkerFrameRepresentation * markerFrame = markerFrameSet[markerFrameIndex];
 				showAllMetadata(markerFrame);
-				vector<WellboreMarker const *> markerSet = markerFrame->getWellboreMarkerSet();
+				vector<WellboreMarker *> markerSet = markerFrame->getWellboreMarkerSet();
 				double* doubleMds = new double[markerFrame->getMdValuesCount()];
 				markerFrame->getMdAsDoubleValues(doubleMds);
 				for (size_t mIndex = 0; mIndex < markerSet.size(); ++mIndex) {
@@ -3283,50 +3283,53 @@ void deserializeGraphicalInformationSet(COMMON_NS::DataObjectRepository & pck)
 {
 	std::cout << "GRAPHICAL INFORMATIONS" << std::endl;
 
-	COMMON_NS::GraphicalInformationSet* graphicalInformationSet = pck.getDataObjects<COMMON_NS::GraphicalInformationSet>()[0];
-	for (unsigned int i = 0; i < graphicalInformationSet->getGraphicalInformationSetCount(); ++i)
-	{
-		COMMON_NS::AbstractObject* targetObject = graphicalInformationSet->getTargetObject(i);
+	std::vector<COMMON_NS::GraphicalInformationSet*> gisSet = pck.getDataObjects<COMMON_NS::GraphicalInformationSet>();
+	for (unsigned int gisIndex = 0; gisIndex < gisSet.size(); ++gisIndex) {
+		COMMON_NS::GraphicalInformationSet* graphicalInformationSet = gisSet[gisIndex];
+		for (unsigned int i = 0; i < graphicalInformationSet->getGraphicalInformationSetCount(); ++i)
+		{
+			COMMON_NS::AbstractObject* targetObject = graphicalInformationSet->getTargetObject(i);
 
-		std::cout << "graphical information for: " << targetObject->getTitle() << std::endl;
+			std::cout << "graphical information for: " << targetObject->getTitle() << std::endl;
 
-		if (graphicalInformationSet->hasDefaultColor(targetObject)) {
-			std::cout << "default hue: " << graphicalInformationSet->getDefaultHue(targetObject) << std::endl;
-			std::cout << "default saturation: " << graphicalInformationSet->getDefaultSaturation(targetObject) << std::endl;
-			std::cout << "default value: " << graphicalInformationSet->getDefaultValue(targetObject) << std::endl;
-			std::cout << "default alpha: " << graphicalInformationSet->getDefaultAlpha(targetObject) << std::endl;
-			if (graphicalInformationSet->hasDefaultColorTitle(targetObject)) {
-				std::cout << "default color title: " << graphicalInformationSet->getDefaultColorTitle(targetObject) << std::endl;
-			}
-		}
-
-		if (graphicalInformationSet->hasDiscreteColorMap(targetObject)) {
-			RESQML2_2_NS::DiscreteColorMap* discreteColorMap = graphicalInformationSet->getDiscreteColorMap(targetObject);
-			std::cout << "discrete color map title: " << discreteColorMap->getTitle() << std::endl;
-			unsigned int r, g, b;
-			for (unsigned int colorIndex = 0; colorIndex < discreteColorMap->getColorCount(); ++colorIndex) {
-				discreteColorMap->getRgbColor(colorIndex, r, g, b);
-				std::cout << colorIndex << ": (" << r << ", " << g << ", " << b << ", ";
-				std::cout << discreteColorMap->getAlpha(colorIndex);
-				if (discreteColorMap->hasColorTitle(colorIndex)) {
-					std::cout << ", " << discreteColorMap->getColorTitle(colorIndex);
+			if (graphicalInformationSet->hasDefaultColor(targetObject)) {
+				std::cout << "default hue: " << graphicalInformationSet->getDefaultHue(targetObject) << std::endl;
+				std::cout << "default saturation: " << graphicalInformationSet->getDefaultSaturation(targetObject) << std::endl;
+				std::cout << "default value: " << graphicalInformationSet->getDefaultValue(targetObject) << std::endl;
+				std::cout << "default alpha: " << graphicalInformationSet->getDefaultAlpha(targetObject) << std::endl;
+				if (graphicalInformationSet->hasDefaultColorTitle(targetObject)) {
+					std::cout << "default color title: " << graphicalInformationSet->getDefaultColorTitle(targetObject) << std::endl;
 				}
-				std::cout << ")" << std::endl;
 			}
-		}
 
-		if (graphicalInformationSet->hasContinuousColorMap(targetObject)) {
-			RESQML2_2_NS::ContinuousColorMap* continuousColorMap = graphicalInformationSet->getContinuousColorMap(targetObject);
-			std::cout << "continuous color map title: " << continuousColorMap->getTitle() << std::endl;
-			unsigned int r, g, b;
-			for (unsigned int mapIndex = 0; mapIndex < continuousColorMap->getColorCount(); ++mapIndex) {
-				continuousColorMap->getRgbColor(mapIndex, r, g, b);
-				std::cout << mapIndex << ": (" << r << ", " << g << ", " << b << ", ";
-				std::cout << continuousColorMap->getAlpha(mapIndex);
-				if (continuousColorMap->hasColorTitle(mapIndex)) {
-					std::cout << ", " << continuousColorMap->getColorTitle(mapIndex);
+			if (graphicalInformationSet->hasDiscreteColorMap(targetObject)) {
+				RESQML2_2_NS::DiscreteColorMap* discreteColorMap = graphicalInformationSet->getDiscreteColorMap(targetObject);
+				std::cout << "discrete color map title: " << discreteColorMap->getTitle() << std::endl;
+				unsigned int r, g, b;
+				for (unsigned int colorIndex = 0; colorIndex < discreteColorMap->getColorCount(); ++colorIndex) {
+					discreteColorMap->getRgbColor(colorIndex, r, g, b);
+					std::cout << colorIndex << ": (" << r << ", " << g << ", " << b << ", ";
+					std::cout << discreteColorMap->getAlpha(colorIndex);
+					if (discreteColorMap->hasColorTitle(colorIndex)) {
+						std::cout << ", " << discreteColorMap->getColorTitle(colorIndex);
+					}
+					std::cout << ")" << std::endl;
 				}
-				std::cout << ")" << std::endl;
+			}
+
+			if (graphicalInformationSet->hasContinuousColorMap(targetObject)) {
+				RESQML2_2_NS::ContinuousColorMap* continuousColorMap = graphicalInformationSet->getContinuousColorMap(targetObject);
+				std::cout << "continuous color map title: " << continuousColorMap->getTitle() << std::endl;
+				unsigned int r, g, b;
+				for (unsigned int mapIndex = 0; mapIndex < continuousColorMap->getColorCount(); ++mapIndex) {
+					continuousColorMap->getRgbColor(mapIndex, r, g, b);
+					std::cout << mapIndex << ": (" << r << ", " << g << ", " << b << ", ";
+					std::cout << continuousColorMap->getAlpha(mapIndex);
+					if (continuousColorMap->hasColorTitle(mapIndex)) {
+						std::cout << ", " << continuousColorMap->getColorTitle(mapIndex);
+					}
+					std::cout << ")" << std::endl;
+				}
 			}
 		}
 	}
@@ -3395,21 +3398,21 @@ void deserialize(const string & inputFile)
 	deserializeRockFluidOrganization(repo);
 
 	std::vector<TectonicBoundaryFeature*> faultSet = repo.getFaultSet();
-	std::vector<PolylineSetRepresentation const *> faultPolyRep = repo.getFaultPolylineSetRepSet();
-	std::vector<TriangulatedSetRepresentation const *> faultTriRepSet = repo.getFaultTriangulatedSetRepSet();
+	std::vector<PolylineSetRepresentation *> faultPolyRep = repo.getFaultPolylineSetRepSet();
+	std::vector<TriangulatedSetRepresentation *> faultTriRepSet = repo.getFaultTriangulatedSetRepSet();
 	std::vector<Horizon*> horizonSet = repo.getHorizonSet();
-	std::vector<Grid2dRepresentation const *> horizonGrid2dSet = repo.getHorizonGrid2dRepSet();
-	std::vector<TriangulatedSetRepresentation const *> horizonTriRepSet = repo.getHorizonTriangulatedSetRepSet();
+	std::vector<Grid2dRepresentation *> horizonGrid2dSet = repo.getHorizonGrid2dRepSet();
+	std::vector<TriangulatedSetRepresentation *> horizonTriRepSet = repo.getHorizonTriangulatedSetRepSet();
 	std::vector<TriangulatedSetRepresentation*> unclassifiedTriRepSet = repo.getUnclassifiedTriangulatedSetRepSet();
-	std::vector<PolylineRepresentation const *> horizonSinglePolylineRepSet = repo.getHorizonPolylineRepSet();
+	std::vector<PolylineRepresentation *> horizonSinglePolylineRepSet = repo.getHorizonPolylineRepSet();
 	std::vector<WellboreFeature*> wellboreSet = repo.getWellboreSet();
-	std::vector<WellboreTrajectoryRepresentation const *> wellboreCubicTrajSet = repo.getWellboreTrajectoryRepresentationSet();
+	std::vector<WellboreTrajectoryRepresentation *> wellboreCubicTrajSet = repo.getWellboreTrajectoryRepresentationSet();
 	std::vector<UnstructuredGridRepresentation*> unstructuredGridRepSet = repo.getUnstructuredGridRepresentationSet();
 	std::vector<RESQML2_NS::TimeSeries*> timeSeriesSet = repo.getTimeSeriesSet();
 	std::vector<StratigraphicColumn*> stratiColumnSet = repo.getStratigraphicColumnSet();
 	std::vector<RESQML2_NS::RepresentationSetRepresentation*> representationSetRepresentationSet = repo.getRepresentationSetRepresentationSet();
 	std::vector<RESQML2_NS::SubRepresentation*> subRepresentationSet = repo.getSubRepresentationSet();
-	std::vector<PolylineSetRepresentation const *> frontierPolyRep = repo.getFrontierPolylineSetRepSet();
+	std::vector<PolylineSetRepresentation *> frontierPolyRep = repo.getFrontierPolylineSetRepSet();
 
 	std::cout << "RepresentationSetRepresentation" << endl;
 	for (size_t i = 0; i < representationSetRepresentationSet.size(); i++) {
@@ -3671,7 +3674,7 @@ void deserialize(const string & inputFile)
 				if (wellboreSet[i]->getInterpretationSet()[j]->getRepresentationSet()[k]->getXmlTag() == WellboreMarkerFrameRepresentation::XML_TAG)
 				{
 					WellboreMarkerFrameRepresentation const * wmf = static_cast<WellboreMarkerFrameRepresentation const *>(wellboreSet[i]->getInterpretationSet()[j]->getRepresentationSet()[k]);
-					vector<WellboreMarker const *> marketSet = wmf->getWellboreMarkerSet();
+					vector<WellboreMarker *> marketSet = wmf->getWellboreMarkerSet();
 					for (size_t markerIndex = 0; markerIndex < marketSet.size(); ++markerIndex)
 					{
 						std::cout << "marker : " << marketSet[markerIndex]->getTitle() << std::endl;
@@ -3727,7 +3730,7 @@ void deserialize(const string & inputFile)
 		delete[] xyzPt;
 		std::cout << "LOGS" << endl;
 		std::cout << "--------------------------------------------------" << std::endl;
-		std::vector<WellboreFrameRepresentation const *> wellboreFrameSet = wellboreCubicTrajSet[i]->getWellboreFrameRepresentationSet();
+		std::vector<WellboreFrameRepresentation *> wellboreFrameSet = wellboreCubicTrajSet[i]->getWellboreFrameRepresentationSet();
 		for (size_t j = 0; j < wellboreFrameSet.size(); j++)
 		{
 			showAllMetadata(wellboreFrameSet[j]);
@@ -4112,7 +4115,7 @@ void deserialize(const string & inputFile)
 	}
 
 	std::cout << endl << "ONLY PARTIAL SUBREPRESENTATIONS" << endl;
-	vector<RESQML2_NS::SubRepresentation const *> onlyPartialSubReps;
+	vector<RESQML2_NS::SubRepresentation *> onlyPartialSubReps;
 	for (size_t i = 0; i < subRepresentationSet.size(); ++i) {
 		if (subRepresentationSet[i]->isPartial()) {
 			onlyPartialSubReps.push_back(subRepresentationSet[i]);

--- a/src/common/AbstractObject.cpp
+++ b/src/common/AbstractObject.cpp
@@ -963,7 +963,7 @@ std::string AbstractObject::getAliasTitleAtIndex(unsigned int index) const
 	throw invalid_argument("No underlying gsoap proxy.");
 }
 
-std::vector<RESQML2_NS::Activity const *> AbstractObject::getActivitySet() const
+std::vector<RESQML2_NS::Activity *> AbstractObject::getActivitySet() const
 {
 	return getRepository()->getSourceObjects<RESQML2_NS::Activity>(this);
 }
@@ -979,13 +979,13 @@ unsigned int AbstractObject::getActivityCount() const
 	return static_cast<unsigned int>(result);
 }
 
-RESQML2_NS::Activity const * AbstractObject::getActivity(unsigned int index) const
+RESQML2_NS::Activity * AbstractObject::getActivity(unsigned int index) const
 {
 	if (partialObject != nullptr) {
 		throw invalid_argument("The wrapped gsoap proxy must not be null");
 	}
 
-	const std::vector<RESQML2_NS::Activity const *>& activites = getActivitySet();
+	const std::vector<RESQML2_NS::Activity *>& activites = getActivitySet();
 	if (index >= activites.size())
 		throw out_of_range("The index is out of range.");
 
@@ -1261,9 +1261,9 @@ ULONG64 AbstractObject::getCountOfIntegerArray(gsoap_resqml2_0_1::resqml2__Abstr
 		throw invalid_argument("The integer array type is not supported yet.");
 }
 
-void AbstractObject::convertDorIntoRel(gsoap_resqml2_0_1::eml20__DataObjectReference const * dor) const
+void AbstractObject::convertDorIntoRel(gsoap_resqml2_0_1::eml20__DataObjectReference const * dor)
 {
-	const AbstractObject * targetObj = getRepository()->getDataObjectByUuid(dor->UUID);
+	AbstractObject * targetObj = getRepository()->getDataObjectByUuid(dor->UUID);
 	if (targetObj == nullptr) { // partial transfer
 		getRepository()->createPartial(dor);
 		targetObj = getRepository()->getDataObjectByUuid(dor->UUID);
@@ -1275,9 +1275,9 @@ void AbstractObject::convertDorIntoRel(gsoap_resqml2_0_1::eml20__DataObjectRefer
 }
 
 #if WITH_EXPERIMENTAL
-void AbstractObject::convertDorIntoRel(gsoap_eml2_2::eml22__DataObjectReference const * dor) const
+void AbstractObject::convertDorIntoRel(gsoap_eml2_2::eml22__DataObjectReference const * dor)
 {
-	const AbstractObject * targetObj = getRepository()->getDataObjectByUuid(dor->Uuid);
+	AbstractObject * targetObj = getRepository()->getDataObjectByUuid(dor->Uuid);
 	if (targetObj == nullptr) { // partial transfer
 		getRepository()->createPartial(dor);
 		targetObj = getRepository()->getDataObjectByUuid(dor->Uuid);

--- a/src/common/AbstractObject.h
+++ b/src/common/AbstractObject.h
@@ -109,7 +109,7 @@ namespace COMMON_NS
 		/**
 		* Read the forward relationships of this dataobject and update the rels of the associated datarepository.
 		*/
-		virtual void loadTargetRelationships() const = 0;
+		virtual void loadTargetRelationships() = 0;
 		friend void COMMON_NS::DataObjectRepository::updateAllRelationships();
 
 		/**
@@ -150,17 +150,17 @@ namespace COMMON_NS
 		*/
 		ULONG64 getCountOfIntegerArray(gsoap_resqml2_0_1::resqml2__AbstractIntegerArray * arrayInput) const;
 
-		void convertDorIntoRel(gsoap_resqml2_0_1::eml20__DataObjectReference const * dor) const;
+		void convertDorIntoRel(gsoap_resqml2_0_1::eml20__DataObjectReference const * dor);
 
 #if WITH_EXPERIMENTAL
-		void convertDorIntoRel(gsoap_eml2_2::eml22__DataObjectReference const * dor) const;
+		void convertDorIntoRel(gsoap_eml2_2::eml22__DataObjectReference const * dor);
 #endif
 
 		// Check that the content type of the DOR is OK with the datatype in memory.
 		template <class valueType>
-		void convertDorIntoRel(gsoap_resqml2_0_1::eml20__DataObjectReference const * dor) const
+		void convertDorIntoRel(gsoap_resqml2_0_1::eml20__DataObjectReference const * dor)
 		{
-			valueType const * targetObj = getRepository()->getDataObjectByUuid<valueType>(dor->UUID);
+			valueType * targetObj = getRepository()->getDataObjectByUuid<valueType>(dor->UUID);
 			if (targetObj == nullptr) { // partial transfer
 				getRepository()->createPartial(dor);
 				targetObj = getRepository()->getDataObjectByUuid<valueType>(dor->UUID);
@@ -172,9 +172,9 @@ namespace COMMON_NS
 		}
 
 		template <class valueType>
-		void convertDorIntoRel(gsoap_eml2_1::eml21__DataObjectReference const * dor) const
+		void convertDorIntoRel(gsoap_eml2_1::eml21__DataObjectReference const * dor)
 		{
-			valueType const * targetObj = getRepository()->getDataObjectByUuid<valueType>(dor->Uuid);
+			valueType * targetObj = getRepository()->getDataObjectByUuid<valueType>(dor->Uuid);
 			if (targetObj == nullptr) { // partial transfer
 				getRepository()->createPartial(dor);
 				targetObj = getRepository()->getDataObjectByUuid<valueType>(dor->Uuid);
@@ -187,9 +187,9 @@ namespace COMMON_NS
 
 #if WITH_EXPERIMENTAL
 		template <class valueType>
-		void convertDorIntoRel(gsoap_eml2_2::eml22__DataObjectReference const * dor) const
+		void convertDorIntoRel(gsoap_eml2_2::eml22__DataObjectReference const * dor)
 		{
-			valueType const * targetObj = getRepository()->getDataObjectByUuid<valueType>(dor->Uuid);
+			valueType * targetObj = getRepository()->getDataObjectByUuid<valueType>(dor->Uuid);
 			if (targetObj == nullptr) { // partial transfer
 				getRepository()->createPartial(dor);
 				targetObj = getRepository()->getDataObjectByUuid<valueType>(dor->Uuid);
@@ -360,7 +360,7 @@ namespace COMMON_NS
 		/**
 		* Get all the activities where the instance is involved.
 		*/
-		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_NS::Activity const *> getActivitySet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_NS::Activity *> getActivitySet() const;
 
 		/**
 		* Get the count of associated activities.
@@ -370,7 +370,7 @@ namespace COMMON_NS
 		/**
 		* Get the associated activity at a particular index.
 		*/
-		DLL_IMPORT_OR_EXPORT RESQML2_NS::Activity const * getActivity(unsigned int index) const;
+		DLL_IMPORT_OR_EXPORT RESQML2_NS::Activity * getActivity(unsigned int index) const;
 
 		/**
 		* Push back an extra metadata (not a standard one)

--- a/src/common/DataObjectRepository.cpp
+++ b/src/common/DataObjectRepository.cpp
@@ -268,7 +268,7 @@ void DataObjectRepository::clear()
 	warnings.clear();
 }
 
-void DataObjectRepository::addRelationship(COMMON_NS::AbstractObject const * source, COMMON_NS::AbstractObject const * target)
+void DataObjectRepository::addRelationship(COMMON_NS::AbstractObject * source, COMMON_NS::AbstractObject * target)
 {
 	if (source == nullptr || target == nullptr) {
 		throw invalid_argument("Cannot set a relationship with a null pointer");
@@ -278,7 +278,7 @@ void DataObjectRepository::addRelationship(COMMON_NS::AbstractObject const * sou
 		forwardRels[source].push_back(target);
 	}
 	else {
-		const std::vector< COMMON_NS::AbstractObject const * >& targets = forwardRels.at(source);
+		const std::vector< COMMON_NS::AbstractObject * >& targets = forwardRels.at(source);
 		if (std::find(targets.begin(), targets.end(), target) == targets.end()) {
 			forwardRels[source].push_back(target);
 		}
@@ -296,18 +296,18 @@ void DataObjectRepository::addRelationship(COMMON_NS::AbstractObject const * sou
 	}
 }
 
-const std::vector< COMMON_NS::AbstractObject const * >& DataObjectRepository::getTargetObjects(COMMON_NS::AbstractObject const * dataObj) const
+const std::vector< COMMON_NS::AbstractObject * >& DataObjectRepository::getTargetObjects(COMMON_NS::AbstractObject const * dataObj) const
 {
 	return forwardRels.at(dataObj);
 }
 
-const std::vector< COMMON_NS::AbstractObject const * >& DataObjectRepository::getSourceObjects(COMMON_NS::AbstractObject const * dataObj) const
+const std::vector< COMMON_NS::AbstractObject * >& DataObjectRepository::getSourceObjects(COMMON_NS::AbstractObject const * dataObj) const
 {
 	return backwardRels.at(dataObj);
 }
 
 namespace {
-	void clearVectorOfMapEntry(std::pair< COMMON_NS::AbstractObject const * const, std::vector< COMMON_NS::AbstractObject const * > > & entry) {
+	void clearVectorOfMapEntry(std::pair< COMMON_NS::AbstractObject const * const, std::vector< COMMON_NS::AbstractObject * > > & entry) {
 		entry.second.clear();
 	}
 }
@@ -340,8 +340,8 @@ void DataObjectRepository::addOrReplaceDataObject(COMMON_NS::AbstractObject* pro
 {
 	if (getDataObjectByUuid(proxy->getUuid()) == nullptr) {
 		dataObjects[proxy->getUuid()].push_back(proxy);
-		forwardRels[proxy] = std::vector<COMMON_NS::AbstractObject const *>();
-		backwardRels[proxy] = std::vector<COMMON_NS::AbstractObject const *>();
+		forwardRels[proxy] = std::vector<COMMON_NS::AbstractObject *>();
+		backwardRels[proxy] = std::vector<COMMON_NS::AbstractObject *>();
 	}
 	else {
 		std::vector< COMMON_NS::AbstractObject* >& versions = dataObjects[proxy->getUuid()];
@@ -975,33 +975,33 @@ Grid2dRepresentation* DataObjectRepository::createGrid2dRepresentation(RESQML2_N
 	return new Grid2dRepresentation(interp, guid, title);
 }
 
-WellboreTrajectoryRepresentation* DataObjectRepository::createWellboreTrajectoryRepresentation(WellboreInterpretation const * interp, const std::string & guid, const std::string & title, RESQML2_NS::MdDatum const * mdInfo)
+WellboreTrajectoryRepresentation* DataObjectRepository::createWellboreTrajectoryRepresentation(WellboreInterpretation * interp, const std::string & guid, const std::string & title, RESQML2_NS::MdDatum * mdInfo)
 {
 	return new WellboreTrajectoryRepresentation(interp, guid, title, mdInfo);
 }
 
-WellboreTrajectoryRepresentation* DataObjectRepository::createWellboreTrajectoryRepresentation(WellboreInterpretation const * interp, const std::string & guid, const std::string & title, DeviationSurveyRepresentation const * deviationSurvey)
+WellboreTrajectoryRepresentation* DataObjectRepository::createWellboreTrajectoryRepresentation(WellboreInterpretation * interp, const std::string & guid, const std::string & title, DeviationSurveyRepresentation * deviationSurvey)
 {
 	return new WellboreTrajectoryRepresentation(interp, guid, title, deviationSurvey);
 }
 
-RESQML2_0_1_NS::DeviationSurveyRepresentation* DataObjectRepository::createDeviationSurveyRepresentation(RESQML2_0_1_NS::WellboreInterpretation const * interp, const std::string & guid, const std::string & title, const bool & isFinal, RESQML2_NS::MdDatum const * mdInfo)
+RESQML2_0_1_NS::DeviationSurveyRepresentation* DataObjectRepository::createDeviationSurveyRepresentation(RESQML2_0_1_NS::WellboreInterpretation * interp, const std::string & guid, const std::string & title, const bool & isFinal, RESQML2_NS::MdDatum * mdInfo)
 {
 	return new DeviationSurveyRepresentation(interp, guid, title, isFinal, mdInfo);
 }
 
-WellboreFrameRepresentation* DataObjectRepository::createWellboreFrameRepresentation(WellboreInterpretation const * interp, const std::string & guid, const std::string & title, WellboreTrajectoryRepresentation const * traj)
+WellboreFrameRepresentation* DataObjectRepository::createWellboreFrameRepresentation(WellboreInterpretation * interp, const std::string & guid, const std::string & title, WellboreTrajectoryRepresentation * traj)
 {
 	return new WellboreFrameRepresentation(interp, guid, title, traj);
 }
 
-WellboreMarkerFrameRepresentation* DataObjectRepository::createWellboreMarkerFrameRepresentation(WellboreInterpretation const * interp, const std::string & guid, const std::string & title, WellboreTrajectoryRepresentation const * traj)
+WellboreMarkerFrameRepresentation* DataObjectRepository::createWellboreMarkerFrameRepresentation(WellboreInterpretation * interp, const std::string & guid, const std::string & title, WellboreTrajectoryRepresentation * traj)
 {
 	return new WellboreMarkerFrameRepresentation(interp, guid, title, traj);
 }
 
-BlockedWellboreRepresentation* DataObjectRepository::createBlockedWellboreRepresentation(WellboreInterpretation const * interp,
-	const std::string & guid, const std::string & title, WellboreTrajectoryRepresentation const * traj)
+BlockedWellboreRepresentation* DataObjectRepository::createBlockedWellboreRepresentation(WellboreInterpretation * interp,
+	const std::string & guid, const std::string & title, WellboreTrajectoryRepresentation * traj)
 {
 	return new BlockedWellboreRepresentation(interp, guid, title, traj);
 }
@@ -1441,19 +1441,19 @@ std::vector<RESQML2_0_1_NS::TectonicBoundaryFeature*> DataObjectRepository::getF
 	return result;
 }
 
-vector<PolylineSetRepresentation const *> DataObjectRepository::getFaultPolylineSetRepSet() const
+vector<PolylineSetRepresentation *> DataObjectRepository::getFaultPolylineSetRepSet() const
 {
 	const std::vector<RESQML2_0_1_NS::TectonicBoundaryFeature*> faultSet = getFaultSet();
 
-	vector<PolylineSetRepresentation const *> result;
+	vector<PolylineSetRepresentation *> result;
 
 	for (size_t featureIndex = 0; featureIndex < faultSet.size(); ++featureIndex) {
-		const vector<RESQML2_NS::AbstractFeatureInterpretation const *> interpSet = faultSet[featureIndex]->getInterpretationSet();
+		const vector<RESQML2_NS::AbstractFeatureInterpretation *> interpSet = faultSet[featureIndex]->getInterpretationSet();
 		for (size_t interpIndex = 0; interpIndex < interpSet.size(); ++interpIndex) {
-			const vector<RESQML2_NS::AbstractRepresentation const *> repSet = interpSet[interpIndex]->getRepresentationSet();
+			const vector<RESQML2_NS::AbstractRepresentation *> repSet = interpSet[interpIndex]->getRepresentationSet();
 			for (size_t repIndex = 0; repIndex < repSet.size(); ++repIndex) {
 				if (repSet[repIndex]->getGsoapType() == SOAP_TYPE_gsoap_resqml2_0_1_resqml2__obj_USCOREPolylineSetRepresentation) {
-					result.push_back(static_cast<PolylineSetRepresentation const *>(repSet[repIndex]));
+					result.push_back(static_cast<PolylineSetRepresentation *>(repSet[repIndex]));
 				}
 			}
 		}
@@ -1462,19 +1462,19 @@ vector<PolylineSetRepresentation const *> DataObjectRepository::getFaultPolyline
 	return result;
 }
 
-vector<PolylineSetRepresentation const *> DataObjectRepository::getFracturePolylineSetRepSet() const
+vector<PolylineSetRepresentation *> DataObjectRepository::getFracturePolylineSetRepSet() const
 {
 	const std::vector<RESQML2_0_1_NS::TectonicBoundaryFeature*> fractureSet = getFractureSet();
 
-	vector<PolylineSetRepresentation const *> result;
+	vector<PolylineSetRepresentation *> result;
 
 	for (size_t featureIndex = 0; featureIndex < fractureSet.size(); ++featureIndex) {
-		const vector<RESQML2_NS::AbstractFeatureInterpretation const *> interpSet = fractureSet[featureIndex]->getInterpretationSet();
+		const vector<RESQML2_NS::AbstractFeatureInterpretation *> interpSet = fractureSet[featureIndex]->getInterpretationSet();
 		for (size_t interpIndex = 0; interpIndex < interpSet.size(); ++interpIndex) {
-			const vector<RESQML2_NS::AbstractRepresentation const *> repSet = interpSet[interpIndex]->getRepresentationSet();
+			const vector<RESQML2_NS::AbstractRepresentation *> repSet = interpSet[interpIndex]->getRepresentationSet();
 			for (size_t repIndex = 0; repIndex < repSet.size(); ++repIndex) {
 				if (repSet[repIndex]->getGsoapType() == SOAP_TYPE_gsoap_resqml2_0_1_resqml2__obj_USCOREPolylineSetRepresentation) {
-					result.push_back(static_cast<PolylineSetRepresentation const *>(repSet[repIndex]));
+					result.push_back(static_cast<PolylineSetRepresentation *>(repSet[repIndex]));
 				}
 			}
 		}
@@ -1483,19 +1483,19 @@ vector<PolylineSetRepresentation const *> DataObjectRepository::getFracturePolyl
 	return result;
 }
 
-vector<PolylineSetRepresentation const *> DataObjectRepository::getFrontierPolylineSetRepSet() const
+vector<PolylineSetRepresentation *> DataObjectRepository::getFrontierPolylineSetRepSet() const
 {
 	const std::vector<RESQML2_0_1_NS::FrontierFeature*> frontierSet = getFrontierSet();
 
-	vector<PolylineSetRepresentation const *> result;
+	vector<PolylineSetRepresentation *> result;
 
 	for (size_t featureIndex = 0; featureIndex < frontierSet.size(); ++featureIndex) {
-		const vector<RESQML2_NS::AbstractFeatureInterpretation const *> interpSet = frontierSet[featureIndex]->getInterpretationSet();
+		const vector<RESQML2_NS::AbstractFeatureInterpretation *> interpSet = frontierSet[featureIndex]->getInterpretationSet();
 		for (size_t interpIndex = 0; interpIndex < interpSet.size(); ++interpIndex) {
-			const vector<RESQML2_NS::AbstractRepresentation const *> repSet = interpSet[interpIndex]->getRepresentationSet();
+			const vector<RESQML2_NS::AbstractRepresentation *> repSet = interpSet[interpIndex]->getRepresentationSet();
 			for (size_t repIndex = 0; repIndex < repSet.size(); ++repIndex) {
 				if (repSet[repIndex]->getGsoapType() == SOAP_TYPE_gsoap_resqml2_0_1_resqml2__obj_USCOREPolylineSetRepresentation) {
-					result.push_back(static_cast<PolylineSetRepresentation const *>(repSet[repIndex]));
+					result.push_back(static_cast<PolylineSetRepresentation *>(repSet[repIndex]));
 				}
 			}
 		}
@@ -1504,18 +1504,18 @@ vector<PolylineSetRepresentation const *> DataObjectRepository::getFrontierPolyl
 	return result;
 }
 
-vector<TriangulatedSetRepresentation const *> DataObjectRepository::getFaultTriangulatedSetRepSet() const
+vector<TriangulatedSetRepresentation *> DataObjectRepository::getFaultTriangulatedSetRepSet() const
 {
 	const std::vector<RESQML2_0_1_NS::TectonicBoundaryFeature*> faultSet = getFaultSet();
-	vector<TriangulatedSetRepresentation const *> result;
+	vector<TriangulatedSetRepresentation *> result;
 
 	for (size_t featureIndex = 0; featureIndex < faultSet.size(); ++featureIndex) {
-		const vector<RESQML2_NS::AbstractFeatureInterpretation const *> interpSet = faultSet[featureIndex]->getInterpretationSet();
+		const vector<RESQML2_NS::AbstractFeatureInterpretation *> interpSet = faultSet[featureIndex]->getInterpretationSet();
 		for (size_t interpIndex = 0; interpIndex < interpSet.size(); ++interpIndex) {
-			const vector<RESQML2_NS::AbstractRepresentation const *> repSet = interpSet[interpIndex]->getRepresentationSet();
+			const vector<RESQML2_NS::AbstractRepresentation *> repSet = interpSet[interpIndex]->getRepresentationSet();
 			for (size_t repIndex = 0; repIndex < repSet.size(); ++repIndex) {
 				if (repSet[repIndex]->getGsoapType() == SOAP_TYPE_gsoap_resqml2_0_1_resqml2__obj_USCORETriangulatedSetRepresentation) {
-					result.push_back(static_cast<TriangulatedSetRepresentation const *>(repSet[repIndex]));
+					result.push_back(static_cast<TriangulatedSetRepresentation *>(repSet[repIndex]));
 				}
 			}
 		}
@@ -1524,19 +1524,19 @@ vector<TriangulatedSetRepresentation const *> DataObjectRepository::getFaultTria
 	return result;
 }
 
-vector<TriangulatedSetRepresentation const *> DataObjectRepository::getFractureTriangulatedSetRepSet() const
+vector<TriangulatedSetRepresentation *> DataObjectRepository::getFractureTriangulatedSetRepSet() const
 {
 	const std::vector<RESQML2_0_1_NS::TectonicBoundaryFeature*> fractureSet = getFractureSet();
 
-	vector<TriangulatedSetRepresentation const *> result;
+	vector<TriangulatedSetRepresentation *> result;
 
 	for (size_t featureIndex = 0; featureIndex < fractureSet.size(); ++featureIndex) {
-		const vector<RESQML2_NS::AbstractFeatureInterpretation const *> interpSet = fractureSet[featureIndex]->getInterpretationSet();
+		const vector<RESQML2_NS::AbstractFeatureInterpretation *> interpSet = fractureSet[featureIndex]->getInterpretationSet();
 		for (size_t interpIndex = 0; interpIndex < interpSet.size(); ++interpIndex) {
-			const vector<RESQML2_NS::AbstractRepresentation const *> repSet = interpSet[interpIndex]->getRepresentationSet();
+			const vector<RESQML2_NS::AbstractRepresentation *> repSet = interpSet[interpIndex]->getRepresentationSet();
 			for (size_t repIndex = 0; repIndex < repSet.size(); ++repIndex) {
 				if (repSet[repIndex]->getGsoapType() == SOAP_TYPE_gsoap_resqml2_0_1_resqml2__obj_USCORETriangulatedSetRepresentation) {
-					result.push_back(static_cast<TriangulatedSetRepresentation const *>(repSet[repIndex]));
+					result.push_back(static_cast<TriangulatedSetRepresentation *>(repSet[repIndex]));
 				}
 			}
 		}
@@ -1596,18 +1596,18 @@ RESQML2_0_1_NS::GeneticBoundaryFeature* DataObjectRepository::getGeobodyBoundary
 
 std::vector<RESQML2_0_1_NS::GeobodyFeature*> DataObjectRepository::getGeobodySet() const { return getDataObjects<RESQML2_0_1_NS::GeobodyFeature>(); }
 
-vector<Grid2dRepresentation const *> DataObjectRepository::getHorizonGrid2dRepSet() const
+vector<Grid2dRepresentation *> DataObjectRepository::getHorizonGrid2dRepSet() const
 {
-	vector<Grid2dRepresentation const *> result;
+	vector<Grid2dRepresentation *> result;
 
 	const vector<Horizon*> horizonSet = getHorizonSet();
 	for (size_t featureIndex = 0; featureIndex < horizonSet.size(); ++featureIndex) {
-		const vector<RESQML2_NS::AbstractFeatureInterpretation const *> interpSet = horizonSet[featureIndex]->getInterpretationSet();
+		const vector<RESQML2_NS::AbstractFeatureInterpretation *> interpSet = horizonSet[featureIndex]->getInterpretationSet();
 		for (size_t interpIndex = 0; interpIndex < interpSet.size(); ++interpIndex) {
-			const vector<RESQML2_NS::AbstractRepresentation const *> repSet = interpSet[interpIndex]->getRepresentationSet();
+			const vector<RESQML2_NS::AbstractRepresentation *> repSet = interpSet[interpIndex]->getRepresentationSet();
 			for (size_t repIndex = 0; repIndex < repSet.size(); ++repIndex) {
 				if (repSet[repIndex]->getGsoapType() == SOAP_TYPE_gsoap_resqml2_0_1_resqml2__obj_USCOREGrid2dRepresentation) {
-					result.push_back(static_cast<Grid2dRepresentation const *>(repSet[repIndex]));
+					result.push_back(static_cast<Grid2dRepresentation *>(repSet[repIndex]));
 				}
 			}
 		}
@@ -1616,18 +1616,18 @@ vector<Grid2dRepresentation const *> DataObjectRepository::getHorizonGrid2dRepSe
 	return result;
 }
 
-std::vector<PolylineRepresentation const *> DataObjectRepository::getHorizonPolylineRepSet() const
+std::vector<PolylineRepresentation *> DataObjectRepository::getHorizonPolylineRepSet() const
 {
-	vector<PolylineRepresentation const *> result;
+	vector<PolylineRepresentation *> result;
 
 	const vector<Horizon*> horizonSet = getHorizonSet();
 	for (size_t featureIndex = 0; featureIndex < horizonSet.size(); ++featureIndex) {
-		const vector<RESQML2_NS::AbstractFeatureInterpretation const *> interpSet = horizonSet[featureIndex]->getInterpretationSet();
+		const vector<RESQML2_NS::AbstractFeatureInterpretation *> interpSet = horizonSet[featureIndex]->getInterpretationSet();
 		for (size_t interpIndex = 0; interpIndex < interpSet.size(); ++interpIndex) {
-			const vector<RESQML2_NS::AbstractRepresentation const *> repSet = interpSet[interpIndex]->getRepresentationSet();
+			const vector<RESQML2_NS::AbstractRepresentation *> repSet = interpSet[interpIndex]->getRepresentationSet();
 			for (size_t repIndex = 0; repIndex < repSet.size(); ++repIndex) {
 				if (repSet[repIndex]->getGsoapType() == SOAP_TYPE_gsoap_resqml2_0_1_resqml2__obj_USCOREPolylineRepresentation) {
-					result.push_back(static_cast<PolylineRepresentation const *>(repSet[repIndex]));
+					result.push_back(static_cast<PolylineRepresentation *>(repSet[repIndex]));
 				}
 			}
 		}
@@ -1636,18 +1636,18 @@ std::vector<PolylineRepresentation const *> DataObjectRepository::getHorizonPoly
 	return result;
 }
 
-std::vector<PolylineSetRepresentation const *> DataObjectRepository::getHorizonPolylineSetRepSet() const
+std::vector<PolylineSetRepresentation *> DataObjectRepository::getHorizonPolylineSetRepSet() const
 {
-	vector<PolylineSetRepresentation const *> result;
+	vector<PolylineSetRepresentation *> result;
 
 	const vector<Horizon*> horizonSet = getHorizonSet();
 	for (size_t featureIndex = 0; featureIndex < horizonSet.size(); ++featureIndex) {
-		const vector<RESQML2_NS::AbstractFeatureInterpretation const *> interpSet = horizonSet[featureIndex]->getInterpretationSet();
+		const vector<RESQML2_NS::AbstractFeatureInterpretation *> interpSet = horizonSet[featureIndex]->getInterpretationSet();
 		for (size_t interpIndex = 0; interpIndex < interpSet.size(); ++interpIndex) {
-			const vector<RESQML2_NS::AbstractRepresentation const *> repSet = interpSet[interpIndex]->getRepresentationSet();
+			const vector<RESQML2_NS::AbstractRepresentation *> repSet = interpSet[interpIndex]->getRepresentationSet();
 			for (size_t repIndex = 0; repIndex < repSet.size(); ++repIndex) {
 				if (repSet[repIndex]->getGsoapType() == SOAP_TYPE_gsoap_resqml2_0_1_resqml2__obj_USCOREPolylineSetRepresentation) {
-					result.push_back(static_cast<PolylineSetRepresentation const *>(repSet[repIndex]));
+					result.push_back(static_cast<PolylineSetRepresentation *>(repSet[repIndex]));
 				}
 			}
 		}
@@ -1656,18 +1656,18 @@ std::vector<PolylineSetRepresentation const *> DataObjectRepository::getHorizonP
 	return result;
 }
 
-vector<TriangulatedSetRepresentation const *> DataObjectRepository::getHorizonTriangulatedSetRepSet() const
+vector<TriangulatedSetRepresentation *> DataObjectRepository::getHorizonTriangulatedSetRepSet() const
 {
-	vector<TriangulatedSetRepresentation const *> result;
+	vector<TriangulatedSetRepresentation *> result;
 
 	const vector<Horizon*> horizonSet = getHorizonSet();
 	for (size_t featureIndex = 0; featureIndex < horizonSet.size(); ++featureIndex) {
-		const vector<RESQML2_NS::AbstractFeatureInterpretation const *> interpSet = horizonSet[featureIndex]->getInterpretationSet();
+		const vector<RESQML2_NS::AbstractFeatureInterpretation *> interpSet = horizonSet[featureIndex]->getInterpretationSet();
 		for (size_t interpIndex = 0; interpIndex < interpSet.size(); ++interpIndex) {
-			const vector<RESQML2_NS::AbstractRepresentation const *> repSet = interpSet[interpIndex]->getRepresentationSet();
+			const vector<RESQML2_NS::AbstractRepresentation *> repSet = interpSet[interpIndex]->getRepresentationSet();
 			for (size_t repIndex = 0; repIndex < repSet.size(); ++repIndex) {
 				if (repSet[repIndex]->getGsoapType() == SOAP_TYPE_gsoap_resqml2_0_1_resqml2__obj_USCORETriangulatedSetRepresentation) {
-					result.push_back(static_cast<TriangulatedSetRepresentation const *>(repSet[repIndex]));
+					result.push_back(static_cast<TriangulatedSetRepresentation *>(repSet[repIndex]));
 				}
 			}
 		}
@@ -1721,19 +1721,19 @@ std::vector<RESQML2_0_1_NS::SeismicLineFeature*> DataObjectRepository::getSeismi
 
 std::vector<RESQML2_0_1_NS::WellboreFeature*> DataObjectRepository::getWellboreSet() const { return getDataObjects<RESQML2_0_1_NS::WellboreFeature>(); }
 
-vector<WellboreTrajectoryRepresentation const *> DataObjectRepository::getWellboreTrajectoryRepresentationSet() const
+vector<WellboreTrajectoryRepresentation *> DataObjectRepository::getWellboreTrajectoryRepresentationSet() const
 {
-	vector<WellboreTrajectoryRepresentation const *> result;
+	vector<WellboreTrajectoryRepresentation *> result;
 
 	const std::vector<RESQML2_0_1_NS::WellboreFeature*> wellboreSet = getWellboreSet();
 
 	for (size_t featureIndex = 0; featureIndex < wellboreSet.size(); ++featureIndex) {
-		const std::vector<RESQML2_NS::AbstractFeatureInterpretation const *> interpSet = wellboreSet[featureIndex]->getInterpretationSet();
+		const std::vector<RESQML2_NS::AbstractFeatureInterpretation *> interpSet = wellboreSet[featureIndex]->getInterpretationSet();
 		for (size_t interpIndex = 0; interpIndex < interpSet.size(); ++interpIndex) {
-			const std::vector<RESQML2_NS::AbstractRepresentation const *> repSet = interpSet[interpIndex]->getRepresentationSet();
+			const std::vector<RESQML2_NS::AbstractRepresentation *> repSet = interpSet[interpIndex]->getRepresentationSet();
 			for (size_t repIndex = 0; repIndex < repSet.size(); ++repIndex) {
 				if (repSet[repIndex]->getGsoapType() == SOAP_TYPE_gsoap_resqml2_0_1_resqml2__obj_USCOREWellboreTrajectoryRepresentation) {
-					result.push_back(static_cast<WellboreTrajectoryRepresentation const *>(repSet[repIndex]));
+					result.push_back(static_cast<WellboreTrajectoryRepresentation *>(repSet[repIndex]));
 				}
 			}
 		}
@@ -1742,19 +1742,19 @@ vector<WellboreTrajectoryRepresentation const *> DataObjectRepository::getWellbo
 	return result;
 }
 
-vector<DeviationSurveyRepresentation const *> DataObjectRepository::getDeviationSurveyRepresentationSet() const
+vector<DeviationSurveyRepresentation *> DataObjectRepository::getDeviationSurveyRepresentationSet() const
 {
-	vector<DeviationSurveyRepresentation const *> result;
+	vector<DeviationSurveyRepresentation *> result;
 
 	const std::vector<RESQML2_0_1_NS::WellboreFeature*> wellboreSet = getWellboreSet();
 
 	for (size_t featureIndex = 0; featureIndex < wellboreSet.size(); ++featureIndex) {
-		const std::vector<RESQML2_NS::AbstractFeatureInterpretation const *> interpSet = wellboreSet[featureIndex]->getInterpretationSet();
+		const std::vector<RESQML2_NS::AbstractFeatureInterpretation *> interpSet = wellboreSet[featureIndex]->getInterpretationSet();
 		for (size_t interpIndex = 0; interpIndex < interpSet.size(); ++interpIndex) {
-			const std::vector<RESQML2_NS::AbstractRepresentation const *> repSet = interpSet[interpIndex]->getRepresentationSet();
+			const std::vector<RESQML2_NS::AbstractRepresentation *> repSet = interpSet[interpIndex]->getRepresentationSet();
 			for (size_t repIndex = 0; repIndex < repSet.size(); ++repIndex) {
 				if (repSet[repIndex]->getGsoapType() == SOAP_TYPE_gsoap_resqml2_0_1_resqml2__obj_USCOREDeviationSurveyRepresentation) {
-					result.push_back(static_cast<DeviationSurveyRepresentation const *>(repSet[repIndex]));
+					result.push_back(static_cast<DeviationSurveyRepresentation *>(repSet[repIndex]));
 				}
 			}
 		}

--- a/src/common/DataObjectRepository.h
+++ b/src/common/DataObjectRepository.h
@@ -168,10 +168,10 @@ namespace COMMON_NS
 		std::unordered_map< std::string, std::vector< COMMON_NS::AbstractObject* > > dataObjects;
 
 		// Forward relationships
-		std::unordered_map< COMMON_NS::AbstractObject const *, std::vector< COMMON_NS::AbstractObject const * > > forwardRels;
+		std::unordered_map< COMMON_NS::AbstractObject const *, std::vector< COMMON_NS::AbstractObject * > > forwardRels;
 
 		// Backward relationships. It is redundant with forward relationships but it allows more performance.
-		std::unordered_map< COMMON_NS::AbstractObject const *, std::vector< COMMON_NS::AbstractObject const * > > backwardRels;
+		std::unordered_map< COMMON_NS::AbstractObject const *, std::vector< COMMON_NS::AbstractObject * > > backwardRels;
 
 		soap* gsoapContext;
 
@@ -215,11 +215,11 @@ namespace COMMON_NS
 		std::string getGsoapErrorMessage() const;
 
 		template <class valueType>
-		std::vector<valueType const *> getObjsFilteredOnDatatype(const std::vector< COMMON_NS::AbstractObject const * >& objs) const
+		std::vector<valueType *> getObjsFilteredOnDatatype(const std::vector< COMMON_NS::AbstractObject * >& objs) const
 		{
-			std::vector<valueType const *> result;
+			std::vector<valueType *> result;
 			for (size_t i = 0; i < objs.size(); ++i) {
-				valueType const * castedObj = dynamic_cast<valueType const *>(objs[i]);
+				valueType * castedObj = dynamic_cast<valueType *>(objs[i]);
 				if (castedObj != nullptr) {
 					result.push_back(castedObj);
 				}
@@ -248,16 +248,16 @@ namespace COMMON_NS
 		* Source and target are defined by Energistics data model. Usually, the simplest is to look at Energistics UML diagrams. Another way is to rely on XSD/XML : explicit relationships are contained by the source objects and point to target objects.
 		* @param source	The source object of the relationship
 		*/
-		DLL_IMPORT_OR_EXPORT void addRelationship(COMMON_NS::AbstractObject const * source, COMMON_NS::AbstractObject const * target);
+		DLL_IMPORT_OR_EXPORT void addRelationship(COMMON_NS::AbstractObject * source, COMMON_NS::AbstractObject * target);
 
 		/**
 		* Get the target objects of a particular data objects.
 		* Throw an exception if the target objects have not been defined yet.
 		*/
-		DLL_IMPORT_OR_EXPORT const std::vector< COMMON_NS::AbstractObject const * >& getTargetObjects(COMMON_NS::AbstractObject const * dataObj) const;
+		DLL_IMPORT_OR_EXPORT const std::vector< COMMON_NS::AbstractObject * >& getTargetObjects(COMMON_NS::AbstractObject const * dataObj) const;
 
 		template <class valueType>
-		std::vector<valueType const *> getTargetObjects(COMMON_NS::AbstractObject const * dataObj) const
+		std::vector<valueType *> getTargetObjects(COMMON_NS::AbstractObject const * dataObj) const
 		{
 			return getObjsFilteredOnDatatype<valueType>(getTargetObjects(dataObj));
 		}
@@ -266,10 +266,10 @@ namespace COMMON_NS
 		* Get the source objects of a particular data objects.
 		* Throw an exception if the source objects have not been defined yet.
 		*/
-		DLL_IMPORT_OR_EXPORT const std::vector< COMMON_NS::AbstractObject const * >& getSourceObjects(COMMON_NS::AbstractObject const * dataObj) const;
+		DLL_IMPORT_OR_EXPORT const std::vector< COMMON_NS::AbstractObject * >& getSourceObjects(COMMON_NS::AbstractObject const * dataObj) const;
 
 		template <class valueType>
-		std::vector<valueType const *> getSourceObjects(COMMON_NS::AbstractObject const * dataObj) const
+		std::vector<valueType *> getSourceObjects(COMMON_NS::AbstractObject const * dataObj) const
 		{
 			return getObjsFilteredOnDatatype<valueType>(getSourceObjects(dataObj));
 		}
@@ -406,27 +406,27 @@ namespace COMMON_NS
 		/**
 		* Get all the individual representations of faults which are associated to a polyline topology
 		*/
-		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::PolylineSetRepresentation const *> getFaultPolylineSetRepSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::PolylineSetRepresentation *> getFaultPolylineSetRepSet() const;
 
 		/**
 		* Get all the individual representations of fractures which are associated to a polyline topology
 		*/
-		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::PolylineSetRepresentation const *> getFracturePolylineSetRepSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::PolylineSetRepresentation *> getFracturePolylineSetRepSet() const;
 
 		/**
 		* Get all the individual representations of frontiers which are associated to a polyline set topology
 		*/
-		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::PolylineSetRepresentation const *> getFrontierPolylineSetRepSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::PolylineSetRepresentation *> getFrontierPolylineSetRepSet() const;
 
 		/**
 		* Get all the individual representations of faults which are associated to a triangulation set topology
 		*/
-		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation const *> getFaultTriangulatedSetRepSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation *> getFaultTriangulatedSetRepSet() const;
 
 		/**
 		* Get all the individual representations of fractures which are associated to a triangulation set topology
 		*/
-		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation const *> getFractureTriangulatedSetRepSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation *> getFractureTriangulatedSetRepSet() const;
 
 		/**
 		* Get all the horizons contained into the EPC document
@@ -449,22 +449,22 @@ namespace COMMON_NS
 		/**
 		* Get all the individual representations of horizons which are associated to grid 2d set topology
 		*/
-		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::Grid2dRepresentation const *> getHorizonGrid2dRepSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::Grid2dRepresentation *> getHorizonGrid2dRepSet() const;
 
 		/**
 		* Get all the single polyline representations of all the horizons
 		*/
-		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::PolylineRepresentation const *> getHorizonPolylineRepSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::PolylineRepresentation *> getHorizonPolylineRepSet() const;
 
 		/**
 		* Get all the single polyline representations of all the horizons
 		*/
-		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::PolylineSetRepresentation const *> getHorizonPolylineSetRepSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::PolylineSetRepresentation *> getHorizonPolylineSetRepSet() const;
 
 		/**
 		* Get all the triangulated set representations of all the horizons
 		*/
-		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation const *> getHorizonTriangulatedSetRepSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::TriangulatedSetRepresentation *> getHorizonTriangulatedSetRepSet() const;
 
 		/**
 		* DEPRECATED : use getDataObjects template method
@@ -504,12 +504,12 @@ namespace COMMON_NS
 		/**
 		* Get all the trajectory representations of all wellbores.
 		*/
-		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::WellboreTrajectoryRepresentation const *> getWellboreTrajectoryRepresentationSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::WellboreTrajectoryRepresentation *> getWellboreTrajectoryRepresentationSet() const;
 
 		/**
 		* Get all the devaition survey of all wellbores.
 		*/
-		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::DeviationSurveyRepresentation const *> getDeviationSurveyRepresentationSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::DeviationSurveyRepresentation *> getDeviationSurveyRepresentationSet() const;
 
 		/**
 		* DEPRECATED : use getDataObjects template method
@@ -1036,17 +1036,17 @@ namespace COMMON_NS
 		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::Grid2dRepresentation* createGrid2dRepresentation(RESQML2_NS::AbstractFeatureInterpretation* interp,
 			const std::string & guid, const std::string & title);
 
-		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::WellboreTrajectoryRepresentation* createWellboreTrajectoryRepresentation(RESQML2_0_1_NS::WellboreInterpretation const * interp, const std::string & guid, const std::string & title, RESQML2_NS::MdDatum const * mdInfo);
-		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::WellboreTrajectoryRepresentation* createWellboreTrajectoryRepresentation(RESQML2_0_1_NS::WellboreInterpretation const * interp, const std::string & guid, const std::string & title, RESQML2_0_1_NS::DeviationSurveyRepresentation const * deviationSurvey);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::WellboreTrajectoryRepresentation* createWellboreTrajectoryRepresentation(RESQML2_0_1_NS::WellboreInterpretation * interp, const std::string & guid, const std::string & title, RESQML2_NS::MdDatum * mdInfo);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::WellboreTrajectoryRepresentation* createWellboreTrajectoryRepresentation(RESQML2_0_1_NS::WellboreInterpretation * interp, const std::string & guid, const std::string & title, RESQML2_0_1_NS::DeviationSurveyRepresentation * deviationSurvey);
 
-		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::DeviationSurveyRepresentation* createDeviationSurveyRepresentation(RESQML2_0_1_NS::WellboreInterpretation const * interp, const std::string & guid, const std::string & title, const bool & isFinal, RESQML2_NS::MdDatum const * mdInfo);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::DeviationSurveyRepresentation* createDeviationSurveyRepresentation(RESQML2_0_1_NS::WellboreInterpretation * interp, const std::string & guid, const std::string & title, const bool & isFinal, RESQML2_NS::MdDatum * mdInfo);
 
-		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::WellboreFrameRepresentation* createWellboreFrameRepresentation(RESQML2_0_1_NS::WellboreInterpretation const * interp, const std::string & guid, const std::string & title, RESQML2_0_1_NS::WellboreTrajectoryRepresentation const * traj);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::WellboreFrameRepresentation* createWellboreFrameRepresentation(RESQML2_0_1_NS::WellboreInterpretation * interp, const std::string & guid, const std::string & title, RESQML2_0_1_NS::WellboreTrajectoryRepresentation * traj);
 
-		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::WellboreMarkerFrameRepresentation* createWellboreMarkerFrameRepresentation(RESQML2_0_1_NS::WellboreInterpretation const * interp, const std::string & guid, const std::string & title, RESQML2_0_1_NS::WellboreTrajectoryRepresentation const * traj);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::WellboreMarkerFrameRepresentation* createWellboreMarkerFrameRepresentation(RESQML2_0_1_NS::WellboreInterpretation * interp, const std::string & guid, const std::string & title, RESQML2_0_1_NS::WellboreTrajectoryRepresentation * traj);
 
-		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::BlockedWellboreRepresentation* createBlockedWellboreRepresentation(RESQML2_0_1_NS::WellboreInterpretation const * interp,
-			const std::string & guid, const std::string & title, RESQML2_0_1_NS::WellboreTrajectoryRepresentation const * traj);
+		DLL_IMPORT_OR_EXPORT RESQML2_0_1_NS::BlockedWellboreRepresentation* createBlockedWellboreRepresentation(RESQML2_0_1_NS::WellboreInterpretation * interp,
+			const std::string & guid, const std::string & title, RESQML2_0_1_NS::WellboreTrajectoryRepresentation * traj);
 
 		DLL_IMPORT_OR_EXPORT RESQML2_NS::RepresentationSetRepresentation* createRepresentationSetRepresentation(
 			RESQML2_0_1_NS::AbstractOrganizationInterpretation* interp,

--- a/src/common/EpcDocument.cpp
+++ b/src/common/EpcDocument.cpp
@@ -98,14 +98,14 @@ namespace {
 	std::vector<epc::Relationship> getAllEpcRelationships(const DataObjectRepository & repo, COMMON_NS::AbstractObject const * dataObj) {
 		std::vector<epc::Relationship> result;
 
-		const std::vector<COMMON_NS::AbstractObject const *>& srcObj = repo.getSourceObjects(dataObj);
+		const std::vector<COMMON_NS::AbstractObject *>& srcObj = repo.getSourceObjects(dataObj);
 		for (size_t index = 0; index < srcObj.size(); ++index) {
 			epc::Relationship relRep(srcObj[index]->getPartNameInEpcDocument(), "", srcObj[index]->getUuid());
 			relRep.setSourceObjectType();
 			result.push_back(relRep);
 		}
 
-		const std::vector<COMMON_NS::AbstractObject const *>& targetObj = repo.getTargetObjects(dataObj);
+		const std::vector<COMMON_NS::AbstractObject *>& targetObj = repo.getTargetObjects(dataObj);
 		for (size_t index = 0; index < targetObj.size(); ++index) {
 			epc::Relationship relRep(targetObj[index]->getPartNameInEpcDocument(), "", targetObj[index]->getUuid());
 			relRep.setDestinationObjectType();
@@ -173,8 +173,8 @@ string EpcDocument::deserializeInto(DataObjectRepository & repo, DataObjectRepos
 				result += "The content type " + contentType + " should belong to eml and not to resqml since obj_EpcExternalPartReference is part of COMMON and not part of RESQML.\n";
 				contentType = "application/x-eml+xml;version=2.0;type=obj_EpcExternalPartReference";
 			}
-			COMMON_NS::AbstractObject* wrapper = repo.addOrReplaceGsoapProxy(package->extractFile(it->second.getExtensionOrPartName().substr(1)), it->second.getContentTypeString());
-			if (it->second.getContentTypeString() == "application/x-eml+xml;version=2.0;type=obj_EpcExternalPartReference") {
+			COMMON_NS::AbstractObject* wrapper = repo.addOrReplaceGsoapProxy(package->extractFile(it->second.getExtensionOrPartName().substr(1)), contentType);
+			if (contentType == "application/x-eml+xml;version=2.0;type=obj_EpcExternalPartReference") {
 				static_cast<RESQML2_0_1_NS::HdfProxy*>(wrapper)->setRootPath(getStorageDirectory());
 				static_cast<RESQML2_0_1_NS::HdfProxy*>(wrapper)->setOpeningMode(hdfPermissionAccess);
 

--- a/src/common/EpcExternalPartReference.cpp
+++ b/src/common/EpcExternalPartReference.cpp
@@ -36,5 +36,5 @@ string EpcExternalPartReference::getXmlTag() const
 	return XML_TAG;
 }
 
-void EpcExternalPartReference::loadTargetRelationships() const
+void EpcExternalPartReference::loadTargetRelationships()
 {}

--- a/src/common/EpcExternalPartReference.h
+++ b/src/common/EpcExternalPartReference.h
@@ -52,6 +52,6 @@ namespace COMMON_NS
 		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const;
 
 	protected:
-		void loadTargetRelationships() const;
+		void loadTargetRelationships();
 	};
 }

--- a/src/common/GraphicalInformationSet.cpp
+++ b/src/common/GraphicalInformationSet.cpp
@@ -267,7 +267,7 @@ std::string GraphicalInformationSet::getDefaultColorTitle(AbstractObject const* 
 	return *color->Title;
 }
 
-void GraphicalInformationSet::setDefaultHsvColor(AbstractObject const* targetObject, double hue, double saturation, double value, double alpha, string const& colorTitle)
+void GraphicalInformationSet::setDefaultHsvColor(AbstractObject * targetObject, double hue, double saturation, double value, double alpha, string const& colorTitle)
 {
 	if (targetObject == nullptr) {
 		throw invalid_argument("The target object cannot be null");
@@ -289,10 +289,10 @@ void GraphicalInformationSet::setDefaultHsvColor(AbstractObject const* targetObj
 		throw invalid_argument("alpha must be in range [0, 1]");
 	}
 
-	if ((dynamic_cast<AbstractFeature const*>(targetObject) == nullptr) &&
-		(dynamic_cast<AbstractFeatureInterpretation const*>(targetObject) == nullptr) &&
-		(dynamic_cast<AbstractRepresentation const*>(targetObject) == nullptr) &&
-		(dynamic_cast<WellboreMarker const*>(targetObject) == nullptr)) {
+	if ((dynamic_cast<AbstractFeature *>(targetObject) == nullptr) &&
+		(dynamic_cast<AbstractFeatureInterpretation *>(targetObject) == nullptr) &&
+		(dynamic_cast<AbstractRepresentation *>(targetObject) == nullptr) &&
+		(dynamic_cast<WellboreMarker *>(targetObject) == nullptr)) {
 		throw invalid_argument("The object must be a feature, interpretation, representation or wellbore marker.");
 	}
 
@@ -350,7 +350,7 @@ void GraphicalInformationSet::setDefaultHsvColor(AbstractObject const* targetObj
 * @param alpha			numeric value in the range [0, 1] for alpha transparency channel (0 means transparent and 1 means opaque). Default value is 1.
 * @param colorTitle		title for the given HSV color
 */
-void GraphicalInformationSet::setDefaultRgbColor(AbstractObject const* targetObject, double red, double green, double blue, double alpha, std::string const& colorTitle)
+void GraphicalInformationSet::setDefaultRgbColor(AbstractObject* targetObject, double red, double green, double blue, double alpha, std::string const& colorTitle)
 {
 	if (targetObject == nullptr) {
 		throw invalid_argument("The target object cannot be null");
@@ -382,7 +382,7 @@ void GraphicalInformationSet::setDefaultRgbColor(AbstractObject const* targetObj
 * @param alpha			numeric value in the range [0, 1] for alpha transparency channel (0 means transparent and 1 means opaque). Default value is 1.
 * @param colorTitle		title for the given HSV color
 */
-void GraphicalInformationSet::setDefaultRgbColor(AbstractObject const* targetObject, unsigned int red, unsigned int green, unsigned int blue, double alpha, std::string const& colorTitle)
+void GraphicalInformationSet::setDefaultRgbColor(AbstractObject* targetObject, unsigned int red, unsigned int green, unsigned int blue, double alpha, std::string const& colorTitle)
 {
 	if (targetObject == nullptr) {
 		throw invalid_argument("The target object cannot be null");
@@ -461,7 +461,7 @@ DiscreteColorMap* GraphicalInformationSet::getDiscreteColorMap(AbstractObject co
 	return getRepository()->getDataObjectByUuid<DiscreteColorMap>(getDiscreteColorMapUuid(targetObject));
 }
 
-void GraphicalInformationSet::setDiscreteColorMap(AbstractObject const* targetObject, DiscreteColorMap* discreteColorMap, 
+void GraphicalInformationSet::setDiscreteColorMap(AbstractObject* targetObject, DiscreteColorMap* discreteColorMap, 
 	LONG64 valueVectorIndex, bool useReverseMapping, bool useLogarithmicMapping)
 {
 	if (targetObject == nullptr) {
@@ -472,8 +472,8 @@ void GraphicalInformationSet::setDiscreteColorMap(AbstractObject const* targetOb
 		throw invalid_argument("The discrete color map cannot be null");
 	}
 
-	if ((dynamic_cast<AbstractValuesProperty const*>(targetObject) == nullptr) &&
-		(dynamic_cast<PropertyKind const*>(targetObject) == nullptr)) {
+	if ((dynamic_cast<AbstractValuesProperty*>(targetObject) == nullptr) &&
+		(dynamic_cast<PropertyKind*>(targetObject) == nullptr)) {
 		throw invalid_argument("The object must be a property or property kind.");
 	}
 
@@ -559,7 +559,7 @@ ContinuousColorMap* GraphicalInformationSet::getContinuousColorMap(AbstractObjec
 	return getRepository()->getDataObjectByUuid<ContinuousColorMap>(getContinuousColorMapUuid(targetObject));
 }
 
-void GraphicalInformationSet::setContinuousColorMap(AbstractObject const* targetObject, ContinuousColorMap* continuousColorMap, 
+void GraphicalInformationSet::setContinuousColorMap(AbstractObject* targetObject, ContinuousColorMap* continuousColorMap, 
 	LONG64 valueVectorIndex, bool useReverseMapping, bool useLogarithmicMapping)
 {
 	if (targetObject == nullptr) {
@@ -730,7 +730,7 @@ void GraphicalInformationSet::hsvToRgb(double hue, double saturation, double val
 	blue = floor(b == 1.0 ? 255 : b * 256.0);
 }
 
-void GraphicalInformationSet::loadTargetRelationships() const
+void GraphicalInformationSet::loadTargetRelationships()
 {
 	_eml22__GraphicalInformationSet const* gis = static_cast<_eml22__GraphicalInformationSet*>(gsoapProxy2_2);
 

--- a/src/common/GraphicalInformationSet.h
+++ b/src/common/GraphicalInformationSet.h
@@ -154,7 +154,7 @@ namespace COMMON_NS
 		* @param alpha			numeric value in the range [0, 1] for alpha transparency channel (0 means transparent and 1 means opaque). Default value is 1.
 		* @param colorTitle		title for the given color. It is not set if title is empty
 		*/
-		DLL_IMPORT_OR_EXPORT void setDefaultHsvColor(AbstractObject const* targetObject, double hue, double saturation, double value, double alpha = 1.0, std::string const& colorTitle = "");
+		DLL_IMPORT_OR_EXPORT void setDefaultHsvColor(AbstractObject* targetObject, double hue, double saturation, double value, double alpha = 1.0, std::string const& colorTitle = "");
 
 		/**
 		* https://en.wikipedia.org/wiki/RGB_color_space
@@ -165,7 +165,7 @@ namespace COMMON_NS
 		* @param alpha			numeric value in the range [0, 1] for alpha transparency channel (0 means transparent and 1 means opaque). Default value is 1.
 		* @param colorTitle		title for the given color. It is not set if title is empty
 		*/
-		DLL_IMPORT_OR_EXPORT void setDefaultRgbColor(AbstractObject const* targetObject, double red, double green, double blue, double alpha = 1.0, std::string const& colorTitle = "");
+		DLL_IMPORT_OR_EXPORT void setDefaultRgbColor(AbstractObject* targetObject, double red, double green, double blue, double alpha = 1.0, std::string const& colorTitle = "");
 
 		/**
 		* https://en.wikipedia.org/wiki/RGB_color_space
@@ -176,7 +176,7 @@ namespace COMMON_NS
 		* @param alpha			numeric value in the range [0, 1] for alpha transparency channel (0 means transparent and 1 means opaque). Default value is 1.
 		* @param colorTitle		title for the given color. It is not set if title is empty
 		*/
-		DLL_IMPORT_OR_EXPORT void setDefaultRgbColor(AbstractObject const* targetObject, unsigned int red, unsigned int green, unsigned int blue, double alpha = 1.0, std::string const& colorTitle = "");
+		DLL_IMPORT_OR_EXPORT void setDefaultRgbColor(AbstractObject* targetObject, unsigned int red, unsigned int green, unsigned int blue, double alpha = 1.0, std::string const& colorTitle = "");
 
 		/**
 		 * @param targetObject	the object for wich we look for a discrete color map. If it has not and it is a property,
@@ -206,7 +206,7 @@ namespace COMMON_NS
 		 */
 		DLL_IMPORT_OR_EXPORT RESQML2_2_NS::DiscreteColorMap* getDiscreteColorMap(AbstractObject const* targetObject) const;
 
-		DLL_IMPORT_OR_EXPORT void setDiscreteColorMap(AbstractObject const* targetObject, RESQML2_2_NS::DiscreteColorMap* discreteColorMap,
+		DLL_IMPORT_OR_EXPORT void setDiscreteColorMap(AbstractObject* targetObject, RESQML2_2_NS::DiscreteColorMap* discreteColorMap,
 			LONG64 valueVectorIndex = 0, bool useReverseMapping = false, bool useLogarithmicMapping = false);
 
 		/**
@@ -237,7 +237,7 @@ namespace COMMON_NS
 		 */
 		DLL_IMPORT_OR_EXPORT RESQML2_2_NS::ContinuousColorMap* getContinuousColorMap(AbstractObject const* targetObject) const;
 
-		DLL_IMPORT_OR_EXPORT void setContinuousColorMap(AbstractObject const* targetObject, RESQML2_2_NS::ContinuousColorMap* continuousColorMap,
+		DLL_IMPORT_OR_EXPORT void setContinuousColorMap(AbstractObject* targetObject, RESQML2_2_NS::ContinuousColorMap* continuousColorMap,
 			LONG64 valueVectorIndex = 0, bool useReverseMapping = false, bool useLogarithmicMapping = false);
 
 		DLL_IMPORT_OR_EXPORT double getColorMapMinIndex(AbstractObject const* targetObject) const;
@@ -296,6 +296,6 @@ namespace COMMON_NS
 			return "eml22";
 		}
 
-		void loadTargetRelationships() const;
+		void loadTargetRelationships();
 	};
 }

--- a/src/resqml2/AbstractColumnLayerGridRepresentation.cpp
+++ b/src/resqml2/AbstractColumnLayerGridRepresentation.cpp
@@ -164,7 +164,7 @@ ULONG64 AbstractColumnLayerGridRepresentation::getIntervalStratigraphicUnitIndic
 	}
 }
 
-void AbstractColumnLayerGridRepresentation::loadTargetRelationships() const
+void AbstractColumnLayerGridRepresentation::loadTargetRelationships()
 {
 	AbstractGridRepresentation::loadTargetRelationships();
 

--- a/src/resqml2/AbstractColumnLayerGridRepresentation.h
+++ b/src/resqml2/AbstractColumnLayerGridRepresentation.h
@@ -47,7 +47,7 @@ namespace RESQML2_NS
 		AbstractColumnLayerGridRepresentation(gsoap_resqml2_0_1::resqml2__AbstractColumnLayerGridRepresentation* fromGsoap, bool withTruncatedPillars) : RESQML2_NS::AbstractGridRepresentation(fromGsoap, withTruncatedPillars) {}
 		AbstractColumnLayerGridRepresentation(gsoap_resqml2_0_1::resqml2__AbstractTruncatedColumnLayerGridRepresentation* fromGsoap, bool withTruncatedPillars) : RESQML2_NS::AbstractGridRepresentation(fromGsoap, withTruncatedPillars) {}
 
-		void loadTargetRelationships() const;
+		void loadTargetRelationships();
 
 	public:
 

--- a/src/resqml2/AbstractFeature.cpp
+++ b/src/resqml2/AbstractFeature.cpp
@@ -41,9 +41,9 @@ namespace {
 	};
 }
 
-std::vector<AbstractFeatureInterpretation const *> AbstractFeature::getInterpretationSet() const
+std::vector<AbstractFeatureInterpretation *> AbstractFeature::getInterpretationSet() const
 {
-	std::vector<AbstractFeatureInterpretation const *> result = getRepository()->getSourceObjects<AbstractFeatureInterpretation>(this);
+	std::vector<AbstractFeatureInterpretation *> result = getRepository()->getSourceObjects<AbstractFeatureInterpretation>(this);
 	result.erase(std::remove_if(result.begin(), result.end(), DifferentFeature(this)), result.end());
 
 	return result;
@@ -51,7 +51,7 @@ std::vector<AbstractFeatureInterpretation const *> AbstractFeature::getInterpret
 
 unsigned int AbstractFeature::getInterpretationCount() const
 {
-	const std::vector<AbstractFeatureInterpretation const*>& interpretationSet = getInterpretationSet();
+	const std::vector<AbstractFeatureInterpretation*>& interpretationSet = getInterpretationSet();
 
 	if (interpretationSet.size() > (std::numeric_limits<unsigned int>::max)()) {
 		throw range_error("There are too many interpretations for this feature.");
@@ -60,9 +60,9 @@ unsigned int AbstractFeature::getInterpretationCount() const
 	return static_cast<unsigned int>(interpretationSet.size());
 }
 
-AbstractFeatureInterpretation const *	AbstractFeature::getInterpretation(unsigned int index) const
+AbstractFeatureInterpretation *	AbstractFeature::getInterpretation(unsigned int index) const
 {
-	const std::vector<AbstractFeatureInterpretation const*>& interpretationSet = getInterpretationSet();
+	const std::vector<AbstractFeatureInterpretation*>& interpretationSet = getInterpretationSet();
 
 	if (interpretationSet.size() > index) {
 		return interpretationSet[index];
@@ -71,5 +71,5 @@ AbstractFeatureInterpretation const *	AbstractFeature::getInterpretation(unsigne
 	throw range_error("The interpretation index is out of the range of the interpretation set of the feature.");
 }
 
-void AbstractFeature::loadTargetRelationships() const
+void AbstractFeature::loadTargetRelationships()
 {}

--- a/src/resqml2/AbstractFeature.h
+++ b/src/resqml2/AbstractFeature.h
@@ -53,7 +53,7 @@ namespace RESQML2_NS
 		/**
 		* Get all the interpretations of this feature
 		*/
-		DLL_IMPORT_OR_EXPORT std::vector<AbstractFeatureInterpretation const *> getInterpretationSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<AbstractFeatureInterpretation *> getInterpretationSet() const;
 
 		/**
 		 * Get the interpretation count of this feature.
@@ -63,10 +63,10 @@ namespace RESQML2_NS
 		/**
 		 * Get a particular interpretation of this feature according to its position in the interpretation ordering.
 		 */
-		DLL_IMPORT_OR_EXPORT AbstractFeatureInterpretation const*	getInterpretation(unsigned int index) const;
+		DLL_IMPORT_OR_EXPORT AbstractFeatureInterpretation *	getInterpretation(unsigned int index) const;
 
 	protected:
 
-		virtual void loadTargetRelationships() const;
+		virtual void loadTargetRelationships();
 	};
 }

--- a/src/resqml2/AbstractFeatureInterpretation.cpp
+++ b/src/resqml2/AbstractFeatureInterpretation.cpp
@@ -50,7 +50,7 @@ void AbstractFeatureInterpretation::setInterpretedFeature(AbstractFeature * feat
 	}
 }
 
-void AbstractFeatureInterpretation::loadTargetRelationships() const
+void AbstractFeatureInterpretation::loadTargetRelationships()
 {
 	gsoap_resqml2_0_1::eml20__DataObjectReference const * dor = getInterpretedFeatureDor();
 	AbstractFeature* interpretedFeature = getRepository()->getDataObjectByUuid<AbstractFeature>(dor->UUID);
@@ -84,7 +84,7 @@ AbstractFeature* AbstractFeatureInterpretation::getInterpretedFeature() const
 	return static_cast<AbstractFeature*>(repository->getDataObjectByUuid(getInterpretedFeatureUuid()));
 }
 
-const gsoap_resqml2_0_1::resqml2__Domain & AbstractFeatureInterpretation::initDomain(const gsoap_resqml2_0_1::resqml2__Domain & defaultDomain) const
+const gsoap_resqml2_0_1::resqml2__Domain & AbstractFeatureInterpretation::initDomain(gsoap_resqml2_0_1::resqml2__Domain defaultDomain) const
 {
 	if (gsoapProxy2_0_1 != nullptr) {
 		const unsigned int repCount = getRepresentationCount();
@@ -150,9 +150,9 @@ namespace {
 	};
 }
 
-vector<AbstractRepresentation const *> AbstractFeatureInterpretation::getRepresentationSet() const
+vector<AbstractRepresentation *> AbstractFeatureInterpretation::getRepresentationSet() const
 {
-	std::vector<AbstractRepresentation const *> result = repository->getSourceObjects<AbstractRepresentation>(this);
+	std::vector<AbstractRepresentation *> result = repository->getSourceObjects<AbstractRepresentation>(this);
 	result.erase(std::remove_if(result.begin(), result.end(), DifferentInterp(this)), result.end());
 
 	return result;
@@ -169,9 +169,9 @@ unsigned int AbstractFeatureInterpretation::getRepresentationCount() const
 	return static_cast<unsigned int>(result);
 }
 
-AbstractRepresentation const * AbstractFeatureInterpretation::getRepresentation(unsigned int index) const
+AbstractRepresentation * AbstractFeatureInterpretation::getRepresentation(unsigned int index) const
 {
-	const std::vector<AbstractRepresentation const*>& representationSet = getRepresentationSet();
+	const std::vector<AbstractRepresentation*>& representationSet = getRepresentationSet();
 
 	if (representationSet.size() > index)
 		return representationSet[index];
@@ -179,7 +179,7 @@ AbstractRepresentation const * AbstractFeatureInterpretation::getRepresentation(
 	throw range_error("The representation index you are requesting is out of range.");
 }
 
-std::vector<GridConnectionSetRepresentation const *> AbstractFeatureInterpretation::getGridConnectionSetRepresentationSet() const
+std::vector<GridConnectionSetRepresentation *> AbstractFeatureInterpretation::getGridConnectionSetRepresentationSet() const
 {
 	return getRepository()->getSourceObjects<GridConnectionSetRepresentation>(this);
 }

--- a/src/resqml2/AbstractFeatureInterpretation.h
+++ b/src/resqml2/AbstractFeatureInterpretation.h
@@ -75,7 +75,7 @@ namespace RESQML2_NS
 		* Init the domain of the interpretation based on its representations
 		* @param	defaultDomain	The default domain to set when there is no representation set to this interpretation
 		*/
-		DLL_IMPORT_OR_EXPORT const gsoap_resqml2_0_1::resqml2__Domain & initDomain(const gsoap_resqml2_0_1::resqml2__Domain & defaultDomain) const;
+		DLL_IMPORT_OR_EXPORT const gsoap_resqml2_0_1::resqml2__Domain & initDomain(gsoap_resqml2_0_1::resqml2__Domain defaultDomain) const;
 
 		/**
 		* Set the domain of the interpretation
@@ -85,7 +85,7 @@ namespace RESQML2_NS
 		/**
 		* Get all the representations of this interpretation
 		*/
-		DLL_IMPORT_OR_EXPORT std::vector<AbstractRepresentation const *> getRepresentationSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<AbstractRepresentation *> getRepresentationSet() const;
 
 		/**
 		 * Get the interpretation count of this feature.
@@ -95,15 +95,15 @@ namespace RESQML2_NS
 		/**
 		* Get all the Grid Connection Set Representation which reference this interpretation.
 		*/
-		DLL_IMPORT_OR_EXPORT std::vector<GridConnectionSetRepresentation const *> getGridConnectionSetRepresentationSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<GridConnectionSetRepresentation *> getGridConnectionSetRepresentationSet() const;
 
 		/**
 		 * Get a particular interpretation of this feature according to its position in the interpretation ordering.
 		 */
-		DLL_IMPORT_OR_EXPORT AbstractRepresentation const * getRepresentation(unsigned int index) const;
+		DLL_IMPORT_OR_EXPORT AbstractRepresentation * getRepresentation(unsigned int index) const;
 
 	protected:
 		
-		virtual void loadTargetRelationships() const;
+		virtual void loadTargetRelationships();
 	};
 }

--- a/src/resqml2/AbstractGridRepresentation.cpp
+++ b/src/resqml2/AbstractGridRepresentation.cpp
@@ -35,7 +35,7 @@ using namespace std;
 
 const char* AbstractGridRepresentation::XML_TAG = "AbstractGridRepresentation";
 
-std::vector<RESQML2_NS::GridConnectionSetRepresentation const *> AbstractGridRepresentation::getGridConnectionSetRepresentationSet() const
+std::vector<RESQML2_NS::GridConnectionSetRepresentation *> AbstractGridRepresentation::getGridConnectionSetRepresentationSet() const
 {
 	return repository->getSourceObjects<RESQML2_NS::GridConnectionSetRepresentation>(this);
 }
@@ -51,9 +51,9 @@ unsigned int AbstractGridRepresentation::getGridConnectionSetRepresentationCount
 	return static_cast<unsigned int>(result);
 }
 
-RESQML2_NS::GridConnectionSetRepresentation const * AbstractGridRepresentation::getGridConnectionSetRepresentation(unsigned int index) const
+RESQML2_NS::GridConnectionSetRepresentation * AbstractGridRepresentation::getGridConnectionSetRepresentation(unsigned int index) const
 {
-	const std::vector<RESQML2_NS::GridConnectionSetRepresentation const *>& gridConnectionSetRepresentationSet = getGridConnectionSetRepresentationSet();
+	const std::vector<RESQML2_NS::GridConnectionSetRepresentation *>& gridConnectionSetRepresentationSet = getGridConnectionSetRepresentationSet();
 
 	if (gridConnectionSetRepresentationSet.size() > index) {
 		return gridConnectionSetRepresentationSet[index];
@@ -118,7 +118,7 @@ AbstractGridRepresentation* AbstractGridRepresentation::getParentGrid() const
 	return nullptr;
 }
 
-std::vector<RESQML2_NS::AbstractGridRepresentation const *> AbstractGridRepresentation::getChildGridSet() const
+std::vector<RESQML2_NS::AbstractGridRepresentation *> AbstractGridRepresentation::getChildGridSet() const
 {
 	return repository->getSourceObjects<RESQML2_NS::AbstractGridRepresentation>(this);
 }
@@ -133,9 +133,9 @@ unsigned int AbstractGridRepresentation::getChildGridCount() const {
 	return static_cast<unsigned int>(result);
 }
 
-AbstractGridRepresentation const * AbstractGridRepresentation::getChildGrid(unsigned int index) const
+AbstractGridRepresentation * AbstractGridRepresentation::getChildGrid(unsigned int index) const
 {
-	const std::vector<RESQML2_NS::AbstractGridRepresentation const *>& childGridSet = getChildGridSet();
+	const std::vector<RESQML2_NS::AbstractGridRepresentation *>& childGridSet = getChildGridSet();
 
 	if (childGridSet.size() > index) {
 		return childGridSet[index];
@@ -1063,7 +1063,7 @@ void AbstractGridRepresentation::getRegridChildCellWeights(const char & dimensio
 	}
 }
 
-void AbstractGridRepresentation::loadTargetRelationships() const
+void AbstractGridRepresentation::loadTargetRelationships()
 {
 	AbstractRepresentation::loadTargetRelationships();
 

--- a/src/resqml2/AbstractGridRepresentation.h
+++ b/src/resqml2/AbstractGridRepresentation.h
@@ -84,7 +84,7 @@ namespace RESQML2_NS
 		/**
 		* Get the vector of all grid connection set rep associated to this grid instance.
 		*/
-		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_NS::GridConnectionSetRepresentation const *> getGridConnectionSetRepresentationSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_NS::GridConnectionSetRepresentation *> getGridConnectionSetRepresentationSet() const;
 
 		/**
 		 * Get the GridConnectionSetRepresentation count into this EPC document which are associated to this grid.
@@ -96,7 +96,7 @@ namespace RESQML2_NS
 		 * Get a particular ijk parametric grid according to its position in the EPC document.
 		 * It is mainly used in SWIG context for parsing the vector from a non C++ language.
 		 */
-		DLL_IMPORT_OR_EXPORT RESQML2_NS::GridConnectionSetRepresentation const * getGridConnectionSetRepresentation(unsigned int index) const;
+		DLL_IMPORT_OR_EXPORT RESQML2_NS::GridConnectionSetRepresentation * getGridConnectionSetRepresentation(unsigned int index) const;
 
 
 		//************************************************************
@@ -124,7 +124,7 @@ namespace RESQML2_NS
 		/**
 		* Get the vector of all child grids
 		*/
-		std::vector<RESQML2_NS::AbstractGridRepresentation const *> getChildGridSet() const;
+		std::vector<RESQML2_NS::AbstractGridRepresentation *> getChildGridSet() const;
 
 		/**
 		* Return the count of child grid in this grid.
@@ -134,7 +134,7 @@ namespace RESQML2_NS
 		/**
 		* Return the count of child grid in this grid.
 		*/
-		DLL_IMPORT_OR_EXPORT AbstractGridRepresentation const * getChildGrid(unsigned int index) const;
+		DLL_IMPORT_OR_EXPORT AbstractGridRepresentation * getChildGrid(unsigned int index) const;
 
 		/**
 		* Indicates that this grid takes place into another unstructured parent grid.
@@ -524,7 +524,7 @@ namespace RESQML2_NS
 
 	protected:
 
-		void loadTargetRelationships() const;
+		void loadTargetRelationships();
 
 		bool withTruncatedPillars;
 	};

--- a/src/resqml2/AbstractLocal3dCrs.cpp
+++ b/src/resqml2/AbstractLocal3dCrs.cpp
@@ -28,7 +28,7 @@ under the License.
 using namespace std;
 using namespace RESQML2_NS;
 
-void AbstractLocal3dCrs::loadTargetRelationships() const {
+void AbstractLocal3dCrs::loadTargetRelationships() {
 }
 
 void AbstractLocal3dCrs::convertXyzPointsToGlobalCrs(double * xyzPoints, ULONG64 xyzPointCount, bool withoutTranslation) const

--- a/src/resqml2/AbstractLocal3dCrs.h
+++ b/src/resqml2/AbstractLocal3dCrs.h
@@ -156,7 +156,7 @@ namespace RESQML2_NS
 
 	protected:
 		
-		void loadTargetRelationships() const;
+		void loadTargetRelationships();
 	};
 }
 

--- a/src/resqml2/AbstractProperty.cpp
+++ b/src/resqml2/AbstractProperty.cpp
@@ -38,7 +38,7 @@ under the License.
 using namespace RESQML2_NS;
 using namespace std;
 
-void AbstractProperty::loadTargetRelationships() const
+void AbstractProperty::loadTargetRelationships()
 {
 	gsoap_resqml2_0_1::eml20__DataObjectReference const * dor = getRepresentationDor();
 	RESQML2_NS::AbstractRepresentation* rep = getRepository()->getDataObjectByUuid<RESQML2_NS::AbstractRepresentation>(dor->UUID);

--- a/src/resqml2/AbstractProperty.h
+++ b/src/resqml2/AbstractProperty.h
@@ -234,6 +234,6 @@ namespace RESQML2_NS
 
 	protected:
 
-		virtual void loadTargetRelationships() const;
+		virtual void loadTargetRelationships();
 	};
 }

--- a/src/resqml2/AbstractRepresentation.cpp
+++ b/src/resqml2/AbstractRepresentation.cpp
@@ -161,12 +161,12 @@ std::string AbstractRepresentation::getLocalCrsUuid() const
 	return dor == nullptr ? "" : dor->UUID;
 }
 
-std::vector<AbstractProperty const *> AbstractRepresentation::getPropertySet() const
+std::vector<AbstractProperty *> AbstractRepresentation::getPropertySet() const
 {
 	return getRepository()->getSourceObjects<RESQML2_NS::AbstractProperty>(this);
 }
 
-std::vector<AbstractValuesProperty const *> AbstractRepresentation::getValuesPropertySet() const
+std::vector<AbstractValuesProperty *> AbstractRepresentation::getValuesPropertySet() const
 {
 	return getRepository()->getSourceObjects<RESQML2_NS::AbstractValuesProperty>(this);
 }
@@ -176,9 +176,9 @@ unsigned int AbstractRepresentation::getValuesPropertyCount() const
 	return getValuesPropertySet().size();
 }
 
-AbstractValuesProperty const * AbstractRepresentation::getValuesProperty(unsigned int index) const
+AbstractValuesProperty * AbstractRepresentation::getValuesProperty(unsigned int index) const
 {
-	const std::vector<AbstractValuesProperty const *>& propSet = getValuesPropertySet();
+	const std::vector<AbstractValuesProperty *>& propSet = getValuesPropertySet();
 
 	if (propSet.size() > index) {
 		return propSet[index];
@@ -188,7 +188,7 @@ AbstractValuesProperty const * AbstractRepresentation::getValuesProperty(unsigne
 	}
 }
 
-void AbstractRepresentation::setInterpretation(AbstractFeatureInterpretation const * interp)
+void AbstractRepresentation::setInterpretation(AbstractFeatureInterpretation * interp)
 {
 	if (interp == nullptr) {
 		throw invalid_argument("Cannot set a null interpretation to a representation");
@@ -235,7 +235,7 @@ std::string AbstractRepresentation::getInterpretationContentType() const
 	return dor == nullptr ? string() : dor->ContentType;
 }
 
-std::vector<SubRepresentation const *> AbstractRepresentation::getSubRepresentationSet() const
+std::vector<SubRepresentation *> AbstractRepresentation::getSubRepresentationSet() const
 {
 	return repository->getSourceObjects<SubRepresentation>(this);
 }
@@ -245,9 +245,9 @@ unsigned int AbstractRepresentation::getSubRepresentationCount() const
 	return getSubRepresentationSet().size();
 }
 
-SubRepresentation const * AbstractRepresentation::getSubRepresentation(unsigned int index) const
+SubRepresentation * AbstractRepresentation::getSubRepresentation(unsigned int index) const
 {
-	const std::vector<SubRepresentation const *>& subRepresentationSet = getSubRepresentationSet();
+	const std::vector<SubRepresentation *>& subRepresentationSet = getSubRepresentationSet();
 
 	if (index >= subRepresentationSet.size()) {
 		throw range_error("The subrepresentation at the specified index is out of range.");
@@ -256,11 +256,11 @@ SubRepresentation const * AbstractRepresentation::getSubRepresentation(unsigned 
 	return subRepresentationSet[index];
 }
 
-std::vector<SubRepresentation const *> AbstractRepresentation::getFaultSubRepresentationSet() const
+std::vector<SubRepresentation *> AbstractRepresentation::getFaultSubRepresentationSet() const
 {
-	std::vector<SubRepresentation const *> result;
+	std::vector<SubRepresentation *> result;
 
-	const std::vector<SubRepresentation const *>& subRepresentationSet = getSubRepresentationSet();
+	const std::vector<SubRepresentation *>& subRepresentationSet = getSubRepresentationSet();
 	for (size_t i = 0; i <subRepresentationSet.size(); ++i) {
 		if (subRepresentationSet[i]->getInterpretation() != nullptr && subRepresentationSet[i]->getInterpretation()->getXmlTag() == "FaultInterpretation") {
 			result.push_back(subRepresentationSet[i]);
@@ -275,9 +275,9 @@ unsigned int AbstractRepresentation::getFaultSubRepresentationCount() const
 	return getFaultSubRepresentationSet().size();
 }
 
-SubRepresentation const * AbstractRepresentation::getFaultSubRepresentation(unsigned int index) const
+SubRepresentation * AbstractRepresentation::getFaultSubRepresentation(unsigned int index) const
 {
-	const std::vector<RESQML2_NS::SubRepresentation const *>& tmp = getFaultSubRepresentationSet();
+	const std::vector<RESQML2_NS::SubRepresentation *>& tmp = getFaultSubRepresentationSet();
 
 	if (index >= tmp.size()) {
 		throw range_error("The fault subrepresentation at the specified index is out of range.");
@@ -366,7 +366,7 @@ void AbstractRepresentation::pushBackIntoRepresentationSet(RepresentationSetRepr
 	repSet->pushBack(this);
 }
 
-std::vector<RepresentationSetRepresentation const *> AbstractRepresentation::getRepresentationSetRespresentationSet() const
+std::vector<RepresentationSetRepresentation *> AbstractRepresentation::getRepresentationSetRespresentationSet() const
 {
 	return repository->getTargetObjects<RepresentationSetRepresentation>(this);
 }
@@ -376,9 +376,9 @@ ULONG64 AbstractRepresentation::getRepresentationSetRepresentationCount() const
 	return getRepresentationSetRespresentationSet().size();
 }
 
-RepresentationSetRepresentation const * AbstractRepresentation::getRepresentationSetRepresentation(const ULONG64  & index) const
+RepresentationSetRepresentation * AbstractRepresentation::getRepresentationSetRepresentation(const ULONG64  & index) const
 {
-	const std::vector<RESQML2_NS::RepresentationSetRepresentation const *>& representationSetRepresentationSet = getRepresentationSetRespresentationSet();
+	const std::vector<RESQML2_NS::RepresentationSetRepresentation *>& representationSetRepresentationSet = getRepresentationSetRespresentationSet();
 
 	if (index >= getRepresentationSetRepresentationCount()) {
 		throw range_error("The index of the representation set representation is out of range.");
@@ -387,7 +387,7 @@ RepresentationSetRepresentation const * AbstractRepresentation::getRepresentatio
 	return representationSetRepresentationSet[index];
 }
 
-void AbstractRepresentation::loadTargetRelationships() const
+void AbstractRepresentation::loadTargetRelationships()
 {
 	gsoap_resqml2_0_1::eml20__DataObjectReference const * dor = getInterpretationDor();
 	if (dor != nullptr) {

--- a/src/resqml2/AbstractRepresentation.h
+++ b/src/resqml2/AbstractRepresentation.h
@@ -104,12 +104,12 @@ namespace RESQML2_NS
 		/**
 		* Getter (read only) of all the properties which use this representation as support.
 		*/
-		DLL_IMPORT_OR_EXPORT std::vector<class AbstractProperty  const *> getPropertySet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<class AbstractProperty *> getPropertySet() const;
 
 		/**
 		* Getter of all the properties values which use this representation as support.
 		*/
-		DLL_IMPORT_OR_EXPORT std::vector<class AbstractValuesProperty const *> getValuesPropertySet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<class AbstractValuesProperty *> getValuesPropertySet() const;
 
 		/**
 		* Getter of the count of values properties which use this representation as support.
@@ -122,13 +122,13 @@ namespace RESQML2_NS
 		* Necessary for now in SWIG context because I ma not sure if I can always wrap a vector of polymorphic class yet.
 		* Throw an out of bound exception if the index is superior or equal to the count of values property.
 		*/
-		DLL_IMPORT_OR_EXPORT class AbstractValuesProperty const * getValuesProperty(unsigned int index) const;
+		DLL_IMPORT_OR_EXPORT class AbstractValuesProperty * getValuesProperty(unsigned int index) const;
 
 		/**
 		 * Set the interpretation which is associated to this representation.
 		 * And push back this representation as a representation of the interpreation as well.
 		 */
-		DLL_IMPORT_OR_EXPORT void setInterpretation(class AbstractFeatureInterpretation const * interp);
+		DLL_IMPORT_OR_EXPORT void setInterpretation(class AbstractFeatureInterpretation * interp);
 
 		/**
 		* Get the interpretation of this representation
@@ -153,7 +153,7 @@ namespace RESQML2_NS
 		/**
 		* Get all the subrepresentations of this instance.
 		*/
-		DLL_IMPORT_OR_EXPORT std::vector<SubRepresentation const *> getSubRepresentationSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<SubRepresentation *> getSubRepresentationSet() const;
 
 		/**
 		 * Get the subrepresentation count into this EPC document.
@@ -165,12 +165,12 @@ namespace RESQML2_NS
 		 * Get a particular subrepresentation according to its position in the EPC document.
 		 * It is mainly used in SWIG context for parsing the vector from a non C++ language.
 		 */
-		DLL_IMPORT_OR_EXPORT SubRepresentation const * getSubRepresentation(unsigned int index) const;
+		DLL_IMPORT_OR_EXPORT SubRepresentation * getSubRepresentation(unsigned int index) const;
 
 		/**
 		* Get all the subrepresentations of this instance which represent a fault.
 		*/
-		DLL_IMPORT_OR_EXPORT std::vector<SubRepresentation const *> getFaultSubRepresentationSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<SubRepresentation *> getFaultSubRepresentationSet() const;
 
 		/**
 		 * Get the subrepresentation count into this EPC document which are representations of a fault.
@@ -182,7 +182,7 @@ namespace RESQML2_NS
 		 * Get a particular fault subrepresentation according to its position in the EPC document.
 		 * It is mainly used in SWIG context for parsing the vector from a non C++ language.
 		 */
-		DLL_IMPORT_OR_EXPORT SubRepresentation const * getFaultSubRepresentation(unsigned int index) const;
+		DLL_IMPORT_OR_EXPORT SubRepresentation * getFaultSubRepresentation(unsigned int index) const;
         
 		/**
 		* Get the xyz point count in a given patch.
@@ -245,7 +245,7 @@ namespace RESQML2_NS
 		/**
 		* Get all the subrepresentations of this instance which represent a fault.
 		*/
-		DLL_IMPORT_OR_EXPORT std::vector<RepresentationSetRepresentation const *> getRepresentationSetRespresentationSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<RepresentationSetRepresentation *> getRepresentationSetRespresentationSet() const;
 
 		/**
 		 * Get the count of representation set representations which contain this representation
@@ -255,7 +255,7 @@ namespace RESQML2_NS
 		/**
 		 * Get the parent representation set representations at the specified index of the representation set representation list.
 		 */
-		DLL_IMPORT_OR_EXPORT RepresentationSetRepresentation const * getRepresentationSetRepresentation(const ULONG64  & index) const;
+		DLL_IMPORT_OR_EXPORT RepresentationSetRepresentation * getRepresentationSetRepresentation(const ULONG64  & index) const;
 
 		/**
 		* Push back a patch of seismic 3D coordinates info.
@@ -303,6 +303,6 @@ namespace RESQML2_NS
 
 	protected:
 
-		virtual void loadTargetRelationships() const;
+		virtual void loadTargetRelationships();
 	};
 }

--- a/src/resqml2/AbstractValuesProperty.cpp
+++ b/src/resqml2/AbstractValuesProperty.cpp
@@ -539,7 +539,7 @@ void AbstractValuesProperty::getLongValuesOf3dPatch(
 	);
 }
 
-void AbstractValuesProperty::loadTargetRelationships() const
+void AbstractValuesProperty::loadTargetRelationships()
 {
 	AbstractProperty::loadTargetRelationships();
 

--- a/src/resqml2/AbstractValuesProperty.h
+++ b/src/resqml2/AbstractValuesProperty.h
@@ -43,7 +43,7 @@ namespace RESQML2_NS
 		*/
 		std::string pushBackRefToExistingIntegerDataset(COMMON_NS::AbstractHdfProxy* hdfProxy, const std::string & datasetName = "", LONG64 nullValue = (std::numeric_limits<LONG64>::max)());
 
-		void loadTargetRelationships() const;
+		void loadTargetRelationships();
 
 	public:
 

--- a/src/resqml2/Activity.cpp
+++ b/src/resqml2/Activity.cpp
@@ -50,7 +50,7 @@ ActivityTemplate* Activity::getActivityTemplate() const
 	return getRepository()->getDataObjectByUuid<RESQML2_NS::ActivityTemplate>(getActivityTemplateDor()->UUID);
 }
 
-void Activity::loadTargetRelationships() const
+void Activity::loadTargetRelationships()
 {
 	gsoap_resqml2_0_1::eml20__DataObjectReference const * dor = getActivityTemplateDor();
 	RESQML2_NS::ActivityTemplate* targetObj = getRepository()->getDataObjectByUuid<ActivityTemplate>(dor->UUID);

--- a/src/resqml2/Activity.h
+++ b/src/resqml2/Activity.h
@@ -115,6 +115,6 @@ namespace RESQML2_NS
 		DLL_IMPORT_OR_EXPORT std::string getXmlTag() const {return XML_TAG;}
 
 	protected:
-		void loadTargetRelationships() const;
+		void loadTargetRelationships();
 	};
 }

--- a/src/resqml2/ActivityTemplate.cpp
+++ b/src/resqml2/ActivityTemplate.cpp
@@ -26,10 +26,10 @@ using namespace gsoap_resqml2_0_1;
 
 const char* ActivityTemplate::XML_TAG = "ActivityTemplate";
 
-std::vector<Activity const *> ActivityTemplate::getActivityInstanceSet() const
+std::vector<Activity *> ActivityTemplate::getActivityInstanceSet() const
 {
 	return getRepository()->getSourceObjects<Activity>(this);
 }
 
-void ActivityTemplate::loadTargetRelationships() const
+void ActivityTemplate::loadTargetRelationships()
 {}

--- a/src/resqml2/ActivityTemplate.h
+++ b/src/resqml2/ActivityTemplate.h
@@ -73,12 +73,12 @@ namespace RESQML2_NS
 		DLL_IMPORT_OR_EXPORT virtual LONG64 getParameterMaxOccurences(const unsigned int & index) const = 0;
 		DLL_IMPORT_OR_EXPORT virtual LONG64 getParameterMaxOccurences(const std::string & paramTitle) const = 0;
 
-		DLL_IMPORT_OR_EXPORT std::vector<Activity const *> getActivityInstanceSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<Activity *> getActivityInstanceSet() const;
 
 		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
 		DLL_IMPORT_OR_EXPORT std::string getXmlTag() const {return XML_TAG;}
 
 	private:
-		void loadTargetRelationships() const;
+		void loadTargetRelationships();
 	};
 }

--- a/src/resqml2/GridConnectionSetRepresentation.cpp
+++ b/src/resqml2/GridConnectionSetRepresentation.cpp
@@ -65,7 +65,7 @@ void GridConnectionSetRepresentation::pushBackInterpretation(AbstractFeatureInte
 	pushBackXmlInterpretation(interp);
 }
 
-void GridConnectionSetRepresentation::loadTargetRelationships() const
+void GridConnectionSetRepresentation::loadTargetRelationships()
 {
 	AbstractRepresentation::loadTargetRelationships();
 

--- a/src/resqml2/GridConnectionSetRepresentation.h
+++ b/src/resqml2/GridConnectionSetRepresentation.h
@@ -244,6 +244,6 @@ namespace RESQML2_NS
 		DLL_IMPORT_OR_EXPORT unsigned int getPatchCount() const {return 1;}
 
 	private:
-		void loadTargetRelationships() const;
+		void loadTargetRelationships();
 	};
 }

--- a/src/resqml2/MdDatum.cpp
+++ b/src/resqml2/MdDatum.cpp
@@ -29,7 +29,7 @@ using namespace gsoap_resqml2_0_1;
 
 const char* MdDatum::XML_TAG = "MdDatum";
 
-void MdDatum::loadTargetRelationships() const
+void MdDatum::loadTargetRelationships()
 {
 	gsoap_resqml2_0_1::eml20__DataObjectReference const * dor = getLocalCrsDor();
 	if (dor != nullptr) {

--- a/src/resqml2/MdDatum.h
+++ b/src/resqml2/MdDatum.h
@@ -103,6 +103,6 @@ namespace RESQML2_NS
 	protected:
 		virtual void setXmlLocalCrs(RESQML2_NS::AbstractLocal3dCrs * localCrs) = 0;
 
-		void loadTargetRelationships() const;
+		void loadTargetRelationships();
 	};
 }

--- a/src/resqml2/PropertyKind.cpp
+++ b/src/resqml2/PropertyKind.cpp
@@ -141,7 +141,7 @@ void PropertyKind::setParentPropertyKind(PropertyKind* parentPropertyKind)
 	setXmlParentPropertyKind(parentPropertyKind);
 }
 
-void PropertyKind::loadTargetRelationships() const
+void PropertyKind::loadTargetRelationships()
 {
 	if (isParentAnEnergisticsPropertyKind()) {
 		return;

--- a/src/resqml2/PropertyKind.h
+++ b/src/resqml2/PropertyKind.h
@@ -122,6 +122,6 @@ namespace RESQML2_NS
 	protected:
 		virtual void setXmlParentPropertyKind(PropertyKind* parentPropertyKind) = 0;
 
-		void loadTargetRelationships() const;
+		void loadTargetRelationships();
 	};
 }

--- a/src/resqml2/RepresentationSetRepresentation.cpp
+++ b/src/resqml2/RepresentationSetRepresentation.cpp
@@ -35,7 +35,7 @@ std::string RepresentationSetRepresentation::getXmlTag() const
 	return XML_TAG;
 }
 
-void RepresentationSetRepresentation::loadTargetRelationships() const
+void RepresentationSetRepresentation::loadTargetRelationships()
 {
 	AbstractRepresentation::loadTargetRelationships();
 

--- a/src/resqml2/RepresentationSetRepresentation.h
+++ b/src/resqml2/RepresentationSetRepresentation.h
@@ -91,6 +91,6 @@ namespace RESQML2_NS
 		DLL_IMPORT_OR_EXPORT void pushBack(RESQML2_NS::AbstractRepresentation* rep);
 
     protected:
-		virtual void loadTargetRelationships() const;
+		virtual void loadTargetRelationships();
 	};
 }

--- a/src/resqml2/SubRepresentation.cpp
+++ b/src/resqml2/SubRepresentation.cpp
@@ -33,7 +33,7 @@ using namespace RESQML2_NS;
 
 const char* SubRepresentation::XML_TAG = "SubRepresentation";
 
-void SubRepresentation::loadTargetRelationships() const
+void SubRepresentation::loadTargetRelationships()
 {
 	AbstractRepresentation::loadTargetRelationships();
 

--- a/src/resqml2/SubRepresentation.h
+++ b/src/resqml2/SubRepresentation.h
@@ -191,6 +191,6 @@ namespace RESQML2_NS
 		DLL_IMPORT_OR_EXPORT std::string getSupportingRepresentationContentType() const;
 
 	private:
-		void loadTargetRelationships() const;
+		void loadTargetRelationships();
 	};
 }

--- a/src/resqml2/TimeSeries.cpp
+++ b/src/resqml2/TimeSeries.cpp
@@ -29,7 +29,7 @@ using namespace RESQML2_NS;
 
 const char* TimeSeries::XML_TAG = "TimeSeries";
 
-void TimeSeries::pushBackTimestamp(const time_t & timestamp)
+void TimeSeries::pushBackTimestamp(time_t timestamp)
 {
 	pushBackTimestamp(*gmtime(&timestamp));
 }
@@ -46,7 +46,7 @@ void TimeSeries::pushBackTimestamp(const tm & timestamp)
 	}
 }
 
-unsigned int TimeSeries::getTimestampIndex(const time_t & timestamp) const
+unsigned int TimeSeries::getTimestampIndex(time_t timestamp) const
 {
 	if (gsoapProxy2_0_1 != nullptr) {
 		gsoap_resqml2_0_1::_resqml2__TimeSeries* timeSeries = static_cast<gsoap_resqml2_0_1::_resqml2__TimeSeries*>(gsoapProxy2_0_1);
@@ -98,13 +98,13 @@ unsigned int TimeSeries::getTimestampCount() const
 	}
 }
 
-time_t TimeSeries::getTimestamp(const unsigned int & index) const
+time_t TimeSeries::getTimestamp(unsigned int index) const
 {
 	tm temp = getTimestampAsTimeStructure(index);
 	return timeTools::timegm(&temp);
 }
 
-tm TimeSeries::getTimestampAsTimeStructure(const unsigned int & index) const
+tm TimeSeries::getTimestampAsTimeStructure(unsigned int index) const
 {
 	if (gsoapProxy2_0_1 != nullptr) {
 		gsoap_resqml2_0_1::_resqml2__TimeSeries* timeSeries = static_cast<gsoap_resqml2_0_1::_resqml2__TimeSeries*>(gsoapProxy2_0_1);
@@ -120,10 +120,10 @@ tm TimeSeries::getTimestampAsTimeStructure(const unsigned int & index) const
 	throw out_of_range("The index is out of range");
 }
 
-std::vector<RESQML2_NS::AbstractProperty const *> TimeSeries::getPropertySet() const
+std::vector<RESQML2_NS::AbstractProperty *> TimeSeries::getPropertySet() const
 {
 	return getRepository()->getSourceObjects<AbstractProperty>(this);
 }
 
-void TimeSeries::loadTargetRelationships() const
+void TimeSeries::loadTargetRelationships()
 {}

--- a/src/resqml2/TimeSeries.h
+++ b/src/resqml2/TimeSeries.h
@@ -54,7 +54,7 @@ namespace RESQML2_NS
 		* Add a representation values object which uses this property type.
 		* Does not add the inverse relationship i.e. from the representation values object to this property type.
 		*/
-		DLL_IMPORT_OR_EXPORT void pushBackTimestamp(const time_t & timestamp);
+		DLL_IMPORT_OR_EXPORT void pushBackTimestamp(time_t timestamp);
 
 		/**
 		* Add a representation values object which uses this property type.
@@ -66,7 +66,7 @@ namespace RESQML2_NS
 		* Get the index of a timestamp in the time series.
 		* @return	uint.max if this timestamp has not been found in this time series.
 		*/
-		DLL_IMPORT_OR_EXPORT unsigned int getTimestampIndex(const time_t & timestamp) const;
+		DLL_IMPORT_OR_EXPORT unsigned int getTimestampIndex(time_t timestamp) const;
 
 		/**
 		* Get the index of a timestamp in the time series.
@@ -82,20 +82,20 @@ namespace RESQML2_NS
 		/**
 		* Get a timestamp at a particular index of this timeseries.
 		*/
-		DLL_IMPORT_OR_EXPORT time_t getTimestamp(const unsigned int & index) const;
+		DLL_IMPORT_OR_EXPORT time_t getTimestamp(unsigned int index) const;
 
 		/**
 		* Get a timestamp as a time structure at a particular index of this timeseries.
 		* It allows to read dates from 1900-01-01T00:00:00
 		*/
-		DLL_IMPORT_OR_EXPORT tm getTimestampAsTimeStructure(const unsigned int & index) const;
+		DLL_IMPORT_OR_EXPORT tm getTimestampAsTimeStructure(unsigned int index) const;
 
 		/**
 		* Get all the properties which use this time series
 		*/
-		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_NS::AbstractProperty const *> getPropertySet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_NS::AbstractProperty *> getPropertySet() const;
 
 	protected:
-		void loadTargetRelationships() const;
+		void loadTargetRelationships();
 	};
 }

--- a/src/resqml2_0_1/AbstractStratigraphicOrganizationInterpretation.cpp
+++ b/src/resqml2_0_1/AbstractStratigraphicOrganizationInterpretation.cpp
@@ -25,7 +25,7 @@ using namespace RESQML2_0_1_NS;
 using namespace gsoap_resqml2_0_1;
 using namespace std;
 
-std::vector<RESQML2_NS::AbstractGridRepresentation const *> AbstractStratigraphicOrganizationInterpretation::getGridRepresentations() const
+std::vector<RESQML2_NS::AbstractGridRepresentation *> AbstractStratigraphicOrganizationInterpretation::getGridRepresentations() const
 {
 	return getRepository()->getSourceObjects<RESQML2_NS::AbstractGridRepresentation>(this);
 }
@@ -41,9 +41,9 @@ unsigned int AbstractStratigraphicOrganizationInterpretation::getGridRepresentat
 	return count;
 }
 
-RESQML2_NS::AbstractGridRepresentation const * AbstractStratigraphicOrganizationInterpretation::getGridRepresentation(unsigned int index) const
+RESQML2_NS::AbstractGridRepresentation * AbstractStratigraphicOrganizationInterpretation::getGridRepresentation(unsigned int index) const
 {
-	const std::vector<RESQML2_NS::AbstractGridRepresentation const *>& gridRepresentationSet = getGridRepresentations();
+	const std::vector<RESQML2_NS::AbstractGridRepresentation *>& gridRepresentationSet = getGridRepresentations();
 
 	if (index >= gridRepresentationSet.size()) {
 		throw out_of_range("The index of the grid representation to get is out of range.");
@@ -54,7 +54,7 @@ RESQML2_NS::AbstractGridRepresentation const * AbstractStratigraphicOrganization
 
 bool AbstractStratigraphicOrganizationInterpretation::isAssociatedToGridRepresentation(RESQML2_NS::AbstractGridRepresentation* gridRep) const
 {
-	const std::vector<RESQML2_NS::AbstractGridRepresentation const *>& gridRepresentationSet = getGridRepresentations();
+	const std::vector<RESQML2_NS::AbstractGridRepresentation *>& gridRepresentationSet = getGridRepresentations();
 
 	return find(gridRepresentationSet.begin(), gridRepresentationSet.end(), gridRep) != gridRepresentationSet.end();
 }

--- a/src/resqml2_0_1/AbstractStratigraphicOrganizationInterpretation.h
+++ b/src/resqml2_0_1/AbstractStratigraphicOrganizationInterpretation.h
@@ -46,7 +46,7 @@ namespace RESQML2_0_1_NS
 		*/
 		virtual ~AbstractStratigraphicOrganizationInterpretation() {}
 
-		std::vector<RESQML2_NS::AbstractGridRepresentation const *> getGridRepresentations() const;
+		std::vector<RESQML2_NS::AbstractGridRepresentation *> getGridRepresentations() const;
 
 		/**
 		* @return The count of grid representation assocaited to this strati organization.
@@ -57,7 +57,7 @@ namespace RESQML2_0_1_NS
 		* Get a grid representation associated to this strati org interp by means of its index.
 		* @param index	The index of the grid representation to get in the array of grid representaitons of this strati org interp.
 		*/
-		DLL_IMPORT_OR_EXPORT RESQML2_NS::AbstractGridRepresentation const * getGridRepresentation(unsigned int index) const;
+		DLL_IMPORT_OR_EXPORT RESQML2_NS::AbstractGridRepresentation * getGridRepresentation(unsigned int index) const;
 
 		/**
 		* Check if a grid representation is wether associated to this strati org interp or not.

--- a/src/resqml2_0_1/AbstractSurfaceRepresentation.cpp
+++ b/src/resqml2_0_1/AbstractSurfaceRepresentation.cpp
@@ -68,7 +68,7 @@ resqml2__PointGeometry* AbstractSurfaceRepresentation::createArray2dOfLatticePoi
 			double xOrigin, double yOrigin, double zOrigin,
 			double xOffsetInFastestDirection, double yOffsetInFastestDirection, double zOffsetInFastestDirection,
 			double xOffsetInSlowestDirection, double yOffsetInSlowestDirection, double zOffsetInSlowestDirection,
-			double spacingInFastestDirection, double spacingInSlowestDirection, RESQML2_NS::AbstractLocal3dCrs const * localCrs)
+			double spacingInFastestDirection, double spacingInSlowestDirection, RESQML2_NS::AbstractLocal3dCrs * localCrs)
 {
 	if (localCrs == nullptr) {
 		throw invalid_argument("The CRS cannot be the null pointer");
@@ -114,9 +114,9 @@ resqml2__PointGeometry* AbstractSurfaceRepresentation::createArray2dOfLatticePoi
 }
 
 resqml2__PointGeometry* AbstractSurfaceRepresentation::createArray2dOfExplicitZ(
-		unsigned int patchIndex, double * zValues, RESQML2_NS::AbstractLocal3dCrs const * localCrs,
+		unsigned int patchIndex, double * zValues, RESQML2_NS::AbstractLocal3dCrs * localCrs,
 		unsigned int numI, unsigned int numJ, COMMON_NS::AbstractHdfProxy * proxy,
-		Grid2dRepresentation const * supportingRepresentation,
+		Grid2dRepresentation * supportingRepresentation,
 		unsigned int startGlobalIndex,
 		int indexIncrementI, int indexIncrementJ)
 {
@@ -176,7 +176,7 @@ resqml2__PointGeometry* AbstractSurfaceRepresentation::createArray2dOfExplicitZ(
 }
 
 resqml2__PointGeometry* AbstractSurfaceRepresentation::createArray2dOfExplicitZ(
-		unsigned int patchIndex, double * zValues, RESQML2_NS::AbstractLocal3dCrs const * localCrs,
+		unsigned int patchIndex, double * zValues, RESQML2_NS::AbstractLocal3dCrs * localCrs,
 		unsigned int numI, unsigned int numJ, COMMON_NS::AbstractHdfProxy * proxy,
 		double originX, double originY, double originZ,
 		double offsetIX, double offsetIY, double offsetIZ, double spacingI,
@@ -249,7 +249,7 @@ resqml2__PointGeometry* AbstractSurfaceRepresentation::createArray2dOfExplicitZ(
 	return geom;
 }
 
-void AbstractSurfaceRepresentation::loadTargetRelationships() const
+void AbstractSurfaceRepresentation::loadTargetRelationships()
 {
 	AbstractRepresentation::loadTargetRelationships();
 
@@ -259,7 +259,7 @@ void AbstractSurfaceRepresentation::loadTargetRelationships() const
 		if (rep->Boundaries[i]->OuterRing != nullptr) {
 			if (rep->Boundaries[i]->OuterRing->soap_type() == SOAP_TYPE_gsoap_resqml2_0_1_resqml2__obj_USCOREPolylineRepresentation) {
 				gsoap_resqml2_0_1::eml20__DataObjectReference* dor = rep->Boundaries[i]->OuterRing;
-				PolylineRepresentation const * outerRing = getRepository()->getDataObjectByUuid<PolylineRepresentation>(dor->UUID);
+				PolylineRepresentation * outerRing = getRepository()->getDataObjectByUuid<PolylineRepresentation>(dor->UUID);
 				if (outerRing == nullptr) { // partial transfer
 					getRepository()->createPartial(dor);
 					outerRing = getRepository()->getDataObjectByUuid<PolylineRepresentation>(dor->UUID);

--- a/src/resqml2_0_1/AbstractSurfaceRepresentation.h
+++ b/src/resqml2_0_1/AbstractSurfaceRepresentation.h
@@ -56,7 +56,7 @@ namespace RESQML2_0_1_NS
 			double xOrigin, double yOrigin, double zOrigin,
 			double xOffsetInFastestDirection, double yOffsetInFastestDirection, double zOffsetInFastestDirection,
 			double xOffsetInSlowestDirection, double yOffsetInSlowestDirection, double zOffsetInSlowestDirection,
-			double spacingInFastestDirection, double spacingInSlowestDirection, RESQML2_NS::AbstractLocal3dCrs const * localCrs);
+			double spacingInFastestDirection, double spacingInSlowestDirection, RESQML2_NS::AbstractLocal3dCrs * localCrs);
 
 		/**
 		* Creates a geometry for a grid 2d representation which derives from another existing grid 2d representation.
@@ -71,9 +71,9 @@ namespace RESQML2_0_1_NS
 		* @param	indexIncrementJ					The constant index increment between two consecutive nodes on the second dimension of the baseLatticeGridRepresentation where z values will be stored.
 		*/
 		gsoap_resqml2_0_1::resqml2__PointGeometry* createArray2dOfExplicitZ(
-			unsigned int patchIndex, double * zValues, RESQML2_NS::AbstractLocal3dCrs const * localCrs,
+			unsigned int patchIndex, double * zValues, RESQML2_NS::AbstractLocal3dCrs * localCrs,
 			unsigned int numI, unsigned int numJ, COMMON_NS::AbstractHdfProxy* proxy,
-			class Grid2dRepresentation const * supportingRepresentation,
+			class Grid2dRepresentation * supportingRepresentation,
 			unsigned int startGlobalIndex = 0,
 			int indexIncrementI = 1, int indexIncrementJ = 1);
 
@@ -86,13 +86,13 @@ namespace RESQML2_0_1_NS
 		* @param	AbstractHdfProxy				The hdf proxy which indicates the hdf file where the values will be stored.
 		*/
 		gsoap_resqml2_0_1::resqml2__PointGeometry* createArray2dOfExplicitZ(
-			unsigned int patchIndex, double * zValues, RESQML2_NS::AbstractLocal3dCrs const * localCrs,
+			unsigned int patchIndex, double * zValues, RESQML2_NS::AbstractLocal3dCrs * localCrs,
 			unsigned int numI, unsigned int numJ, COMMON_NS::AbstractHdfProxy* proxy,
 			double originX, double originY, double originZ,
 			double offsetIX, double offsetIY, double offsetIZ, double spacingI,
 			double offsetJX, double offsetJY, double offsetJZ, double spacingJ);
 
-		virtual void loadTargetRelationships() const;
+		virtual void loadTargetRelationships();
 
 	public:
 

--- a/src/resqml2_0_1/Activity.cpp
+++ b/src/resqml2_0_1/Activity.cpp
@@ -492,7 +492,7 @@ std::string Activity::getResqmlVersion() const
 	return "2.0.1";
 }
 
-void Activity::loadTargetRelationships() const
+void Activity::loadTargetRelationships()
 {
 	_resqml2__Activity* activity = static_cast<_resqml2__Activity*>(gsoapProxy2_0_1);
 

--- a/src/resqml2_0_1/Activity.h
+++ b/src/resqml2_0_1/Activity.h
@@ -32,7 +32,7 @@ namespace RESQML2_0_1_NS
 	protected:
 		Activity() : RESQML2_NS::Activity() {}
 
-		void loadTargetRelationships() const;
+		void loadTargetRelationships();
 
 	public:
 

--- a/src/resqml2_0_1/BlockedWellboreRepresentation.cpp
+++ b/src/resqml2_0_1/BlockedWellboreRepresentation.cpp
@@ -35,7 +35,7 @@ using namespace gsoap_resqml2_0_1;
 
 const char* BlockedWellboreRepresentation::XML_TAG = "BlockedWellboreRepresentation";
 
-void BlockedWellboreRepresentation::init(const std::string & guid, const std::string & title, WellboreTrajectoryRepresentation const * traj)
+void BlockedWellboreRepresentation::init(const std::string & guid, const std::string & title, WellboreTrajectoryRepresentation * traj)
 {
 	if (traj == nullptr) {
 		throw invalid_argument("The wellbore trajectory of a blocked wellbore cannot be null.");
@@ -53,8 +53,8 @@ void BlockedWellboreRepresentation::init(const std::string & guid, const std::st
 	getRepository()->addRelationship(this, traj);
 }
 
-BlockedWellboreRepresentation::BlockedWellboreRepresentation(WellboreInterpretation const * interp,
-	const std::string & guid, const std::string & title, WellboreTrajectoryRepresentation  const * traj)
+BlockedWellboreRepresentation::BlockedWellboreRepresentation(WellboreInterpretation * interp,
+	const std::string & guid, const std::string & title, WellboreTrajectoryRepresentation  * traj)
 {
 	init(guid, title, traj);
 
@@ -192,7 +192,7 @@ std::string BlockedWellboreRepresentation::getSupportingGridRepresentationUuid(u
 	return getSupportingGridRepresentationDor(index)->UUID;
 }
 
-void BlockedWellboreRepresentation::loadTargetRelationships() const
+void BlockedWellboreRepresentation::loadTargetRelationships()
 {
 	WellboreFrameRepresentation::loadTargetRelationships();
 
@@ -201,7 +201,7 @@ void BlockedWellboreRepresentation::loadTargetRelationships() const
 	// Supporting grid representation
 	for (size_t i = 0; i < rep->Grid.size(); ++i) {
 		gsoap_resqml2_0_1::eml20__DataObjectReference* dor = rep->Grid[i];
-		RESQML2_NS::AbstractGridRepresentation const * supportingGridRep = getRepository()->getDataObjectByUuid<RESQML2_NS::AbstractGridRepresentation>(dor->UUID);
+		RESQML2_NS::AbstractGridRepresentation * supportingGridRep = getRepository()->getDataObjectByUuid<RESQML2_NS::AbstractGridRepresentation>(dor->UUID);
 		if (supportingGridRep == nullptr) { // partial transfer
 			getRepository()->createPartial(dor);
 			supportingGridRep = getRepository()->getDataObjectByUuid<RESQML2_NS::AbstractGridRepresentation>(dor->UUID);

--- a/src/resqml2_0_1/BlockedWellboreRepresentation.h
+++ b/src/resqml2_0_1/BlockedWellboreRepresentation.h
@@ -30,7 +30,7 @@ namespace RESQML2_0_1_NS
 	class BlockedWellboreRepresentation : public WellboreFrameRepresentation
 	{
 	private:
-		void init(const std::string & guid, const std::string & title, class WellboreTrajectoryRepresentation const * traj);
+		void init(const std::string & guid, const std::string & title, class WellboreTrajectoryRepresentation * traj);
 
 	public:
 
@@ -46,8 +46,8 @@ namespace RESQML2_0_1_NS
         * @param title	A title for the instance to create.
         * @param traj	The wellbore trajectory this intance is based on.
 		*/
-		BlockedWellboreRepresentation(class WellboreInterpretation const * interp,
-			const std::string & guid, const std::string & title, class WellboreTrajectoryRepresentation const * traj);
+		BlockedWellboreRepresentation(class WellboreInterpretation * interp,
+			const std::string & guid, const std::string & title, class WellboreTrajectoryRepresentation * traj);
 
 		/**
 		* Creates an instance of this class by wrapping a gsoap instance.
@@ -112,6 +112,6 @@ namespace RESQML2_0_1_NS
 		DLL_IMPORT_OR_EXPORT std::string getSupportingGridRepresentationUuid(unsigned int index) const;
 
 	private:
-		void loadTargetRelationships() const;
+		void loadTargetRelationships();
 	};
 }

--- a/src/resqml2_0_1/CategoricalProperty.cpp
+++ b/src/resqml2_0_1/CategoricalProperty.cpp
@@ -78,7 +78,7 @@ CategoricalProperty::CategoricalProperty(RESQML2_NS::AbstractRepresentation * re
 	setLocalPropertyKind(localPropKind);
 }
 
-void CategoricalProperty::loadTargetRelationships() const
+void CategoricalProperty::loadTargetRelationships()
 {
 	AbstractValuesProperty::loadTargetRelationships();
 

--- a/src/resqml2_0_1/CategoricalProperty.h
+++ b/src/resqml2_0_1/CategoricalProperty.h
@@ -174,6 +174,6 @@ namespace RESQML2_0_1_NS
 		bool validatePropertyKindAssociation(const gsoap_resqml2_0_1::resqml2__ResqmlPropertyKind & pk);
 
 	protected:
-		virtual void loadTargetRelationships() const;
+		virtual void loadTargetRelationships();
 	};
 }

--- a/src/resqml2_0_1/DeviationSurveyRepresentation.cpp
+++ b/src/resqml2_0_1/DeviationSurveyRepresentation.cpp
@@ -35,7 +35,7 @@ using namespace COMMON_NS;
 
 const char* DeviationSurveyRepresentation::XML_TAG = "DeviationSurveyRepresentation";
 
-DeviationSurveyRepresentation::DeviationSurveyRepresentation(WellboreInterpretation const * interp, const string & guid, const std::string & title, bool isFinal, RESQML2_NS::MdDatum const * mdInfo)
+DeviationSurveyRepresentation::DeviationSurveyRepresentation(WellboreInterpretation * interp, const string & guid, const std::string & title, bool isFinal, RESQML2_NS::MdDatum * mdInfo)
 {
 	gsoapProxy2_0_1 = soap_new_resqml2__obj_USCOREDeviationSurveyRepresentation(interp->getGsoapContext(), 1);	
 	_resqml2__DeviationSurveyRepresentation* rep = static_cast<_resqml2__DeviationSurveyRepresentation*>(gsoapProxy2_0_1);
@@ -111,7 +111,7 @@ void DeviationSurveyRepresentation::setGeometry(double * firstStationLocation, c
 	proxy->writeArrayNdOfDoubleValues(rep->uuid, "inclinations", inclinations, dim, 1);
 }
 
-void DeviationSurveyRepresentation::loadTargetRelationships() const
+void DeviationSurveyRepresentation::loadTargetRelationships()
 {
 	AbstractRepresentation::loadTargetRelationships();
 
@@ -176,7 +176,7 @@ void DeviationSurveyRepresentation::getAzimuths(double* values) const
 	}
 }
 
-void DeviationSurveyRepresentation::setMdDatum(RESQML2_NS::MdDatum const * mdDatum)
+void DeviationSurveyRepresentation::setMdDatum(RESQML2_NS::MdDatum * mdDatum)
 {
 	if (mdDatum == nullptr) {
 		throw invalid_argument("The md Datum is missing.");
@@ -242,14 +242,14 @@ gsoap_resqml2_0_1::eml20__DataObjectReference* DeviationSurveyRepresentation::ge
 	return nullptr;
 }
 
-vector<WellboreFrameRepresentation const *> DeviationSurveyRepresentation::getWellboreFrameRepresentationSet() const
+vector<WellboreFrameRepresentation *> DeviationSurveyRepresentation::getWellboreFrameRepresentationSet() const
 {
-	vector<WellboreFrameRepresentation const *> result;
+	vector<WellboreFrameRepresentation *> result;
 
-	const vector<WellboreTrajectoryRepresentation const *>& trajectories = getWellboreTrajectoryRepresentationSet();
+	const vector<WellboreTrajectoryRepresentation *>& trajectories = getWellboreTrajectoryRepresentationSet();
 	for (size_t index = 0; index < trajectories.size(); ++index) {
 		if (trajectories[index]->getMdDatumUuid() == getMdDatumUuid() && trajectories[index]->getMdUom() == getMdUom()) {
-			vector<WellboreFrameRepresentation const *> tmp = trajectories[index]->getWellboreFrameRepresentationSet();
+			vector<WellboreFrameRepresentation *> tmp = trajectories[index]->getWellboreFrameRepresentationSet();
 			result.insert(result.end(), tmp.begin(), tmp.end());
 		}
 	}
@@ -259,7 +259,7 @@ vector<WellboreFrameRepresentation const *> DeviationSurveyRepresentation::getWe
 
 unsigned int DeviationSurveyRepresentation::getWellboreFrameRepresentationCount() const
 {
-	const vector<WellboreTrajectoryRepresentation const *>& trajectories = getWellboreTrajectoryRepresentationSet();
+	const vector<WellboreTrajectoryRepresentation *>& trajectories = getWellboreTrajectoryRepresentationSet();
 	unsigned int result = 0;
 	for (size_t index = 0; index < trajectories.size(); ++index) {
 		if (trajectories[index]->getMdDatumUuid() == getMdDatumUuid() && trajectories[index]->getMdUom() == getMdUom()) {
@@ -270,11 +270,11 @@ unsigned int DeviationSurveyRepresentation::getWellboreFrameRepresentationCount(
 	return result;
 }
 
-WellboreFrameRepresentation const * DeviationSurveyRepresentation::getWellboreFrameRepresentation(unsigned int index) const
+WellboreFrameRepresentation * DeviationSurveyRepresentation::getWellboreFrameRepresentation(unsigned int index) const
 {
-	const vector<WellboreTrajectoryRepresentation const *>& trajectories = getWellboreTrajectoryRepresentationSet();
+	const vector<WellboreTrajectoryRepresentation *>& trajectories = getWellboreTrajectoryRepresentationSet();
 	for (size_t trajIndex = 0; trajIndex < trajectories.size(); ++trajIndex) {
-		WellboreTrajectoryRepresentation const * traj = trajectories[trajIndex];
+		WellboreTrajectoryRepresentation * traj = trajectories[trajIndex];
 		if (traj->getMdDatumUuid() == getMdDatumUuid() && traj->getMdUom() == getMdUom()) {
 			unsigned int count = traj->getWellboreFrameRepresentationCount();
 			if (index < count) {
@@ -289,7 +289,7 @@ WellboreFrameRepresentation const * DeviationSurveyRepresentation::getWellboreFr
 	throw out_of_range("The index is out of range");
 }
 
-std::vector<WellboreTrajectoryRepresentation const *> DeviationSurveyRepresentation::getWellboreTrajectoryRepresentationSet() const
+std::vector<WellboreTrajectoryRepresentation *> DeviationSurveyRepresentation::getWellboreTrajectoryRepresentationSet() const
 {
 	return getRepository()->getSourceObjects<WellboreTrajectoryRepresentation>(this);
 }
@@ -305,9 +305,9 @@ unsigned int DeviationSurveyRepresentation::getWellboreTrajectoryRepresentationC
 	return static_cast<unsigned int>(result);
 }
 
-WellboreTrajectoryRepresentation const * DeviationSurveyRepresentation::getWellboreTrajectoryRepresentation(const unsigned int & index) const
+WellboreTrajectoryRepresentation * DeviationSurveyRepresentation::getWellboreTrajectoryRepresentation(unsigned int index) const
 {
-	const std::vector<WellboreTrajectoryRepresentation const *>& wbTrajectoryRepSet = getWellboreTrajectoryRepresentationSet();
+	const std::vector<WellboreTrajectoryRepresentation *>& wbTrajectoryRepSet = getWellboreTrajectoryRepresentationSet();
 
 	if (index >= wbTrajectoryRepSet.size())
 	{

--- a/src/resqml2_0_1/DeviationSurveyRepresentation.h
+++ b/src/resqml2_0_1/DeviationSurveyRepresentation.h
@@ -47,7 +47,7 @@ namespace RESQML2_0_1_NS
 		* @param isFinal				Used to indicate that this is a final version of the deviation survey, as distinct from the interim interpretations.
 		* @param mdInfo					The MD information of the survey, mainly the well reference point.
 		*/
-		DeviationSurveyRepresentation(class WellboreInterpretation const * interp, const std::string & guid, const std::string & title, bool isFinal, RESQML2_NS::MdDatum const * mdInfo);
+		DeviationSurveyRepresentation(class WellboreInterpretation * interp, const std::string & guid, const std::string & title, bool isFinal, RESQML2_NS::MdDatum * mdInfo);
 
 		/**
 		* Creates an instance of this class by wrapping a gsoap instance.
@@ -79,7 +79,7 @@ namespace RESQML2_0_1_NS
 		/**
 		* Set the Md datum of this trajectory
 		*/
-		DLL_IMPORT_OR_EXPORT void setMdDatum(RESQML2_NS::MdDatum const * mdDatum);
+		DLL_IMPORT_OR_EXPORT void setMdDatum(RESQML2_NS::MdDatum * mdDatum);
 
 		/**
 		* @return	null pointer if no md datum is associated to this representation. Otherwise return the data object reference of the associated md datum.
@@ -148,7 +148,7 @@ namespace RESQML2_0_1_NS
 		/**
 		* Getter of all the wellbore frame representations of associated wellbore trajectory which share the same md datum and md uom.
 		*/
-		DLL_IMPORT_OR_EXPORT std::vector<class WellboreFrameRepresentation const *> getWellboreFrameRepresentationSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<class WellboreFrameRepresentation *> getWellboreFrameRepresentationSet() const;
 
 		/**
 		* Get the count of all the wellbore frame representations of associated wellbore trajectory which share the same md datum and md uom.
@@ -161,12 +161,12 @@ namespace RESQML2_0_1_NS
 		* Necessary for now in SWIG context because I am not sure if I can always wrap a vector of polymorphic class yet.
 		* Throw an out of bound exception if the index is superior or equal to the count of wellbore frame representation.
 		*/
-		DLL_IMPORT_OR_EXPORT class WellboreFrameRepresentation const * getWellboreFrameRepresentation(unsigned int index) const;
+		DLL_IMPORT_OR_EXPORT class WellboreFrameRepresentation * getWellboreFrameRepresentation(unsigned int index) const;
 
 		/**
 		* Getter (in read only mode) of all the wellbore trajectories which are associated to this deviation survey.
 		*/
-		DLL_IMPORT_OR_EXPORT std::vector<class WellboreTrajectoryRepresentation const *> getWellboreTrajectoryRepresentationSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<class WellboreTrajectoryRepresentation *> getWellboreTrajectoryRepresentationSet() const;
 
 		/**
 		* Get the count of all the wellbore trajectories which are associated to this deviation survey.
@@ -179,13 +179,13 @@ namespace RESQML2_0_1_NS
 		* Necessary for now in SWIG context because I am not sure if I can always wrap a vector of polymorphic class yet.
 		* Throw an out of bound exception if the index is superior or equal to the count of wellbore frame representation.
 		*/
-		DLL_IMPORT_OR_EXPORT class WellboreTrajectoryRepresentation const * getWellboreTrajectoryRepresentation(const unsigned int & index) const;
+		DLL_IMPORT_OR_EXPORT class WellboreTrajectoryRepresentation * getWellboreTrajectoryRepresentation(unsigned int index) const;
 
 		gsoap_resqml2_0_1::eml20__DataObjectReference* getHdfProxyDor() const;
 
 		DLL_IMPORT_OR_EXPORT unsigned int getPatchCount() const {return 1;}
 
 	protected:
-		void loadTargetRelationships() const;
+		void loadTargetRelationships();
 	};
 }

--- a/src/resqml2_0_1/EarthModelInterpretation.cpp
+++ b/src/resqml2_0_1/EarthModelInterpretation.cpp
@@ -132,7 +132,7 @@ RockFluidOrganizationInterpretation* EarthModelInterpretation::getRockFluidOrgan
 	return repository->getDataObjectByUuid<RockFluidOrganizationInterpretation>(static_cast<_resqml2__EarthModelInterpretation*>(gsoapProxy2_0_1)->Fluid->UUID);
 }
 		
-void EarthModelInterpretation::loadTargetRelationships() const
+void EarthModelInterpretation::loadTargetRelationships()
 {
 	AbstractFeatureInterpretation::loadTargetRelationships();
 

--- a/src/resqml2_0_1/EarthModelInterpretation.h
+++ b/src/resqml2_0_1/EarthModelInterpretation.h
@@ -98,6 +98,6 @@ namespace RESQML2_0_1_NS
 		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
     private:
-		void loadTargetRelationships() const;
+		void loadTargetRelationships();
 	};
 }

--- a/src/resqml2_0_1/Grid2dRepresentation.cpp
+++ b/src/resqml2_0_1/Grid2dRepresentation.cpp
@@ -614,7 +614,7 @@ void Grid2dRepresentation::setGeometryAsArray2dOfLatticePoints3d(
 			double xOrigin, double yOrigin, double zOrigin,
 			double xOffsetInFastestDirection, double yOffsetInFastestDirection, double zOffsetInFastestDirection,
 			double xOffsetInSlowestDirection, double yOffsetInSlowestDirection, double zOffsetInSlowestDirection,
-			double spacingInFastestDirection, double spacingInSlowestDirection, RESQML2_NS::AbstractLocal3dCrs const * localCrs)
+			double spacingInFastestDirection, double spacingInSlowestDirection, RESQML2_NS::AbstractLocal3dCrs * localCrs)
 {
 	if (localCrs == nullptr) {
 		localCrs = getRepository()->getDefaultCrs();
@@ -640,7 +640,7 @@ void Grid2dRepresentation::setGeometryAsArray2dOfLatticePoints3d(
 void Grid2dRepresentation::setGeometryAsArray2dOfExplicitZ(
 		double * zValues,
 		unsigned int numI, unsigned int numJ, COMMON_NS::AbstractHdfProxy * proxy,
-		Grid2dRepresentation * supportingGrid2dRepresentation, RESQML2_NS::AbstractLocal3dCrs const * localCrs,
+		Grid2dRepresentation * supportingGrid2dRepresentation, RESQML2_NS::AbstractLocal3dCrs * localCrs,
 		unsigned int startIndexI, unsigned int startIndexJ,
 		int indexIncrementI, int indexIncrementJ)
 {
@@ -671,7 +671,7 @@ void Grid2dRepresentation::setGeometryAsArray2dOfExplicitZ(
 				unsigned int numI, unsigned int numJ, COMMON_NS::AbstractHdfProxy * proxy,
 				double originX, double originY, double originZ,
 				double offsetIX, double offsetIY, double offsetIZ, double spacingI,
-				double offsetJX, double offsetJY, double offsetJZ, double spacingJ, RESQML2_NS::AbstractLocal3dCrs const * localCrs)
+				double offsetJX, double offsetJY, double offsetJZ, double spacingJ, RESQML2_NS::AbstractLocal3dCrs * localCrs)
 {
 	if (localCrs == nullptr) {
 		localCrs = getRepository()->getDefaultCrs();
@@ -769,7 +769,7 @@ int Grid2dRepresentation::getIndexOffsetOnSupportingRepresentation(const unsigne
 	throw invalid_argument("It does not exist supporting representation for this representation.");
 }
 
-void Grid2dRepresentation::loadTargetRelationships() const
+void Grid2dRepresentation::loadTargetRelationships()
 {
 	AbstractSurfaceRepresentation::loadTargetRelationships();
 

--- a/src/resqml2_0_1/Grid2dRepresentation.h
+++ b/src/resqml2_0_1/Grid2dRepresentation.h
@@ -281,7 +281,7 @@ namespace RESQML2_0_1_NS
 			double xOrigin, double yOrigin, double zOrigin,
 			double xOffsetInFastestDirection, double yOffsetInFastestDirection, double zOffsetInFastestDirection,
 			double xOffsetInSlowestDirection, double yOffsetInSlowestDirection, double zOffsetInSlowestDirection,
-			double spacingInFastestDirection, double spacingInSlowestDirection, RESQML2_NS::AbstractLocal3dCrs const * localCrs = nullptr);
+			double spacingInFastestDirection, double spacingInSlowestDirection, RESQML2_NS::AbstractLocal3dCrs * localCrs = nullptr);
 
 		/**
 		* Set the geometry patch for a lattice 2d grid.
@@ -290,7 +290,7 @@ namespace RESQML2_0_1_NS
 		DLL_IMPORT_OR_EXPORT void setGeometryAsArray2dOfExplicitZ(
 			double * zValues,
 			unsigned int numI, unsigned int numJ, COMMON_NS::AbstractHdfProxy* proxy,
-			Grid2dRepresentation * supportingGrid2dRepresentation, RESQML2_NS::AbstractLocal3dCrs const * localCrs = nullptr,
+			Grid2dRepresentation * supportingGrid2dRepresentation, RESQML2_NS::AbstractLocal3dCrs * localCrs = nullptr,
 			unsigned int startIndexI = 0, unsigned int startIndexJ = 0,
 			int indexIncrementI = 1, int indexIncrementJ = 1);
 
@@ -303,7 +303,7 @@ namespace RESQML2_0_1_NS
 			unsigned int numI, unsigned int numJ, COMMON_NS::AbstractHdfProxy* proxy,
 			double originX, double originY, double originZ,
 			double offsetIX, double offsetIY, double offsetIZ, double spacingI,
-			double offsetJX, double offsetJY, double offsetJZ, double spacingJ, RESQML2_NS::AbstractLocal3dCrs const * localCrs = nullptr);
+			double offsetJX, double offsetJY, double offsetJZ, double spacingJ, RESQML2_NS::AbstractLocal3dCrs * localCrs = nullptr);
 
 		gsoap_resqml2_0_1::eml20__DataObjectReference const * getSupportingRepresentationDor() const;
 
@@ -342,6 +342,6 @@ namespace RESQML2_0_1_NS
 		DLL_IMPORT_OR_EXPORT unsigned int getPatchCount() const {return 1;}
 
 	private:
-		void loadTargetRelationships() const;
+		void loadTargetRelationships();
 	};
 }

--- a/src/resqml2_0_1/IjkGridExplicitRepresentation.cpp
+++ b/src/resqml2_0_1/IjkGridExplicitRepresentation.cpp
@@ -351,7 +351,7 @@ void IjkGridExplicitRepresentation::setGeometryAsCoordinateLineNodesUsingExistin
 	const std::string & points, COMMON_NS::AbstractHdfProxy* proxy,
 	const unsigned long splitCoordinateLineCount, const std::string & pillarOfCoordinateLine,
 	const std::string & splitCoordinateLineColumnCumulativeCount, const std::string & splitCoordinateLineColumns,
-	const std::string & definedPillars, RESQML2_NS::AbstractLocal3dCrs const * localCrs)
+	const std::string & definedPillars, RESQML2_NS::AbstractLocal3dCrs * localCrs)
 {
 	if (points.empty()) {
 		throw invalid_argument("The points HDF dataset of the ijk grid cannot be empty.");
@@ -445,7 +445,7 @@ void IjkGridExplicitRepresentation::setGeometryAsCoordinateLineNodes(
 	double * points, COMMON_NS::AbstractHdfProxy * proxy,
 	unsigned long splitCoordinateLineCount, unsigned int * pillarOfCoordinateLine,
 	unsigned int * splitCoordinateLineColumnCumulativeCount, unsigned int * splitCoordinateLineColumns,
-	char * definedPillars, RESQML2_NS::AbstractLocal3dCrs const * localCrs)
+	char * definedPillars, RESQML2_NS::AbstractLocal3dCrs * localCrs)
 {
 	if (points == nullptr) {
 		throw invalid_argument("The points of the ijk grid cannot be null.");

--- a/src/resqml2_0_1/IjkGridExplicitRepresentation.h
+++ b/src/resqml2_0_1/IjkGridExplicitRepresentation.h
@@ -107,7 +107,7 @@ namespace RESQML2_0_1_NS
 			double * points, COMMON_NS::AbstractHdfProxy* proxy = nullptr,
 			unsigned long splitCoordinateLineCount = 0, unsigned int * pillarOfCoordinateLine = nullptr,
 			unsigned int * splitCoordinateLineColumnCumulativeCount = nullptr, unsigned int * splitCoordinateLineColumns = nullptr,
-			char * definedPillars = nullptr, RESQML2_NS::AbstractLocal3dCrs const * localCrs = nullptr);
+			char * definedPillars = nullptr, RESQML2_NS::AbstractLocal3dCrs * localCrs = nullptr);
 
 		/**
 		* Same as setGeometryAsCoordinateLineNodes where the hdf datasets are already written in the the file.
@@ -117,7 +117,7 @@ namespace RESQML2_0_1_NS
 			const std::string & points, COMMON_NS::AbstractHdfProxy* proxy = nullptr,
 			unsigned long splitCoordinateLineCount = 0, const std::string & pillarOfCoordinateLine = "",
 			const std::string & splitCoordinateLineColumnCumulativeCount = "", const std::string & splitCoordinateLineColumns = "",
-			const std::string & definedPillars = "", RESQML2_NS::AbstractLocal3dCrs const * localCrs = nullptr);
+			const std::string & definedPillars = "", RESQML2_NS::AbstractLocal3dCrs * localCrs = nullptr);
 
 		/**
 		* Check wether the node geometry dataset is compressed or not.

--- a/src/resqml2_0_1/IjkGridLatticeRepresentation.cpp
+++ b/src/resqml2_0_1/IjkGridLatticeRepresentation.cpp
@@ -50,7 +50,7 @@ bool IjkGridLatticeRepresentation::isASeismicCube() const
 	// A Seismic cube is defined by an IjkGridRepresentation that has a feature of type SeismicLatticeFeature and that
 	// has at least one continuous property (amplitude).
 	bool atLeastOneContProp = false;
-	vector<RESQML2_NS::AbstractValuesProperty const *> allValuesProperty = getValuesPropertySet();
+	vector<RESQML2_NS::AbstractValuesProperty *> allValuesProperty = getValuesPropertySet();
     for (size_t propIndex = 0; propIndex < allValuesProperty.size(); ++propIndex)
     {
         if (allValuesProperty[propIndex]->getGsoapType() == SOAP_TYPE_gsoap_resqml2_0_1_resqml2__obj_USCOREContinuousProperty)
@@ -70,7 +70,7 @@ bool IjkGridLatticeRepresentation::isAFaciesCube() const
 	// A Facies cube is defined by an IjkGridRepresentation that has a feature of type SeismicLatticeFeature and that
 	// has at least one categorical property (facies).
 	bool atLeastOneCateProp = false;
-	vector<RESQML2_NS::AbstractValuesProperty const *> allValuesProperty = getValuesPropertySet();
+	vector<RESQML2_NS::AbstractValuesProperty *> allValuesProperty = getValuesPropertySet();
     for (size_t propIndex = 0; propIndex < allValuesProperty.size(); ++propIndex)
     {
         if (allValuesProperty[propIndex]->getGsoapType() == SOAP_TYPE_gsoap_resqml2_0_1_resqml2__obj_USCORECategoricalProperty)
@@ -420,7 +420,7 @@ void IjkGridLatticeRepresentation::setGeometryAsCoordinateLineNodes(
 	double originX, double originY, double originZ,
 	double directionIX, double directionIY, double directionIZ, double spacingI,
 	double directionJX, double directionJY, double directionJZ, double spacingJ,
-	double directionKX, double directionKY, double directionKZ, double spacingK, RESQML2_NS::AbstractLocal3dCrs const * localCrs)
+	double directionKX, double directionKY, double directionKZ, double spacingK, RESQML2_NS::AbstractLocal3dCrs * localCrs)
 {
 	if (localCrs == nullptr) {
 		localCrs = getRepository()->getDefaultCrs();

--- a/src/resqml2_0_1/IjkGridLatticeRepresentation.h
+++ b/src/resqml2_0_1/IjkGridLatticeRepresentation.h
@@ -247,7 +247,7 @@ namespace RESQML2_0_1_NS
 			double originX, double originY, double originZ,
 			double directionIX, double directionIY, double directionIZ, double spacingI,
 			double directionJX, double directionJY, double directionJZ, double spacingJ,
-			double directionKX, double directionKY, double directionKZ, double spacingK, RESQML2_NS::AbstractLocal3dCrs const * localCrs = nullptr);
+			double directionKX, double directionKY, double directionKZ, double spacingK, RESQML2_NS::AbstractLocal3dCrs * localCrs = nullptr);
 
 		/**
 		* Push back a patch of seismic 3D coordinates info.

--- a/src/resqml2_0_1/IjkGridParametricRepresentation.cpp
+++ b/src/resqml2_0_1/IjkGridParametricRepresentation.cpp
@@ -1328,7 +1328,7 @@ void IjkGridParametricRepresentation::getXyzPointsOfPatch(const unsigned int & p
 
 void IjkGridParametricRepresentation::setGeometryAsParametricNonSplittedPillarNodes(
 	gsoap_resqml2_0_1::resqml2__PillarShape mostComplexPillarGeometry, bool isRightHanded,
-	double * parameters, double * controlPoints, double * controlPointParameters, unsigned int controlPointMaxCountPerPillar, short * pillarKind, COMMON_NS::AbstractHdfProxy* proxy, RESQML2_NS::AbstractLocal3dCrs const * localCrs)
+	double * parameters, double * controlPoints, double * controlPointParameters, unsigned int controlPointMaxCountPerPillar, short * pillarKind, COMMON_NS::AbstractHdfProxy* proxy, RESQML2_NS::AbstractLocal3dCrs * localCrs)
 {
 	setGeometryAsParametricSplittedPillarNodes(mostComplexPillarGeometry, isRightHanded, parameters, controlPoints, controlPointParameters, controlPointMaxCountPerPillar, pillarKind, proxy,
 		0, nullptr, nullptr, nullptr, localCrs);
@@ -1336,7 +1336,7 @@ void IjkGridParametricRepresentation::setGeometryAsParametricNonSplittedPillarNo
 
 void IjkGridParametricRepresentation::setGeometryAsParametricNonSplittedPillarNodesUsingExistingDatasets(
 	gsoap_resqml2_0_1::resqml2__PillarShape mostComplexPillarGeometry, gsoap_resqml2_0_1::resqml2__KDirection kDirectionKind, bool isRightHanded,
-	const std::string & parameters, const std::string & controlPoints, const std::string & controlPointParameters, unsigned int controlPointMaxCountPerPillar, const std::string & pillarKind, const std::string & definedPillars, COMMON_NS::AbstractHdfProxy* proxy, RESQML2_NS::AbstractLocal3dCrs const * localCrs)
+	const std::string & parameters, const std::string & controlPoints, const std::string & controlPointParameters, unsigned int controlPointMaxCountPerPillar, const std::string & pillarKind, const std::string & definedPillars, COMMON_NS::AbstractHdfProxy* proxy, RESQML2_NS::AbstractLocal3dCrs * localCrs)
 {
 	setGeometryAsParametricSplittedPillarNodesUsingExistingDatasets(mostComplexPillarGeometry, kDirectionKind, isRightHanded, parameters, controlPoints, controlPointParameters, controlPointMaxCountPerPillar, pillarKind, definedPillars, proxy,
 		0, "", "", "", localCrs);
@@ -1346,7 +1346,7 @@ void IjkGridParametricRepresentation::setGeometryAsParametricSplittedPillarNodes
 	gsoap_resqml2_0_1::resqml2__PillarShape mostComplexPillarGeometry, bool isRightHanded,
 	double * parameters, double * controlPoints, double * controlPointParameters, unsigned int controlPointMaxCountPerPillar, short * pillarKind, COMMON_NS::AbstractHdfProxy * proxy,
 	unsigned long splitCoordinateLineCount, unsigned int * pillarOfCoordinateLine,
-	unsigned int * splitCoordinateLineColumnCumulativeCount, unsigned int * splitCoordinateLineColumns, RESQML2_NS::AbstractLocal3dCrs const * localCrs)
+	unsigned int * splitCoordinateLineColumnCumulativeCount, unsigned int * splitCoordinateLineColumns, RESQML2_NS::AbstractLocal3dCrs * localCrs)
 {
 	if (pillarKind == nullptr) {
 		throw invalid_argument("The kind of the coordinate lines cannot be null.");
@@ -1412,7 +1412,7 @@ void IjkGridParametricRepresentation::setGeometryAsParametricSplittedPillarNodes
 	gsoap_resqml2_0_1::resqml2__PillarShape mostComplexPillarGeometry, gsoap_resqml2_0_1::resqml2__KDirection kDirectionKind, bool isRightHanded,
 	const std::string & parameters, const std::string & controlPoints, const std::string & controlPointParameters, unsigned int controlPointMaxCountPerPillar, const std::string & pillarKind, const std::string & definedPillars, COMMON_NS::AbstractHdfProxy* proxy,
 	unsigned long splitCoordinateLineCount, const std::string & pillarOfCoordinateLine,
-	const std::string & splitCoordinateLineColumnCumulativeCount, const std::string & splitCoordinateLineColumns, RESQML2_NS::AbstractLocal3dCrs const * localCrs)
+	const std::string & splitCoordinateLineColumnCumulativeCount, const std::string & splitCoordinateLineColumns, RESQML2_NS::AbstractLocal3dCrs * localCrs)
 {
 	if (pillarKind.empty())
 		throw invalid_argument("The kind of the coordinate lines cannot be null.");
@@ -1457,7 +1457,7 @@ void IjkGridParametricRepresentation::setGeometryAsParametricSplittedPillarNodes
 void IjkGridParametricRepresentation::setGeometryAsParametricSplittedPillarNodes(bool isRightHanded,
 	double * parameters, double * controlPoints, double * controlPointParameters, unsigned int controlPointCountPerPillar, short pillarKind, COMMON_NS::AbstractHdfProxy * proxy,
 	unsigned long splitCoordinateLineCount, unsigned int * pillarOfCoordinateLine,
-	unsigned int * splitCoordinateLineColumnCumulativeCount, unsigned int * splitCoordinateLineColumns, RESQML2_NS::AbstractLocal3dCrs const * localCrs)
+	unsigned int * splitCoordinateLineColumnCumulativeCount, unsigned int * splitCoordinateLineColumns, RESQML2_NS::AbstractLocal3dCrs * localCrs)
 {
 	if (parameters == nullptr) {
 		throw invalid_argument("The parameters of the nodes of the ijk grid cannot be null.");
@@ -1538,7 +1538,7 @@ void IjkGridParametricRepresentation::setGeometryAsParametricSplittedPillarNodes
 	gsoap_resqml2_0_1::resqml2__KDirection kDirectionKind, bool isRightHanded,
 	const std::string & parameters, const std::string & controlPoints, const std::string & controlPointParameters, unsigned int controlPointCountPerPillar, short pillarKind, COMMON_NS::AbstractHdfProxy* proxy,
 	unsigned long splitCoordinateLineCount, const std::string & pillarOfCoordinateLine,
-	const std::string &  splitCoordinateLineColumnCumulativeCount, const std::string & splitCoordinateLineColumns, RESQML2_NS::AbstractLocal3dCrs const * localCrs)
+	const std::string &  splitCoordinateLineColumnCumulativeCount, const std::string & splitCoordinateLineColumns, RESQML2_NS::AbstractLocal3dCrs * localCrs)
 {
 	if (controlPointCountPerPillar < 1) {
 		throw invalid_argument("The max count of control points per coordinate line of the ijk grid cannot be less than one.");

--- a/src/resqml2_0_1/IjkGridParametricRepresentation.h
+++ b/src/resqml2_0_1/IjkGridParametricRepresentation.h
@@ -232,7 +232,7 @@ namespace RESQML2_0_1_NS
 		DLL_IMPORT_OR_EXPORT void setGeometryAsParametricNonSplittedPillarNodes(
 			gsoap_resqml2_0_1::resqml2__PillarShape mostComplexPillarGeometry, bool isRightHanded,
 			double * parameters, double * controlPoints, double * controlPointParameters, unsigned int controlPointMaxCountPerPillar, short * pillarKind,
-			COMMON_NS::AbstractHdfProxy* proxy = nullptr, RESQML2_NS::AbstractLocal3dCrs const * localCrs = nullptr);
+			COMMON_NS::AbstractHdfProxy* proxy = nullptr, RESQML2_NS::AbstractLocal3dCrs * localCrs = nullptr);
 
 		/**
 		* Same as setGeometryAsParametricNonSplittedPillarNodes where the hdf datasets are already written in the the file.
@@ -241,7 +241,7 @@ namespace RESQML2_0_1_NS
 		DLL_IMPORT_OR_EXPORT void setGeometryAsParametricNonSplittedPillarNodesUsingExistingDatasets(
 			gsoap_resqml2_0_1::resqml2__PillarShape mostComplexPillarGeometry, gsoap_resqml2_0_1::resqml2__KDirection kDirectionKind, bool isRightHanded,
 			const std::string & parameters, const std::string & controlPoints, const std::string & controlPointParameters, unsigned int controlPointMaxCountPerPillar, const std::string & pillarKind, const std::string & definedPillars,
-			COMMON_NS::AbstractHdfProxy* proxy = nullptr, RESQML2_NS::AbstractLocal3dCrs const * localCrs = nullptr);
+			COMMON_NS::AbstractHdfProxy* proxy = nullptr, RESQML2_NS::AbstractLocal3dCrs * localCrs = nullptr);
 
 		/**
 		* Set the geometry of the IJK grid as parametric pillar nodes where at least one pillar is supposed to be splitted
@@ -263,7 +263,7 @@ namespace RESQML2_0_1_NS
 			gsoap_resqml2_0_1::resqml2__PillarShape mostComplexPillarGeometry, bool isRightHanded,
 			double * parameters, double * controlPoints, double * controlPointParameters, unsigned int controlPointMaxCountPerPillar, short * pillarKind, COMMON_NS::AbstractHdfProxy* proxy,
 			unsigned long splitCoordinateLineCount, unsigned int * pillarOfCoordinateLine,
-			unsigned int * splitCoordinateLineColumnCumulativeCount, unsigned int * splitCoordinateLineColumns, RESQML2_NS::AbstractLocal3dCrs const * localCrs = nullptr);
+			unsigned int * splitCoordinateLineColumnCumulativeCount, unsigned int * splitCoordinateLineColumns, RESQML2_NS::AbstractLocal3dCrs * localCrs = nullptr);
 
 		/**
 		* Same as setGeometryAsParametricSplittedPillarNodes where the hdf datasets are already written in the the file.
@@ -273,7 +273,7 @@ namespace RESQML2_0_1_NS
 			gsoap_resqml2_0_1::resqml2__PillarShape mostComplexPillarGeometry, gsoap_resqml2_0_1::resqml2__KDirection kDirectionKind, bool isRightHanded,
 			const std::string & parameters, const std::string & controlPoints, const std::string & controlPointParameters, unsigned int controlPointMaxCountPerPillar, const std::string & pillarKind, const std::string & definedPillars, COMMON_NS::AbstractHdfProxy* proxy,
 			unsigned long splitCoordinateLineCount, const std::string & pillarOfCoordinateLine,
-			const std::string & splitCoordinateLineColumnCumulativeCount, const std::string & splitCoordinateLineColumns, RESQML2_NS::AbstractLocal3dCrs const * localCrs = nullptr);
+			const std::string & splitCoordinateLineColumnCumulativeCount, const std::string & splitCoordinateLineColumns, RESQML2_NS::AbstractLocal3dCrs * localCrs = nullptr);
 
 		/**
 		* Set the geometry of the IJK grid as parametric pillar nodes where at least one pillar is supposed to be splitted and where all pillars are of the same kind.
@@ -293,7 +293,7 @@ namespace RESQML2_0_1_NS
 		DLL_IMPORT_OR_EXPORT void setGeometryAsParametricSplittedPillarNodes(bool isRightHanded,
 			double * parameters, double * controlPoints, double * controlPointParameters, unsigned int controlPointCountPerPillar, short pillarKind, COMMON_NS::AbstractHdfProxy* proxy,
 			unsigned long splitCoordinateLineCount, unsigned int * pillarOfCoordinateLine,
-			unsigned int * splitCoordinateLineColumnCumulativeCount, unsigned int * splitCoordinateLineColumns, RESQML2_NS::AbstractLocal3dCrs const * localCrs = nullptr);
+			unsigned int * splitCoordinateLineColumnCumulativeCount, unsigned int * splitCoordinateLineColumns, RESQML2_NS::AbstractLocal3dCrs * localCrs = nullptr);
 
 		/**
 		* Same as setGeometryAsParametricSplittedPillarNodes where the hdf datasets are already written in the the file.
@@ -302,7 +302,7 @@ namespace RESQML2_0_1_NS
 			gsoap_resqml2_0_1::resqml2__KDirection kDirectionKind, bool isRightHanded,
 			const std::string & parameters, const std::string & controlPoints, const std::string & controlPointParameters, unsigned int controlPointCountPerPillar, short pillarKind, COMMON_NS::AbstractHdfProxy* proxy,
 			unsigned long splitCoordinateLineCount, const std::string & pillarOfCoordinateLine,
-			const std::string & splitCoordinateLineColumnCumulativeCount, const std::string & splitCoordinateLineColumns, RESQML2_NS::AbstractLocal3dCrs const * localCrs = nullptr);
+			const std::string & splitCoordinateLineColumnCumulativeCount, const std::string & splitCoordinateLineColumns, RESQML2_NS::AbstractLocal3dCrs * localCrs = nullptr);
 
 		/**
 		* Check wether the node geometry dataset is compressed or not.

--- a/src/resqml2_0_1/PolylineRepresentation.cpp
+++ b/src/resqml2_0_1/PolylineRepresentation.cpp
@@ -152,7 +152,7 @@ bool PolylineRepresentation::isASeismicLine() const
 	// A Seismic line is defined by an PolylineRepresentation that has a feature of type SeismicLineFeature and that
 	// has at least one continuous property (amplitude).
 	bool atLeastOneContProp = false;
-	vector<RESQML2_NS::AbstractValuesProperty const *> allValuesProperty = getValuesPropertySet();
+	vector<RESQML2_NS::AbstractValuesProperty *> allValuesProperty = getValuesPropertySet();
     for (unsigned int propIndex = 0; propIndex < allValuesProperty.size(); ++propIndex)
     {
         if (allValuesProperty[propIndex]->getGsoapType() == SOAP_TYPE_gsoap_resqml2_0_1_resqml2__obj_USCOREContinuousProperty)
@@ -173,7 +173,7 @@ bool PolylineRepresentation::isAFaciesLine() const
 	// A Facies line is defined by an PolylineRepresentation that has a feature of type SeismicLineFeature and that
 	// has at least one categorical property (facies).
 	bool atLeastOneCateProp = false;
-	vector<RESQML2_NS::AbstractValuesProperty const *> allValuesProperty = getValuesPropertySet();
+	vector<RESQML2_NS::AbstractValuesProperty *> allValuesProperty = getValuesPropertySet();
     for (unsigned int propIndex = 0; propIndex < allValuesProperty.size(); ++propIndex)
     {
         if (allValuesProperty[propIndex]->getGsoapType() == SOAP_TYPE_gsoap_resqml2_0_1_resqml2__obj_USCORECategoricalProperty)

--- a/src/resqml2_0_1/RockFluidOrganizationInterpretation.cpp
+++ b/src/resqml2_0_1/RockFluidOrganizationInterpretation.cpp
@@ -53,7 +53,7 @@ RockFluidOrganizationInterpretation::RockFluidOrganizationInterpretation(Organiz
 	setInterpretedFeature(orgFeat);
 }
 
-std::vector<RESQML2_NS::AbstractGridRepresentation const *> RockFluidOrganizationInterpretation::getGridRepresentationSet() const
+std::vector<RESQML2_NS::AbstractGridRepresentation *> RockFluidOrganizationInterpretation::getGridRepresentationSet() const
 {
 	return getRepository()->getSourceObjects<RESQML2_NS::AbstractGridRepresentation>(this);
 }
@@ -68,9 +68,9 @@ unsigned int RockFluidOrganizationInterpretation::getGridRepresentationCount() c
 	return static_cast<unsigned int>(count);
 }
 
-RESQML2_NS::AbstractGridRepresentation const * RockFluidOrganizationInterpretation::getGridRepresentation(unsigned int index) const
+RESQML2_NS::AbstractGridRepresentation * RockFluidOrganizationInterpretation::getGridRepresentation(unsigned int index) const
 {
-	const std::vector<RESQML2_NS::AbstractGridRepresentation const *>& gridRepresentationSet = getGridRepresentationSet();
+	const std::vector<RESQML2_NS::AbstractGridRepresentation *>& gridRepresentationSet = getGridRepresentationSet();
 
 	if (index >= gridRepresentationSet.size()) {
 		throw range_error("The index of the grid representation to get is out of range.");
@@ -81,7 +81,7 @@ RESQML2_NS::AbstractGridRepresentation const * RockFluidOrganizationInterpretati
 
 bool RockFluidOrganizationInterpretation::isAssociatedToGridRepresentation(RESQML2_NS::AbstractGridRepresentation* gridRep) const
 {
-	const std::vector<RESQML2_NS::AbstractGridRepresentation const *>& gridRepresentationSet = getGridRepresentationSet();
+	const std::vector<RESQML2_NS::AbstractGridRepresentation *>& gridRepresentationSet = getGridRepresentationSet();
 	return find(gridRepresentationSet.begin(), gridRepresentationSet.end(), gridRep) != gridRepresentationSet.end();
 }
 
@@ -109,7 +109,7 @@ RockFluidUnitInterpretation* RockFluidOrganizationInterpretation::getRockFluidUn
 	return repository->getDataObjectByUuid<RockFluidUnitInterpretation>(static_cast<_resqml2__RockFluidOrganizationInterpretation*>(gsoapProxy2_0_1)->RockFluidUnitIndex->RockFluidUnit->UUID);
 }
 
-void RockFluidOrganizationInterpretation::loadTargetRelationships() const
+void RockFluidOrganizationInterpretation::loadTargetRelationships()
 {
 	AbstractOrganizationInterpretation::loadTargetRelationships();
 

--- a/src/resqml2_0_1/RockFluidOrganizationInterpretation.h
+++ b/src/resqml2_0_1/RockFluidOrganizationInterpretation.h
@@ -59,7 +59,7 @@ namespace RESQML2_0_1_NS
 		*/
 		~RockFluidOrganizationInterpretation() {}
 		
-		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_NS::AbstractGridRepresentation const *> getGridRepresentationSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_NS::AbstractGridRepresentation *> getGridRepresentationSet() const;
 
 		/**
 		* @return The count of grid representation associated to this rock fluid organization.
@@ -70,7 +70,7 @@ namespace RESQML2_0_1_NS
 		* Get a grid representation associated to this rock fluid org interp by means of its index.
 		* @param index	The index of the grid representation to get in the array of grid representaitons of this rock fluid org interp.
 		*/
-		DLL_IMPORT_OR_EXPORT RESQML2_NS::AbstractGridRepresentation const * getGridRepresentation(unsigned int index) const;
+		DLL_IMPORT_OR_EXPORT RESQML2_NS::AbstractGridRepresentation * getGridRepresentation(unsigned int index) const;
 
 		/**
 		* Check if a grid representation is wether associated to this rock fluid org interp or not.
@@ -101,6 +101,6 @@ namespace RESQML2_0_1_NS
 		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
 	private:
-		void loadTargetRelationships() const;
+		void loadTargetRelationships();
 	};
 }

--- a/src/resqml2_0_1/RockFluidUnitFeature.cpp
+++ b/src/resqml2_0_1/RockFluidUnitFeature.cpp
@@ -67,7 +67,7 @@ BoundaryFeature* RockFluidUnitFeature::getBottom() const
 	return repository->getDataObjectByUuid<BoundaryFeature>(static_cast<_resqml2__RockFluidUnitFeature*>(gsoapProxy2_0_1)->FluidBoundaryBottom->UUID);
 }
 
-void RockFluidUnitFeature::loadTargetRelationships() const
+void RockFluidUnitFeature::loadTargetRelationships()
 {
 	GeologicUnitFeature::loadTargetRelationships();
 

--- a/src/resqml2_0_1/RockFluidUnitFeature.h
+++ b/src/resqml2_0_1/RockFluidUnitFeature.h
@@ -60,6 +60,6 @@ namespace RESQML2_0_1_NS
 		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
 	private:
-		void loadTargetRelationships() const;
+		void loadTargetRelationships();
 	};
 }

--- a/src/resqml2_0_1/SealedVolumeFrameworkRepresentation.cpp
+++ b/src/resqml2_0_1/SealedVolumeFrameworkRepresentation.cpp
@@ -300,7 +300,7 @@ bool SealedVolumeFrameworkRepresentation::getSideFlagOfInternalShellFace(unsigne
 	return getRegionInternalShellFace(regionIndex, internalShellIndex, faceIndex)->SideIsPlus;
 }
 
-void SealedVolumeFrameworkRepresentation::loadTargetRelationships() const
+void SealedVolumeFrameworkRepresentation::loadTargetRelationships()
 {
 	RESQML2_NS::RepresentationSetRepresentation::loadTargetRelationships();
 

--- a/src/resqml2_0_1/SealedVolumeFrameworkRepresentation.h
+++ b/src/resqml2_0_1/SealedVolumeFrameworkRepresentation.h
@@ -220,7 +220,7 @@ namespace RESQML2_0_1_NS
 		gsoap_resqml2_0_1::eml20__DataObjectReference* getStratiUnitInterpDor(unsigned int regionIndex) const;
 		std::string getStratiUnitInterpUuid(unsigned int regionIndex) const;
 
-		void loadTargetRelationships() const;
+		void loadTargetRelationships();
 
 		void setXmlSealedSurfaceFramework(class SealedSurfaceFrameworkRepresentation* ssf);
 		void setXmlInterpretationOfVolumeRegion(unsigned int regionIndex, class StratigraphicUnitInterpretation * stratiUnitInterp);

--- a/src/resqml2_0_1/SeismicLineFeature.cpp
+++ b/src/resqml2_0_1/SeismicLineFeature.cpp
@@ -75,7 +75,7 @@ SeismicLineSetFeature* SeismicLineFeature::getSeismicLineSet() const
 	return seismicLine->IsPartOf == nullptr ? nullptr : getRepository()->getDataObjectByUuid<SeismicLineSetFeature>(seismicLine->IsPartOf->UUID);
 }
 
-void SeismicLineFeature::loadTargetRelationships() const
+void SeismicLineFeature::loadTargetRelationships()
 {
 	_resqml2__SeismicLineFeature* seismicLine = static_cast<_resqml2__SeismicLineFeature*>(gsoapProxy2_0_1);
 

--- a/src/resqml2_0_1/SeismicLineFeature.h
+++ b/src/resqml2_0_1/SeismicLineFeature.h
@@ -79,6 +79,6 @@ namespace RESQML2_0_1_NS
 		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
 	private:
-		void loadTargetRelationships() const;
+		void loadTargetRelationships();
 	};
 }

--- a/src/resqml2_0_1/StratigraphicColumn.cpp
+++ b/src/resqml2_0_1/StratigraphicColumn.cpp
@@ -40,19 +40,19 @@ StratigraphicColumn::StratigraphicColumn(COMMON_NS::DataObjectRepository* repo, 
 	repo->addOrReplaceDataObject(this);
 }
 
-void StratigraphicColumn::pushBackStratiColumnRank(StratigraphicColumnRankInterpretation const * stratiColumnRank)
+void StratigraphicColumn::pushBackStratiColumnRank(StratigraphicColumnRankInterpretation * stratiColumnRank)
 {
 	getRepository()->addRelationship(this, stratiColumnRank);
 
 	static_cast<_resqml2__StratigraphicColumn*>(gsoapProxy2_0_1)->Ranks.push_back(stratiColumnRank->newResqmlReference());
 }
 
-std::vector<class StratigraphicColumnRankInterpretation const *> StratigraphicColumn::getStratigraphicColumnRankInterpretationSet() const
+std::vector<class StratigraphicColumnRankInterpretation *> StratigraphicColumn::getStratigraphicColumnRankInterpretationSet() const
 {
 	return getRepository()->getSourceObjects<StratigraphicColumnRankInterpretation>(this);
 }
 
-void StratigraphicColumn::loadTargetRelationships() const
+void StratigraphicColumn::loadTargetRelationships()
 {
 	const std::vector<eml20__DataObjectReference *>& stratColRanks= static_cast<_resqml2__StratigraphicColumn*>(gsoapProxy2_0_1)->Ranks;
 	for (size_t i = 0; i < stratColRanks.size(); ++i) {

--- a/src/resqml2_0_1/StratigraphicColumn.h
+++ b/src/resqml2_0_1/StratigraphicColumn.h
@@ -53,17 +53,17 @@ namespace RESQML2_0_1_NS
 		*/
 		~StratigraphicColumn() {}
 
-		DLL_IMPORT_OR_EXPORT void pushBackStratiColumnRank(class StratigraphicColumnRankInterpretation const * stratiColumnRank);
+		DLL_IMPORT_OR_EXPORT void pushBackStratiColumnRank(class StratigraphicColumnRankInterpretation * stratiColumnRank);
 
 		/**
 		 * Get all the stratigraphic column rank interpretations which are contained in this stratigraphic column.
 		 */
-		DLL_IMPORT_OR_EXPORT std::vector<class StratigraphicColumnRankInterpretation const *> getStratigraphicColumnRankInterpretationSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<class StratigraphicColumnRankInterpretation *> getStratigraphicColumnRankInterpretationSet() const;
                 
 		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
 		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
     private:
-		void loadTargetRelationships() const;
+		void loadTargetRelationships();
 	};
 }

--- a/src/resqml2_0_1/StratigraphicColumnRankInterpretation.cpp
+++ b/src/resqml2_0_1/StratigraphicColumnRankInterpretation.cpp
@@ -159,7 +159,7 @@ void StratigraphicColumnRankInterpretation::pushBackStratigraphicBinaryContact(S
 	}
 }
 		
-void StratigraphicColumnRankInterpretation::loadTargetRelationships() const
+void StratigraphicColumnRankInterpretation::loadTargetRelationships()
 {
 	AbstractStratigraphicOrganizationInterpretation::loadTargetRelationships();
 
@@ -180,22 +180,22 @@ void StratigraphicColumnRankInterpretation::loadTargetRelationships() const
 	}
 }
 
-std::vector<StratigraphicUnitInterpretation const *> StratigraphicColumnRankInterpretation::getStratigraphicUnitInterpretationSet() const
+std::vector<StratigraphicUnitInterpretation *> StratigraphicColumnRankInterpretation::getStratigraphicUnitInterpretationSet() const
 {
 	return getRepository()->getTargetObjects<StratigraphicUnitInterpretation>(this);
 }
 
-std::vector<StratigraphicOccurrenceInterpretation const *> StratigraphicColumnRankInterpretation::getStratigraphicOccurrenceInterpretationSet() const
+std::vector<StratigraphicOccurrenceInterpretation *> StratigraphicColumnRankInterpretation::getStratigraphicOccurrenceInterpretationSet() const
 {
 	return getRepository()->getSourceObjects<StratigraphicOccurrenceInterpretation>(this);
 }
 
-std::vector<HorizonInterpretation const *> StratigraphicColumnRankInterpretation::getHorizonInterpretationSet() const
+std::vector<HorizonInterpretation *> StratigraphicColumnRankInterpretation::getHorizonInterpretationSet() const
 {
 	return getRepository()->getTargetObjects<HorizonInterpretation>(this);
 }
 
-std::vector<StratigraphicColumn const *> StratigraphicColumnRankInterpretation::getStratigraphicColumnSet() const
+std::vector<StratigraphicColumn *> StratigraphicColumnRankInterpretation::getStratigraphicColumnSet() const
 {
 	return getRepository()->getSourceObjects<StratigraphicColumn>(this);
 }

--- a/src/resqml2_0_1/StratigraphicColumnRankInterpretation.h
+++ b/src/resqml2_0_1/StratigraphicColumnRankInterpretation.h
@@ -115,27 +115,27 @@ namespace RESQML2_0_1_NS
 		/**
 		* Get all the stratigraphic unit interpretations contained in this StratigraphicColumnRankInterpretation.
 		*/
-		DLL_IMPORT_OR_EXPORT std::vector<class StratigraphicUnitInterpretation const *> getStratigraphicUnitInterpretationSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<class StratigraphicUnitInterpretation *> getStratigraphicUnitInterpretationSet() const;
 
 		/**
 		* Get all the stratigraphic occurence interpretations associated with this StratigraphicColumnRankInterpretation.
 		*/
-		DLL_IMPORT_OR_EXPORT std::vector<class StratigraphicOccurrenceInterpretation const *> getStratigraphicOccurrenceInterpretationSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<class StratigraphicOccurrenceInterpretation *> getStratigraphicOccurrenceInterpretationSet() const;
 
 		/**
 		* Get all the horizon interpretations contained in this StratigraphicColumnRankInterpretation.
 		*/
-		DLL_IMPORT_OR_EXPORT std::vector<class HorizonInterpretation const *> getHorizonInterpretationSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<class HorizonInterpretation *> getHorizonInterpretationSet() const;
 
 		/**
 		* Get all the stratigraphic column this strati column rank belongs to.
 		*/
-		DLL_IMPORT_OR_EXPORT std::vector<StratigraphicColumn const *> getStratigraphicColumnSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<StratigraphicColumn *> getStratigraphicColumnSet() const;
 
 		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
 		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
 	private:
-		void loadTargetRelationships() const;
+		void loadTargetRelationships();
 	};
 }

--- a/src/resqml2_0_1/StratigraphicOccurrenceInterpretation.cpp
+++ b/src/resqml2_0_1/StratigraphicOccurrenceInterpretation.cpp
@@ -66,12 +66,12 @@ std::string StratigraphicOccurrenceInterpretation::getStratigraphicColumnRankInt
 	return static_cast<_resqml2__StratigraphicOccurrenceInterpretation*>(gsoapProxy2_0_1)->IsOccurrenceOf->UUID;
 }
 
-std::vector<class WellboreMarkerFrameRepresentation const *> StratigraphicOccurrenceInterpretation::getWellboreMarkerFrameRepresentationSet() const
+std::vector<class WellboreMarkerFrameRepresentation *> StratigraphicOccurrenceInterpretation::getWellboreMarkerFrameRepresentationSet() const
 {
 	return getRepository()->getSourceObjects<WellboreMarkerFrameRepresentation>(this);
 }
 	
-void StratigraphicOccurrenceInterpretation::loadTargetRelationships() const
+void StratigraphicOccurrenceInterpretation::loadTargetRelationships()
 {
 	AbstractStratigraphicOrganizationInterpretation::loadTargetRelationships();
 

--- a/src/resqml2_0_1/StratigraphicOccurrenceInterpretation.h
+++ b/src/resqml2_0_1/StratigraphicOccurrenceInterpretation.h
@@ -61,7 +61,7 @@ namespace RESQML2_0_1_NS
 		/**
 		* Get all the stratigraphic occurence interpretations associated with this StratigraphicColumnRankInterpretation.
 		*/
-		DLL_IMPORT_OR_EXPORT std::vector<class WellboreMarkerFrameRepresentation const *> getWellboreMarkerFrameRepresentationSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<class WellboreMarkerFrameRepresentation *> getWellboreMarkerFrameRepresentationSet() const;
 
 		DLL_IMPORT_OR_EXPORT std::string getStratigraphicColumnRankInterpretationUuid() const;
                 
@@ -69,6 +69,6 @@ namespace RESQML2_0_1_NS
 		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
 	private:
-		void loadTargetRelationships() const;
+		void loadTargetRelationships();
 	};
 }

--- a/src/resqml2_0_1/StringTableLookup.cpp
+++ b/src/resqml2_0_1/StringTableLookup.cpp
@@ -157,4 +157,4 @@ unordered_map<long, string> StringTableLookup::getMap() const
 	return result;
 }
 
-void StringTableLookup::loadTargetRelationships() const {}
+void StringTableLookup::loadTargetRelationships() {}

--- a/src/resqml2_0_1/StringTableLookup.h
+++ b/src/resqml2_0_1/StringTableLookup.h
@@ -113,6 +113,6 @@ namespace RESQML2_0_1_NS
 		DLL_IMPORT_OR_EXPORT std::unordered_map<long, std::string> getMap() const;
 
 	protected:
-		void loadTargetRelationships() const;
+		void loadTargetRelationships();
 	};
 }

--- a/src/resqml2_0_1/StructuralOrganizationInterpretation.cpp
+++ b/src/resqml2_0_1/StructuralOrganizationInterpretation.cpp
@@ -215,7 +215,7 @@ RESQML2_NS::AbstractFeatureInterpretation* StructuralOrganizationInterpretation:
 	}
 }
 		
-void StructuralOrganizationInterpretation::loadTargetRelationships() const
+void StructuralOrganizationInterpretation::loadTargetRelationships()
 {
 	AbstractOrganizationInterpretation::loadTargetRelationships();
 

--- a/src/resqml2_0_1/StructuralOrganizationInterpretation.h
+++ b/src/resqml2_0_1/StructuralOrganizationInterpretation.h
@@ -107,6 +107,6 @@ namespace RESQML2_0_1_NS
 		DLL_IMPORT_OR_EXPORT AbstractFeatureInterpretation* getSideFrontierInterpretation(unsigned int index) const;
 
     private:	
-		void loadTargetRelationships() const;
+		void loadTargetRelationships();
 	};
 }

--- a/src/resqml2_0_1/UnstructuredGridRepresentation.cpp
+++ b/src/resqml2_0_1/UnstructuredGridRepresentation.cpp
@@ -391,7 +391,7 @@ void UnstructuredGridRepresentation::getCellFaceIsRightHanded(unsigned char* cel
 void UnstructuredGridRepresentation::setGeometryUsingExistingDatasets(const std::string& cellFaceIsRightHanded, const std::string& points, ULONG64 pointCount, COMMON_NS::AbstractHdfProxy* proxy,
 	const std::string& faceIndicesPerCell, const std::string&faceIndicesCumulativeCountPerCell,
 	ULONG64 faceCount, const std::string& nodeIndicesPerFace, const std::string& nodeIndicesCumulativeCountPerFace,
-	gsoap_resqml2_0_1::resqml2__CellShape cellShape, RESQML2_NS::AbstractLocal3dCrs const * localCrs)
+	gsoap_resqml2_0_1::resqml2__CellShape cellShape, RESQML2_NS::AbstractLocal3dCrs * localCrs)
 {
 	if (cellFaceIsRightHanded.empty())
 		throw invalid_argument("The cellFaceIsRightHanded dataset path information cannot be empty.");
@@ -479,7 +479,7 @@ void UnstructuredGridRepresentation::setGeometryUsingExistingDatasets(const std:
 void UnstructuredGridRepresentation::setGeometry(unsigned char * cellFaceIsRightHanded, double * points, ULONG64 pointCount, COMMON_NS::AbstractHdfProxy * proxy,
 	ULONG64 * faceIndicesPerCell, ULONG64 * faceIndicesCumulativeCountPerCell,
 	ULONG64 faceCount, ULONG64 * nodeIndicesPerFace, ULONG64 * nodeIndicesCumulativeCountPerFace,
-	gsoap_resqml2_0_1::resqml2__CellShape cellShape, RESQML2_NS::AbstractLocal3dCrs const * localCrs)
+	gsoap_resqml2_0_1::resqml2__CellShape cellShape, RESQML2_NS::AbstractLocal3dCrs * localCrs)
 {
 	if (cellFaceIsRightHanded == nullptr)
 		throw invalid_argument("The cellFaceIsRightHanded information cannot be null.");
@@ -520,7 +520,7 @@ void UnstructuredGridRepresentation::setGeometry(unsigned char * cellFaceIsRight
 }
 
 void UnstructuredGridRepresentation::setConstantCellShapeGeometryUsingExistingDatasets(const std::string& cellFaceIsRightHanded, const std::string& points,
-	ULONG64 pointCount, ULONG64 faceCount, RESQML2_NS::AbstractLocal3dCrs const * localCrs, COMMON_NS::AbstractHdfProxy* proxy,
+	ULONG64 pointCount, ULONG64 faceCount, RESQML2_NS::AbstractLocal3dCrs * localCrs, COMMON_NS::AbstractHdfProxy* proxy,
 	const std::string& faceIndicesPerCell, ULONG64 faceCountPerCell,
 	const std::string& nodeIndicesPerFace, ULONG64 nodeCountPerFace)
 {
@@ -624,7 +624,7 @@ void UnstructuredGridRepresentation::setConstantCellShapeGeometryUsingExistingDa
 }
 
 void UnstructuredGridRepresentation::setConstantCellShapeGeometry(unsigned char * cellFaceIsRightHanded, double * points,
-	ULONG64 pointCount, ULONG64 faceCount, RESQML2_NS::AbstractLocal3dCrs const * localCrs, COMMON_NS::AbstractHdfProxy* proxy,
+	ULONG64 pointCount, ULONG64 faceCount, RESQML2_NS::AbstractLocal3dCrs * localCrs, COMMON_NS::AbstractHdfProxy* proxy,
 	ULONG64 * faceIndicesPerCell, ULONG64 faceCountPerCell,
 	ULONG64 * nodeIndicesPerFace, ULONG64 nodeCountPerFace)
 {
@@ -675,7 +675,7 @@ void UnstructuredGridRepresentation::setConstantCellShapeGeometry(unsigned char 
 
 void UnstructuredGridRepresentation::setTetrahedraOnlyGeometryUsingExistingDatasets(const std::string& cellFaceIsRightHanded, const std::string& points,
 	ULONG64 pointCount, ULONG64 faceCount, COMMON_NS::AbstractHdfProxy* proxy,
-	const std::string& faceIndicesPerCell, const std::string& nodeIndicesPerFace, RESQML2_NS::AbstractLocal3dCrs const * localCrs)
+	const std::string& faceIndicesPerCell, const std::string& nodeIndicesPerFace, RESQML2_NS::AbstractLocal3dCrs * localCrs)
 {
 	setConstantCellShapeGeometryUsingExistingDatasets(cellFaceIsRightHanded, points,
 		pointCount, faceCount, localCrs, proxy,
@@ -684,7 +684,7 @@ void UnstructuredGridRepresentation::setTetrahedraOnlyGeometryUsingExistingDatas
 }
 
 void UnstructuredGridRepresentation::setTetrahedraOnlyGeometry(unsigned char * cellFaceIsRightHanded, double * points, ULONG64 pointCount, ULONG64 faceCount, COMMON_NS::AbstractHdfProxy * proxy,
-	ULONG64 * faceIndicesPerCell, ULONG64 * nodeIndicesPerFace, RESQML2_NS::AbstractLocal3dCrs const * localCrs)
+	ULONG64 * faceIndicesPerCell, ULONG64 * nodeIndicesPerFace, RESQML2_NS::AbstractLocal3dCrs * localCrs)
 {
 	setConstantCellShapeGeometry(cellFaceIsRightHanded, points,
 		pointCount, faceCount, localCrs, proxy,
@@ -694,7 +694,7 @@ void UnstructuredGridRepresentation::setTetrahedraOnlyGeometry(unsigned char * c
 
 void UnstructuredGridRepresentation::setHexahedraOnlyGeometryUsingExistingDatasets(const std::string& cellFaceIsRightHanded, const std::string& points,
 	ULONG64 pointCount, ULONG64 faceCount, COMMON_NS::AbstractHdfProxy* proxy,
-	const std::string& faceIndicesPerCell, const std::string& nodeIndicesPerFace, RESQML2_NS::AbstractLocal3dCrs const * localCrs)
+	const std::string& faceIndicesPerCell, const std::string& nodeIndicesPerFace, RESQML2_NS::AbstractLocal3dCrs * localCrs)
 {
 	setConstantCellShapeGeometryUsingExistingDatasets(cellFaceIsRightHanded, points,
 		pointCount, faceCount, localCrs, proxy,
@@ -703,7 +703,7 @@ void UnstructuredGridRepresentation::setHexahedraOnlyGeometryUsingExistingDatase
 }
 
 void UnstructuredGridRepresentation::setHexahedraOnlyGeometry(unsigned char * cellFaceIsRightHanded, double * points, ULONG64 pointCount, ULONG64 faceCount, COMMON_NS::AbstractHdfProxy * proxy,
-	ULONG64 * faceIndicesPerCell, ULONG64 * nodeIndicesPerFace, RESQML2_NS::AbstractLocal3dCrs const * localCrs)
+	ULONG64 * faceIndicesPerCell, ULONG64 * nodeIndicesPerFace, RESQML2_NS::AbstractLocal3dCrs * localCrs)
 {
 	setConstantCellShapeGeometry(cellFaceIsRightHanded, points,
 		pointCount, faceCount, localCrs, proxy,

--- a/src/resqml2_0_1/UnstructuredGridRepresentation.h
+++ b/src/resqml2_0_1/UnstructuredGridRepresentation.h
@@ -51,7 +51,7 @@ namespace RESQML2_0_1_NS
 		* @param nodeCountPerFace					The constant node count per face.
 		*/
 		void setConstantCellShapeGeometryUsingExistingDatasets(const std::string& cellFaceIsRightHanded, const std::string& points,
-			ULONG64 pointCount, ULONG64 faceCount, RESQML2_NS::AbstractLocal3dCrs const * localCrs, COMMON_NS::AbstractHdfProxy* proxy,
+			ULONG64 pointCount, ULONG64 faceCount, RESQML2_NS::AbstractLocal3dCrs * localCrs, COMMON_NS::AbstractHdfProxy* proxy,
 			const std::string& faceIndicesPerCell, ULONG64 faceCountPerCell,
 			const std::string& nodeIndicesPerFace, ULONG64 nodeCountPerFace);
 
@@ -68,7 +68,7 @@ namespace RESQML2_0_1_NS
 		* @param nodeCountPerFace					The constant node count per face.
 		*/
 		void setConstantCellShapeGeometry(unsigned char * cellFaceIsRightHanded, double * points,
-			ULONG64 pointCount, ULONG64 faceCount, RESQML2_NS::AbstractLocal3dCrs const * localCrs, COMMON_NS::AbstractHdfProxy* proxy,
+			ULONG64 pointCount, ULONG64 faceCount, RESQML2_NS::AbstractLocal3dCrs * localCrs, COMMON_NS::AbstractHdfProxy* proxy,
 			ULONG64 * faceIndicesPerCell, ULONG64 faceCountPerCell,
 			ULONG64 * nodeIndicesPerFace, ULONG64 nodeCountPerFace);
 
@@ -265,7 +265,7 @@ namespace RESQML2_0_1_NS
 		DLL_IMPORT_OR_EXPORT void setGeometryUsingExistingDatasets(const std::string& cellFaceIsRightHanded, const std::string& points, ULONG64 pointCount, COMMON_NS::AbstractHdfProxy* proxy,
 			const std::string& faceIndicesPerCell, const std::string& faceIndicesCumulativeCountPerCell,
 			ULONG64 faceCount, const std::string& nodeIndicesPerFace, const std::string& nodeIndicesCumulativeCountPerFace,
-			gsoap_resqml2_0_1::resqml2__CellShape cellShape, RESQML2_NS::AbstractLocal3dCrs const * localCrs = nullptr);
+			gsoap_resqml2_0_1::resqml2__CellShape cellShape, RESQML2_NS::AbstractLocal3dCrs * localCrs = nullptr);
 
 		/**
 		 * Set the geometry and creates corresponding HDF5 datasets.
@@ -283,7 +283,7 @@ namespace RESQML2_0_1_NS
 		DLL_IMPORT_OR_EXPORT void setGeometry(unsigned char * cellFaceIsRightHanded, double * points, ULONG64 pointCount, COMMON_NS::AbstractHdfProxy* proxy,
 			ULONG64 * faceIndicesPerCell, ULONG64 * faceIndicesCumulativeCountPerCell,
 			ULONG64 faceCount, ULONG64 * nodeIndicesPerFace, ULONG64 * nodeIndicesCumulativeCountPerFace,
-			gsoap_resqml2_0_1::resqml2__CellShape cellShape, RESQML2_NS::AbstractLocal3dCrs const * localCrs = nullptr);
+			gsoap_resqml2_0_1::resqml2__CellShape cellShape, RESQML2_NS::AbstractLocal3dCrs * localCrs = nullptr);
 
 		/**
 		* Set a geometry which is only defined by means of tetrahedra using some existing hdf5 dataset. This geometry only contains tetrahedra.
@@ -297,7 +297,7 @@ namespace RESQML2_0_1_NS
 		*/
 		DLL_IMPORT_OR_EXPORT void setTetrahedraOnlyGeometryUsingExistingDatasets(const std::string& cellFaceIsRightHanded, const std::string& points,
 			ULONG64 pointCount, ULONG64 faceCount, COMMON_NS::AbstractHdfProxy* proxy,
-			const std::string& faceIndicesPerCell, const std::string& nodeIndicesPerFace, RESQML2_NS::AbstractLocal3dCrs const * localCrs = nullptr);
+			const std::string& faceIndicesPerCell, const std::string& nodeIndicesPerFace, RESQML2_NS::AbstractLocal3dCrs * localCrs = nullptr);
 
 		/**
 		* Set a geometry which is only defined by means of tetrahedra and creates corresponding HDF5 datasets. This geometry only contains tetrahedra.
@@ -311,7 +311,7 @@ namespace RESQML2_0_1_NS
 		*/
 		DLL_IMPORT_OR_EXPORT void setTetrahedraOnlyGeometry(unsigned char * cellFaceIsRightHanded, double * points,
 			ULONG64 pointCount, ULONG64 faceCount, COMMON_NS::AbstractHdfProxy* proxy,
-			ULONG64 * faceIndicesPerCell, ULONG64 * nodeIndicesPerFace, RESQML2_NS::AbstractLocal3dCrs const * localCrs = nullptr);
+			ULONG64 * faceIndicesPerCell, ULONG64 * nodeIndicesPerFace, RESQML2_NS::AbstractLocal3dCrs * localCrs = nullptr);
 
 		/**
 		* Set a geometry which is only defined by means of tetrahedra using some existing hdf5 dataset. This geometry only contains hexahedra.
@@ -325,7 +325,7 @@ namespace RESQML2_0_1_NS
 		*/
 		DLL_IMPORT_OR_EXPORT void setHexahedraOnlyGeometryUsingExistingDatasets(const std::string& cellFaceIsRightHanded, const std::string& points,
 			ULONG64 pointCount, ULONG64 faceCount, COMMON_NS::AbstractHdfProxy* proxy,
-			const std::string& faceIndicesPerCell, const std::string& nodeIndicesPerFace, RESQML2_NS::AbstractLocal3dCrs const * localCrs = nullptr);
+			const std::string& faceIndicesPerCell, const std::string& nodeIndicesPerFace, RESQML2_NS::AbstractLocal3dCrs * localCrs = nullptr);
 
 		/**
 		* Set a geometry which is only defined by means of tetrahedra and creates corresponding HDF5 datasets. This geometry only contains hexahedra.
@@ -339,7 +339,7 @@ namespace RESQML2_0_1_NS
 		*/
 		DLL_IMPORT_OR_EXPORT void setHexahedraOnlyGeometry(unsigned char * cellFaceIsRightHanded, double * points,
 			ULONG64 pointCount, ULONG64 faceCount, COMMON_NS::AbstractHdfProxy* proxy,
-			ULONG64 * faceIndicesPerCell, ULONG64 * nodeIndicesPerFace, RESQML2_NS::AbstractLocal3dCrs const * localCrs = nullptr);
+			ULONG64 * faceIndicesPerCell, ULONG64 * nodeIndicesPerFace, RESQML2_NS::AbstractLocal3dCrs * localCrs = nullptr);
 
 		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
 		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}

--- a/src/resqml2_0_1/WellboreFrameRepresentation.cpp
+++ b/src/resqml2_0_1/WellboreFrameRepresentation.cpp
@@ -33,7 +33,7 @@ using namespace gsoap_resqml2_0_1;
 
 const char* WellboreFrameRepresentation::XML_TAG = "WellboreFrameRepresentation";
 
-WellboreFrameRepresentation::WellboreFrameRepresentation(WellboreInterpretation const * interp, const string & guid, const std::string & title, WellboreTrajectoryRepresentation const * traj)
+WellboreFrameRepresentation::WellboreFrameRepresentation(WellboreInterpretation * interp, const string & guid, const std::string & title, WellboreTrajectoryRepresentation * traj)
 {
 	gsoapProxy2_0_1 = soap_new_resqml2__obj_USCOREWellboreFrameRepresentation(interp->getGsoapContext(), 1);	
 	_resqml2__WellboreFrameRepresentation* frame = static_cast<_resqml2__WellboreFrameRepresentation*>(gsoapProxy2_0_1);

--- a/src/resqml2_0_1/WellboreFrameRepresentation.h
+++ b/src/resqml2_0_1/WellboreFrameRepresentation.h
@@ -45,7 +45,7 @@ namespace RESQML2_0_1_NS
 		* @param title		A title for the instance to create.
 		* @param traj		The trajectory this WellboreFeature frame is based on.
 		*/
-		WellboreFrameRepresentation(class WellboreInterpretation const * interp, const std::string & guid, const std::string & title, class WellboreTrajectoryRepresentation const * traj);
+		WellboreFrameRepresentation(class WellboreInterpretation * interp, const std::string & guid, const std::string & title, class WellboreTrajectoryRepresentation * traj);
 
 		/**
 		* Creates an instance of this class by wrapping a gsoap instance.

--- a/src/resqml2_0_1/WellboreInterpretation.cpp
+++ b/src/resqml2_0_1/WellboreInterpretation.cpp
@@ -46,7 +46,7 @@ bool WellboreInterpretation::isDrilled() const
 	return static_cast<_resqml2__WellboreInterpretation*>(gsoapProxy2_0_1)->IsDrilled;
 }
 
-std::vector<WellboreTrajectoryRepresentation const*> WellboreInterpretation::getWellboreTrajectoryRepresentationSet() const
+std::vector<WellboreTrajectoryRepresentation*> WellboreInterpretation::getWellboreTrajectoryRepresentationSet() const
 {
 	return getRepository()->getSourceObjects<WellboreTrajectoryRepresentation>(this);
 }

--- a/src/resqml2_0_1/WellboreInterpretation.h
+++ b/src/resqml2_0_1/WellboreInterpretation.h
@@ -62,7 +62,7 @@ namespace RESQML2_0_1_NS
 		/**
 		* Get all the trajectory representations of this interpretation
 		*/
-		DLL_IMPORT_OR_EXPORT std::vector<class WellboreTrajectoryRepresentation const*> getWellboreTrajectoryRepresentationSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<class WellboreTrajectoryRepresentation *> getWellboreTrajectoryRepresentationSet() const;
 
 		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
 		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}

--- a/src/resqml2_0_1/WellboreMarker.cpp
+++ b/src/resqml2_0_1/WellboreMarker.cpp
@@ -88,11 +88,11 @@ void WellboreMarker::setBoundaryFeatureInterpretation(BoundaryFeatureInterpretat
 	marker->Interpretation = interp->newResqmlReference();
 }
 
-void WellboreMarker::loadTargetRelationships() const
+void WellboreMarker::loadTargetRelationships()
 {}
 
 WellboreMarkerFrameRepresentation const * WellboreMarker::getWellMarkerFrameRepresentation() const
 {
-	const vector<WellboreMarkerFrameRepresentation const *> wmfr = getRepository()->getSourceObjects<WellboreMarkerFrameRepresentation>(this);
+	const vector<WellboreMarkerFrameRepresentation *> wmfr = getRepository()->getSourceObjects<WellboreMarkerFrameRepresentation>(this);
 	return wmfr.size() == 1 ? wmfr[0] : nullptr;
 }

--- a/src/resqml2_0_1/WellboreMarker.h
+++ b/src/resqml2_0_1/WellboreMarker.h
@@ -90,6 +90,6 @@ namespace RESQML2_0_1_NS
 		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
 	private:
-		void loadTargetRelationships() const;
+		void loadTargetRelationships();
 	};
 }

--- a/src/resqml2_0_1/WellboreMarkerFrameRepresentation.cpp
+++ b/src/resqml2_0_1/WellboreMarkerFrameRepresentation.cpp
@@ -42,7 +42,7 @@ using namespace gsoap_resqml2_0_1;
 
 const char* WellboreMarkerFrameRepresentation::XML_TAG = "WellboreMarkerFrameRepresentation";
 
-WellboreMarkerFrameRepresentation::WellboreMarkerFrameRepresentation(WellboreInterpretation const * interp, const std::string & guid, const std::string & title, WellboreTrajectoryRepresentation const * traj)
+WellboreMarkerFrameRepresentation::WellboreMarkerFrameRepresentation(WellboreInterpretation * interp, const std::string & guid, const std::string & title, WellboreTrajectoryRepresentation * traj)
 {
 	gsoapProxy2_0_1 = soap_new_resqml2__obj_USCOREWellboreMarkerFrameRepresentation(interp->getGsoapContext(), 1);	
 	_resqml2__WellboreMarkerFrameRepresentation* frame = static_cast<_resqml2__WellboreMarkerFrameRepresentation*>(gsoapProxy2_0_1);
@@ -116,7 +116,7 @@ void WellboreMarkerFrameRepresentation::setIntervalStratigraphicUnits(unsigned i
 	proxy->writeArrayNd(frame->uuid, "IntervalStratigraphicUnits", H5T_NATIVE_UINT, stratiUnitIndices, &dim, 1);
 }
 
-void WellboreMarkerFrameRepresentation::loadTargetRelationships() const
+void WellboreMarkerFrameRepresentation::loadTargetRelationships()
 {
 	WellboreFrameRepresentation::loadTargetRelationships();
 
@@ -141,7 +141,7 @@ void WellboreMarkerFrameRepresentation::loadTargetRelationships() const
 	}
 }
 
-std::vector<WellboreMarker const *> WellboreMarkerFrameRepresentation::getWellboreMarkerSet() const
+std::vector<WellboreMarker *> WellboreMarkerFrameRepresentation::getWellboreMarkerSet() const
 {
 	return getRepository()->getTargetObjects<WellboreMarker>(this);
 }

--- a/src/resqml2_0_1/WellboreMarkerFrameRepresentation.h
+++ b/src/resqml2_0_1/WellboreMarkerFrameRepresentation.h
@@ -43,7 +43,7 @@ namespace RESQML2_0_1_NS
 		* @param title		A title for the instance to create.
 		* @param traj		The trajectory this WellboreFeature frame is based on.
 		*/
-		WellboreMarkerFrameRepresentation(class WellboreInterpretation const * interp, const std::string & guid, const std::string & title, class WellboreTrajectoryRepresentation const * traj);
+		WellboreMarkerFrameRepresentation(class WellboreInterpretation * interp, const std::string & guid, const std::string & title, class WellboreTrajectoryRepresentation * traj);
 
 		/**
 		* Creates an instance of this class by wrapping a gsoap instance.
@@ -61,7 +61,7 @@ namespace RESQML2_0_1_NS
 		/**
 		* Get all the wellbore markers of this well marker frame representation.
 		*/
-		DLL_IMPORT_OR_EXPORT std::vector<class WellboreMarker const *> getWellboreMarkerSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<class WellboreMarker *> getWellboreMarkerSet() const;
 
 		DLL_IMPORT_OR_EXPORT void setStratigraphicOccurrenceInterpretation(class StratigraphicOccurrenceInterpretation * stratiOccurenceInterp);
 
@@ -78,7 +78,7 @@ namespace RESQML2_0_1_NS
 		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const { return XML_TAG; }
 
 	protected:
-		void loadTargetRelationships() const;
+		void loadTargetRelationships();
 
 	private:
 		/**

--- a/src/resqml2_0_1/WellboreTrajectoryRepresentation.cpp
+++ b/src/resqml2_0_1/WellboreTrajectoryRepresentation.cpp
@@ -35,7 +35,7 @@ using namespace COMMON_NS;
 
 const char* WellboreTrajectoryRepresentation::XML_TAG = "WellboreTrajectoryRepresentation";
 
-WellboreTrajectoryRepresentation::WellboreTrajectoryRepresentation(WellboreInterpretation const * interp, const string & guid, const std::string & title, RESQML2_NS::MdDatum const * mdInfo)
+WellboreTrajectoryRepresentation::WellboreTrajectoryRepresentation(WellboreInterpretation * interp, const string & guid, const std::string & title, RESQML2_NS::MdDatum * mdInfo)
 {
 	gsoapProxy2_0_1 = soap_new_resqml2__obj_USCOREWellboreTrajectoryRepresentation(interp->getGsoapContext(), 1);	
 	_resqml2__WellboreTrajectoryRepresentation* rep = static_cast<_resqml2__WellboreTrajectoryRepresentation*>(gsoapProxy2_0_1);
@@ -51,7 +51,7 @@ WellboreTrajectoryRepresentation::WellboreTrajectoryRepresentation(WellboreInter
 	setInterpretation(interp);
 }
 
-WellboreTrajectoryRepresentation::WellboreTrajectoryRepresentation(WellboreInterpretation const * interp, const string & guid, const std::string & title, DeviationSurveyRepresentation const * deviationSurvey)
+WellboreTrajectoryRepresentation::WellboreTrajectoryRepresentation(WellboreInterpretation * interp, const string & guid, const std::string & title, DeviationSurveyRepresentation * deviationSurvey)
 {
 	gsoapProxy2_0_1 = soap_new_resqml2__obj_USCOREWellboreTrajectoryRepresentation(interp->getGsoapContext(), 1);
 	_resqml2__WellboreTrajectoryRepresentation* rep = static_cast<_resqml2__WellboreTrajectoryRepresentation*>(gsoapProxy2_0_1);
@@ -162,7 +162,7 @@ void WellboreTrajectoryRepresentation::setGeometry(double * controlPoints,
 	proxy->writeArrayNdOfDoubleValues(rep->uuid, "tangentVectors", tangentVectors, dim, 2);
 }
 
-void WellboreTrajectoryRepresentation::loadTargetRelationships() const
+void WellboreTrajectoryRepresentation::loadTargetRelationships()
 {
 	AbstractRepresentation::loadTargetRelationships();
 
@@ -215,7 +215,7 @@ double WellboreTrajectoryRepresentation::getParentTrajectoryMd() const
 	}
 }
 
-std::vector<WellboreTrajectoryRepresentation const *> WellboreTrajectoryRepresentation::getChildrenTrajectorySet() const
+std::vector<WellboreTrajectoryRepresentation *> WellboreTrajectoryRepresentation::getChildrenTrajectorySet() const
 {
 	return getRepository()->getSourceObjects<WellboreTrajectoryRepresentation>(this);
 }
@@ -340,7 +340,7 @@ void WellboreTrajectoryRepresentation::getTangentVectors(double* tangentVectors)
 	hdfProxy->readArrayNdOfDoubleValues(dataset->PathInHdfFile, tangentVectors);
 }
 
-void WellboreTrajectoryRepresentation::setMdDatum(RESQML2_NS::MdDatum const * mdDatum)
+void WellboreTrajectoryRepresentation::setMdDatum(RESQML2_NS::MdDatum * mdDatum)
 {
 	if (mdDatum == nullptr) {
 		throw invalid_argument("The md Datum is missing.");
@@ -413,7 +413,7 @@ DeviationSurveyRepresentation* WellboreTrajectoryRepresentation::getDeviationSur
 	return dsDor == nullptr ? nullptr : repository->getDataObjectByUuid<DeviationSurveyRepresentation>(dsDor->UUID);
 }
 
-std::vector<WellboreFrameRepresentation const *> WellboreTrajectoryRepresentation::getWellboreFrameRepresentationSet() const
+std::vector<WellboreFrameRepresentation *> WellboreTrajectoryRepresentation::getWellboreFrameRepresentationSet() const
 {
 	return getRepository()->getSourceObjects<WellboreFrameRepresentation>(this);
 }
@@ -423,9 +423,9 @@ unsigned int WellboreTrajectoryRepresentation::getWellboreFrameRepresentationCou
 	return getWellboreFrameRepresentationSet().size();
 }
 
-WellboreFrameRepresentation const * WellboreTrajectoryRepresentation::getWellboreFrameRepresentation(unsigned int index) const
+WellboreFrameRepresentation * WellboreTrajectoryRepresentation::getWellboreFrameRepresentation(unsigned int index) const
 {
-	const std::vector<WellboreFrameRepresentation const *>& wfrs = getWellboreFrameRepresentationSet();
+	const std::vector<WellboreFrameRepresentation *>& wfrs = getWellboreFrameRepresentationSet();
 	
 	if (index >= wfrs.size()) {
 		throw out_of_range("The index if out of range");

--- a/src/resqml2_0_1/WellboreTrajectoryRepresentation.h
+++ b/src/resqml2_0_1/WellboreTrajectoryRepresentation.h
@@ -47,12 +47,12 @@ namespace RESQML2_0_1_NS
 		* @param title					A title for the instance to create.
 		* @param mdInfo					The MD information of the trajectory, mainly the well reference point.
 		*/
-		WellboreTrajectoryRepresentation(class WellboreInterpretation const * interp, const std::string & guid, const std::string & title, RESQML2_NS::MdDatum const * mdInfo);
+		WellboreTrajectoryRepresentation(class WellboreInterpretation * interp, const std::string & guid, const std::string & title, RESQML2_NS::MdDatum * mdInfo);
 
 		/**
 		* Creates an instance with an existing deviation survey as its origin.
 		*/
-		WellboreTrajectoryRepresentation(class WellboreInterpretation const * interp, const std::string & guid, const std::string & title, DeviationSurveyRepresentation const * deviationSurvey);
+		WellboreTrajectoryRepresentation(class WellboreInterpretation * interp, const std::string & guid, const std::string & title, DeviationSurveyRepresentation * deviationSurvey);
 
 		/**
 		* Creates an instance of this class by wrapping a gsoap instance.
@@ -106,7 +106,7 @@ namespace RESQML2_0_1_NS
 		/**
 		* Set the Md datum of this trajectory
 		*/
-		DLL_IMPORT_OR_EXPORT void setMdDatum(RESQML2_NS::MdDatum const * mdDatum);
+		DLL_IMPORT_OR_EXPORT void setMdDatum(RESQML2_NS::MdDatum * mdDatum);
 
 		/**
 		* Getter of the md information associated to this WellboreFeature trajectory representation.
@@ -185,12 +185,12 @@ namespace RESQML2_0_1_NS
 		/**
 		* Get a set of all children trajectories of this trajectory
 		*/
-		DLL_IMPORT_OR_EXPORT std::vector<WellboreTrajectoryRepresentation const *> getChildrenTrajectorySet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<WellboreTrajectoryRepresentation *> getChildrenTrajectorySet() const;
 
 		/**
 		* Getter (in read only mode) of all the associated Wellbore frame representations
 		*/
-		DLL_IMPORT_OR_EXPORT std::vector<class WellboreFrameRepresentation const *> getWellboreFrameRepresentationSet() const;
+		DLL_IMPORT_OR_EXPORT std::vector<class WellboreFrameRepresentation *> getWellboreFrameRepresentationSet() const;
 
 		/**
 		* Get the count of wellbore frame representation which are associated with this wellbore trajectory.
@@ -203,7 +203,7 @@ namespace RESQML2_0_1_NS
 		* Necessary for now in SWIG context because I mm not sure if I can always wrap a vector of polymorphic class yet.
 		* Throw an out of bound exception if the index is superior or equal to the count of wellbore frame representation.
 		*/
-		DLL_IMPORT_OR_EXPORT class WellboreFrameRepresentation const * getWellboreFrameRepresentation(unsigned int index) const;
+		DLL_IMPORT_OR_EXPORT class WellboreFrameRepresentation * getWellboreFrameRepresentation(unsigned int index) const;
 
 		/**
 		* Set the deviation survey which is the source of this trajectory.
@@ -234,6 +234,6 @@ namespace RESQML2_0_1_NS
 		gsoap_resqml2_0_1::eml20__DataObjectReference* getDeviationSurveyDor() const;
 
 	protected:
-		void loadTargetRelationships() const;
+		void loadTargetRelationships();
 	};
 }

--- a/src/resqml2_2/AbstractColorMap.h
+++ b/src/resqml2_2/AbstractColorMap.h
@@ -134,7 +134,7 @@ namespace RESQML2_2_NS
 
 		virtual void computeMinMax(LONG64& min, LONG64& max) const = 0;
 
-		void loadTargetRelationships() const {};
+		void loadTargetRelationships() {};
 
 		DLL_IMPORT_OR_EXPORT std::string getXmlNamespace() const {
 			return "resqml22";

--- a/src/witsml2_0/Well.cpp
+++ b/src/witsml2_0/Well.cpp
@@ -262,20 +262,20 @@ unsigned int Well::getDatumCount() const
 	return static_cast<witsml2__Well*>(gsoapProxy2_1)->WellDatum.size();
 }
 
-void Well::loadTargetRelationships() const
+void Well::loadTargetRelationships()
 {}
 
-std::vector<RESQML2_0_1_NS::WellboreFeature const *> Well::getResqmlWellboreFeatures() const
+std::vector<RESQML2_0_1_NS::WellboreFeature *> Well::getResqmlWellboreFeatures() const
 {
 	return getRepository()->getSourceObjects<RESQML2_0_1_NS::WellboreFeature>(this);
 }
 
-std::vector<Wellbore const *> Well::getWellbores() const
+std::vector<Wellbore *> Well::getWellbores() const
 {
 	return getRepository()->getSourceObjects<Wellbore>(this);
 }
 
-std::vector<WellCompletion const *> Well::getWellcompletions() const
+std::vector<WellCompletion *> Well::getWellcompletions() const
 {
 	return getRepository()->getSourceObjects<WellCompletion>(this);
 }

--- a/src/witsml2_0/Well.h
+++ b/src/witsml2_0/Well.h
@@ -142,17 +142,17 @@ namespace WITSML2_0_NS
 
 		DLL_IMPORT_OR_EXPORT unsigned int getDatumCount() const;
 
-		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::WellboreFeature const *> getResqmlWellboreFeatures() const;
+		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::WellboreFeature *> getResqmlWellboreFeatures() const;
 
-		DLL_IMPORT_OR_EXPORT std::vector<Wellbore const *> getWellbores() const;
+		DLL_IMPORT_OR_EXPORT std::vector<Wellbore *> getWellbores() const;
 
-		DLL_IMPORT_OR_EXPORT std::vector<WellCompletion const *> getWellcompletions() const;
+		DLL_IMPORT_OR_EXPORT std::vector<WellCompletion *> getWellcompletions() const;
 
 		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
 		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
 	protected:
 
-		void loadTargetRelationships() const;
+		void loadTargetRelationships();
 	};
 }

--- a/src/witsml2_0/WellCompletion.cpp
+++ b/src/witsml2_0/WellCompletion.cpp
@@ -66,12 +66,12 @@ void WellCompletion::setWell(Well* witsmlWell)
 	wellCompletion->Well = witsmlWell->newEmlReference();
 }
 
-std::vector<WellboreCompletion const *> WellCompletion::getWellboreCompletions() const
+std::vector<WellboreCompletion *> WellCompletion::getWellboreCompletions() const
 {
 	return getRepository()->getSourceObjects<WellboreCompletion>(this);
 }
 
-void WellCompletion::loadTargetRelationships() const
+void WellCompletion::loadTargetRelationships()
 {
 	convertDorIntoRel<Well>(getWellDor());
 }

--- a/src/witsml2_0/WellCompletion.h
+++ b/src/witsml2_0/WellCompletion.h
@@ -46,7 +46,7 @@ namespace WITSML2_0_NS
 
 		DLL_IMPORT_OR_EXPORT void setWell(class Well* witsmlWell);
 
-		DLL_IMPORT_OR_EXPORT std::vector<WellboreCompletion const *> getWellboreCompletions() const;
+		DLL_IMPORT_OR_EXPORT std::vector<WellboreCompletion *> getWellboreCompletions() const;
 
 		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
 		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const { return XML_TAG; }
@@ -55,6 +55,6 @@ namespace WITSML2_0_NS
 		/**
 		* Resolve all relationships of the object in the repository.
 		*/
-		void loadTargetRelationships() const;
+		void loadTargetRelationships();
 	};
 }

--- a/src/witsml2_0/Wellbore.cpp
+++ b/src/witsml2_0/Wellbore.cpp
@@ -105,22 +105,22 @@ void Wellbore::setShape(witsml2__WellboreShape shape)
 	*wellbore->Shape = shape;
 }
 
-void Wellbore::loadTargetRelationships() const
+void Wellbore::loadTargetRelationships()
 {
 	convertDorIntoRel<Well>(getWellDor());
 }
 
-std::vector<RESQML2_0_1_NS::WellboreFeature const *> Wellbore::getResqmlWellboreFeature() const
+std::vector<RESQML2_0_1_NS::WellboreFeature *> Wellbore::getResqmlWellboreFeature() const
 {
 	return getRepository()->getSourceObjects<RESQML2_0_1_NS::WellboreFeature>(this);
 }
 
-std::vector<WellboreCompletion const *> Wellbore::getWellboreCompletions() const
+std::vector<WellboreCompletion *> Wellbore::getWellboreCompletions() const
 {
 	return getRepository()->getSourceObjects<WellboreCompletion>(this);
 }
 
-std::vector<Trajectory const *> Wellbore::getTrajectories() const
+std::vector<Trajectory *> Wellbore::getTrajectories() const
 {
 	return getRepository()->getSourceObjects<Trajectory>(this);
 }

--- a/src/witsml2_0/Wellbore.h
+++ b/src/witsml2_0/Wellbore.h
@@ -65,10 +65,10 @@ namespace WITSML2_0_NS
 
 		DLL_IMPORT_OR_EXPORT void setWell(class Well* witsmlWell);
 
-		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::WellboreFeature const *> getResqmlWellboreFeature() const;
+		DLL_IMPORT_OR_EXPORT std::vector<RESQML2_0_1_NS::WellboreFeature *> getResqmlWellboreFeature() const;
 
-		DLL_IMPORT_OR_EXPORT std::vector<WellboreCompletion const *> getWellboreCompletions() const;
-		DLL_IMPORT_OR_EXPORT std::vector<Trajectory const *> getTrajectories() const;
+		DLL_IMPORT_OR_EXPORT std::vector<WellboreCompletion *> getWellboreCompletions() const;
+		DLL_IMPORT_OR_EXPORT std::vector<Trajectory *> getTrajectories() const;
 
 		DLL_IMPORT_OR_EXPORT void setShape(gsoap_eml2_1::witsml2__WellboreShape shape);
 
@@ -80,6 +80,6 @@ namespace WITSML2_0_NS
 		/**
 		* Resolve all relationships of the object in the repository.
 		*/
-		void loadTargetRelationships() const;
+		void loadTargetRelationships();
 	};
 }

--- a/src/witsml2_0/WellboreCompletion.cpp
+++ b/src/witsml2_0/WellboreCompletion.cpp
@@ -537,7 +537,7 @@ void WellboreCompletion::setPerforationHistoryBaseMd(unsigned int historyIndex,
 	perforationStatusHistory->PerforationMdInterval->MdBase->__item = BaseMd;
 }
 
-void WellboreCompletion::loadTargetRelationships() const
+void WellboreCompletion::loadTargetRelationships()
 {
 	WellboreObject::loadTargetRelationships();
 

--- a/src/witsml2_0/WellboreCompletion.h
+++ b/src/witsml2_0/WellboreCompletion.h
@@ -187,6 +187,6 @@ namespace WITSML2_0_NS
 		/**
 		* Resolve all relationships of the object in an epc document.
 		*/
-		void loadTargetRelationships() const;
+		void loadTargetRelationships();
 	};
 }

--- a/src/witsml2_0/WellboreObject.cpp
+++ b/src/witsml2_0/WellboreObject.cpp
@@ -31,7 +31,7 @@ Wellbore* WellboreObject::getWellbore() const
 	return getRepository()->getDataObjectByUuid<Wellbore>(getWellboreDor()->Uuid);
 }
 
-void WellboreObject::loadTargetRelationships() const
+void WellboreObject::loadTargetRelationships()
 {
 	convertDorIntoRel<Wellbore>(getWellboreDor());
 }

--- a/src/witsml2_0/WellboreObject.h
+++ b/src/witsml2_0/WellboreObject.h
@@ -46,7 +46,7 @@ namespace WITSML2_0_NS
 		/**
 		* Resolve all relationships of the object in a repository.
 		*/
-		void loadTargetRelationships() const;
+		void loadTargetRelationships();
 
 	public:
 

--- a/swig/swigResqml2Include.i
+++ b/swig/swigResqml2Include.i
@@ -461,10 +461,10 @@ namespace RESQML2_NS
 	class TimeSeries : public COMMON_NS::AbstractObject
 	{
 	public:
-		void pushBackTimestamp(const time_t & timestamp);
-		unsigned int getTimestampIndex(const time_t & timestamp) const;
+		void pushBackTimestamp(time_t timestamp);
+		unsigned int getTimestampIndex(time_t timestamp) const;
 		unsigned int getTimestampCount() const;
-		time_t getTimestamp(const unsigned int & index) const;
+		time_t getTimestamp(unsigned int index) const;
 	};
 	
 	class AbstractProperty: public COMMON_NS::AbstractObject

--- a/swig/swigResqml2_0_1Include.i
+++ b/swig/swigResqml2_0_1Include.i
@@ -2463,7 +2463,7 @@ namespace RESQML2_0_1_NS
 	{
 	public:
 		bool isDrilled() const;
-		std::vector<WellboreTrajectoryRepresentation const *> getWellboreTrajectoryRepresentationSet() const;
+		std::vector<WellboreTrajectoryRepresentation *> getWellboreTrajectoryRepresentationSet() const;
 	};
 	
 #ifdef SWIGPYTHON
@@ -2541,10 +2541,10 @@ namespace RESQML2_0_1_NS
 		bool isAChronoStratiRank() const;
 		StratigraphicUnitInterpretation* getSubjectOfContact(const unsigned int & contactIndex) const;
 		StratigraphicUnitInterpretation* getDirectObjectOfContact(const unsigned int & contactIndex) const;
-		std::vector<class StratigraphicUnitInterpretation const *> getStratigraphicUnitInterpretationSet() const;
-		std::vector<class StratigraphicOccurrenceInterpretation const *> getStratigraphicOccurrenceInterpretationSet() const;
-        std::vector<class HorizonInterpretation const *> getHorizonInterpretationSet() const;
-		std::vector<StratigraphicColumn const *> getStratigraphicColumnSet() const;
+		std::vector<class StratigraphicUnitInterpretation *> getStratigraphicUnitInterpretationSet() const;
+		std::vector<class StratigraphicOccurrenceInterpretation *> getStratigraphicOccurrenceInterpretationSet() const;
+        std::vector<class HorizonInterpretation *> getHorizonInterpretationSet() const;
+		std::vector<StratigraphicColumn *> getStratigraphicColumnSet() const;
 	};
 	
 	class WellboreMarkerFrameRepresentation;	
@@ -2558,7 +2558,7 @@ namespace RESQML2_0_1_NS
 		StratigraphicColumnRankInterpretation * getStratigraphicColumnRankInterpretation() const;
 		std::string getStratigraphicColumnRankInterpretationUuid() const;
 		
-		std::vector<class WellboreMarkerFrameRepresentation const *> getWellboreMarkerFrameRepresentationSet() const;
+		std::vector<class WellboreMarkerFrameRepresentation *> getWellboreMarkerFrameRepresentationSet() const;
 	};
 
 #ifdef SWIGPYTHON
@@ -2567,8 +2567,8 @@ namespace RESQML2_0_1_NS
 	class StratigraphicColumn : public COMMON_NS::AbstractObject
 	{
 	public:
-		void pushBackStratiColumnRank(StratigraphicColumnRankInterpretation const * stratiColumnRank);
-		std::vector<class StratigraphicColumnRankInterpretation const *> getStratigraphicColumnRankInterpretationSet() const;
+		void pushBackStratiColumnRank(StratigraphicColumnRankInterpretation * stratiColumnRank);
+		std::vector<class StratigraphicColumnRankInterpretation *> getStratigraphicColumnRankInterpretationSet() const;
 	};
 
 #ifdef SWIGPYTHON
@@ -2721,12 +2721,12 @@ namespace RESQML2_0_1_NS
 			double xOrigin, double yOrigin, double zOrigin,
 			double xOffsetInFastestDirection, double yOffsetInFastestDirection, double zOffsetInFastestDirection,
 			double xOffsetInSlowestDirection, double yOffsetInSlowestDirection, double zOffsetInSlowestDirection,
-			double spacingInFastestDirection, double spacingInSlowestDirection, RESQML2_NS::AbstractLocal3dCrs const * localCrs = nullptr);
+			double spacingInFastestDirection, double spacingInSlowestDirection, RESQML2_NS::AbstractLocal3dCrs * localCrs = nullptr);
 
 		void setGeometryAsArray2dOfExplicitZ(
 			double * zValues,
 			unsigned int numI, unsigned int numJ, COMMON_NS::AbstractHdfProxy* proxy,
-			Grid2dRepresentation * supportingGrid2dRepresentation, RESQML2_NS::AbstractLocal3dCrs const * localCrs = nullptr,
+			Grid2dRepresentation * supportingGrid2dRepresentation, RESQML2_NS::AbstractLocal3dCrs * localCrs = nullptr,
 			unsigned int startIndexI = 0, unsigned int startIndexJ = 0,
 			int indexIncrementI = 1, int indexIncrementJ = 1);
 
@@ -2735,7 +2735,7 @@ namespace RESQML2_0_1_NS
 			unsigned int numI, unsigned int numJ, COMMON_NS::AbstractHdfProxy* proxy,
 			double originX, double originY, double originZ,
 			double offsetIX, double offsetIY, double offsetIZ, double spacingI,
-			double offsetJX, double offsetJY, double offsetJZ, double spacingJ, RESQML2_NS::AbstractLocal3dCrs const * localCrs = nullptr);
+			double offsetJX, double offsetJY, double offsetJZ, double spacingJ, RESQML2_NS::AbstractLocal3dCrs * localCrs = nullptr);
 		
 		Grid2dRepresentation*  getSupportingRepresentation();
 		std::string getSupportingRepresentationUuid() const;
@@ -2779,7 +2779,7 @@ namespace RESQML2_0_1_NS
 		void addParentTrajectory(double kickoffMd, double parentMd, WellboreTrajectoryRepresentation* parentTrajRep);
 		WellboreTrajectoryRepresentation* getParentTrajectory() const;
 		double getParentTrajectoryMd() const;
-		std::vector<WellboreTrajectoryRepresentation const *> getChildrenTrajectorySet() const;
+		std::vector<WellboreTrajectoryRepresentation *> getChildrenTrajectorySet() const;
 
 		bool hasGeometry() const;
 		int getGeometryKind() const;
@@ -2872,7 +2872,7 @@ namespace RESQML2_0_1_NS
 	{
 	public:		
 		unsigned int getWellboreMarkerCount();
-		std::vector<WellboreMarker const *> getWellboreMarkerSet() const;
+		std::vector<WellboreMarker *> getWellboreMarkerSet() const;
 
 		void setIntervalStratigraphicUnits(unsigned int * stratiUnitIndices, unsigned int nullValue, class StratigraphicOccurrenceInterpretation* stratiOccurenceInterp, COMMON_NS::AbstractHdfProxy* proxy);
 		StratigraphicOccurrenceInterpretation* getStratigraphicOccurrenceInterpretation();
@@ -2941,28 +2941,28 @@ namespace RESQML2_0_1_NS
 		void setGeometryUsingExistingDatasets(const std::string& cellFaceIsRightHanded, const std::string& points, ULONG64 pointCount, COMMON_NS::AbstractHdfProxy* proxy,
 			const std::string& faceIndicesPerCell, const std::string& faceIndicesCumulativeCountPerCell,
 			ULONG64 faceCount, const std::string& nodeIndicesPerFace, const std::string& nodeIndicesCumulativeCountPerFace,
-			gsoap_resqml2_0_1::resqml2__CellShape cellShape, RESQML2_NS::AbstractLocal3dCrs const * localCrs = nullptr);
+			gsoap_resqml2_0_1::resqml2__CellShape cellShape, RESQML2_NS::AbstractLocal3dCrs * localCrs = nullptr);
 
 		void setGeometry(unsigned char * cellFaceIsRightHanded, double * points, ULONG64 pointCount, COMMON_NS::AbstractHdfProxy* proxy,
 			ULONG64 * faceIndicesPerCell, ULONG64 * faceIndicesCumulativeCountPerCell,
 			ULONG64 faceCount, ULONG64 * nodeIndicesPerFace, ULONG64 * nodeIndicesCumulativeCountPerFace,
-			gsoap_resqml2_0_1::resqml2__CellShape cellShape, RESQML2_NS::AbstractLocal3dCrs const * localCrs = nullptr);
+			gsoap_resqml2_0_1::resqml2__CellShape cellShape, RESQML2_NS::AbstractLocal3dCrs * localCrs = nullptr);
 
 		void setTetrahedraOnlyGeometryUsingExistingDatasets(const std::string& cellFaceIsRightHanded, const std::string& points,
 			ULONG64 pointCount, ULONG64 faceCount, COMMON_NS::AbstractHdfProxy* proxy,
-			const std::string& faceIndicesPerCell, const std::string& nodeIndicesPerFace, RESQML2_NS::AbstractLocal3dCrs const * localCrs = nullptr);
+			const std::string& faceIndicesPerCell, const std::string& nodeIndicesPerFace, RESQML2_NS::AbstractLocal3dCrs * localCrs = nullptr);
 
 		void setTetrahedraOnlyGeometry(unsigned char * cellFaceIsRightHanded, double * points,
 			ULONG64 pointCount, ULONG64 faceCount, COMMON_NS::AbstractHdfProxy* proxy,
-			ULONG64 * faceIndicesPerCell, ULONG64 * nodeIndicesPerFace, RESQML2_NS::AbstractLocal3dCrs const * localCrs = nullptr);
+			ULONG64 * faceIndicesPerCell, ULONG64 * nodeIndicesPerFace, RESQML2_NS::AbstractLocal3dCrs * localCrs = nullptr);
 
 		void setHexahedraOnlyGeometryUsingExistingDatasets(const std::string& cellFaceIsRightHanded, const std::string& points,
 			ULONG64 pointCount, ULONG64 faceCount, COMMON_NS::AbstractHdfProxy* proxy,
-			const std::string& faceIndicesPerCell, const std::string& nodeIndicesPerFace, RESQML2_NS::AbstractLocal3dCrs const * localCrs = nullptr);
+			const std::string& faceIndicesPerCell, const std::string& nodeIndicesPerFace, RESQML2_NS::AbstractLocal3dCrs * localCrs = nullptr);
 
 		void setHexahedraOnlyGeometry(unsigned char * cellFaceIsRightHanded, double * points,
 			ULONG64 pointCount, ULONG64 faceCount, COMMON_NS::AbstractHdfProxy* proxy,
-			ULONG64 * faceIndicesPerCell, ULONG64 * nodeIndicesPerFace, RESQML2_NS::AbstractLocal3dCrs const * localCrs = nullptr);
+			ULONG64 * faceIndicesPerCell, ULONG64 * nodeIndicesPerFace, RESQML2_NS::AbstractLocal3dCrs * localCrs = nullptr);
 	};
 	
 #ifdef SWIGPYTHON
@@ -3057,7 +3057,7 @@ namespace RESQML2_0_1_NS
 			double originX, double originY, double originZ,
 			double directionIX, double directionIY, double directionIZ, double spacingI,
 			double directionJX, double directionJY, double directionJZ, double spacingJ,
-			double directionKX, double directionKY, double directionKZ, double spacingK, RESQML2_NS::AbstractLocal3dCrs const * localCrs = nullptr);
+			double directionKX, double directionKY, double directionKZ, double spacingK, RESQML2_NS::AbstractLocal3dCrs * localCrs = nullptr);
 
 		void addSeismic3dCoordinatesToPatch(
 			unsigned int patchIndex,
@@ -3077,14 +3077,14 @@ namespace RESQML2_0_1_NS
 			double * points, COMMON_NS::AbstractHdfProxy* proxy = nullptr,
 			unsigned long splitCoordinateLineCount = 0, unsigned int * pillarOfCoordinateLine = nullptr,
 			unsigned int * splitCoordinateLineColumnCumulativeCount = nullptr, unsigned int * splitCoordinateLineColumns = nullptr,
-			char * definedPillars = nullptr, RESQML2_NS::AbstractLocal3dCrs const * localCrs = nullptr);
+			char * definedPillars = nullptr, RESQML2_NS::AbstractLocal3dCrs * localCrs = nullptr);
 
 		void setGeometryAsCoordinateLineNodesUsingExistingDatasets(
 			gsoap_resqml2_0_1::resqml2__PillarShape mostComplexPillarGeometry, gsoap_resqml2_0_1::resqml2__KDirection kDirectionKind, bool isRightHanded,
 			const std::string & points, COMMON_NS::AbstractHdfProxy* proxy = nullptr,
 			unsigned long splitCoordinateLineCount = 0, const std::string & pillarOfCoordinateLine = "",
 			const std::string & splitCoordinateLineColumnCumulativeCount = "", const std::string & splitCoordinateLineColumns = "",
-			const std::string & definedPillars = "", RESQML2_NS::AbstractLocal3dCrs const * localCrs = nullptr);
+			const std::string & definedPillars = "", RESQML2_NS::AbstractLocal3dCrs * localCrs = nullptr);
 	};
 
 #ifdef SWIGPYTHON
@@ -3103,35 +3103,35 @@ namespace RESQML2_0_1_NS
 		void setGeometryAsParametricNonSplittedPillarNodes(
 			gsoap_resqml2_0_1::resqml2__PillarShape mostComplexPillarGeometry, bool isRightHanded,
 			double * parameters, double * controlPoints, double * controlPointParameters, unsigned int controlPointMaxCountPerPillar, short * pillarKind,
-			COMMON_NS::AbstractHdfProxy* proxy = nullptr, RESQML2_NS::AbstractLocal3dCrs const * localCrs = nullptr);
+			COMMON_NS::AbstractHdfProxy* proxy = nullptr, RESQML2_NS::AbstractLocal3dCrs * localCrs = nullptr);
 
 		void setGeometryAsParametricNonSplittedPillarNodesUsingExistingDatasets(
 			gsoap_resqml2_0_1::resqml2__PillarShape mostComplexPillarGeometry, gsoap_resqml2_0_1::resqml2__KDirection kDirectionKind, bool isRightHanded,
 			const std::string & parameters, const std::string & controlPoints, const std::string & controlPointParameters, unsigned int controlPointMaxCountPerPillar, const std::string & pillarKind, const std::string & definedPillars,
-			COMMON_NS::AbstractHdfProxy* proxy = nullptr, RESQML2_NS::AbstractLocal3dCrs const * localCrs = nullptr);
+			COMMON_NS::AbstractHdfProxy* proxy = nullptr, RESQML2_NS::AbstractLocal3dCrs * localCrs = nullptr);
 
 		void setGeometryAsParametricSplittedPillarNodes(
 			gsoap_resqml2_0_1::resqml2__PillarShape mostComplexPillarGeometry, bool isRightHanded,
 			double * parameters, double * controlPoints, double * controlPointParameters, unsigned int controlPointMaxCountPerPillar, short * pillarKind, COMMON_NS::AbstractHdfProxy* proxy,
 			unsigned long splitCoordinateLineCount, unsigned int * pillarOfCoordinateLine,
-			unsigned int * splitCoordinateLineColumnCumulativeCount, unsigned int * splitCoordinateLineColumns, RESQML2_NS::AbstractLocal3dCrs const * localCrs = nullptr);
+			unsigned int * splitCoordinateLineColumnCumulativeCount, unsigned int * splitCoordinateLineColumns, RESQML2_NS::AbstractLocal3dCrs * localCrs = nullptr);
 
 		void setGeometryAsParametricSplittedPillarNodesUsingExistingDatasets(
 			gsoap_resqml2_0_1::resqml2__PillarShape mostComplexPillarGeometry, gsoap_resqml2_0_1::resqml2__KDirection kDirectionKind, bool isRightHanded,
 			const std::string & parameters, const std::string & controlPoints, const std::string & controlPointParameters, unsigned int controlPointMaxCountPerPillar, const std::string & pillarKind, const std::string & definedPillars, COMMON_NS::AbstractHdfProxy* proxy,
 			unsigned long splitCoordinateLineCount, const std::string & pillarOfCoordinateLine,
-			const std::string & splitCoordinateLineColumnCumulativeCount, const std::string & splitCoordinateLineColumns, RESQML2_NS::AbstractLocal3dCrs const * localCrs = nullptr);
+			const std::string & splitCoordinateLineColumnCumulativeCount, const std::string & splitCoordinateLineColumns, RESQML2_NS::AbstractLocal3dCrs * localCrs = nullptr);
 
 		void setGeometryAsParametricSplittedPillarNodes(bool isRightHanded,
 			double * parameters, double * controlPoints, double * controlPointParameters, unsigned int controlPointCountPerPillar, short pillarKind, COMMON_NS::AbstractHdfProxy* proxy,
 			unsigned long splitCoordinateLineCount, unsigned int * pillarOfCoordinateLine,
-			unsigned int * splitCoordinateLineColumnCumulativeCount, unsigned int * splitCoordinateLineColumns, RESQML2_NS::AbstractLocal3dCrs const * localCrs = nullptr);
+			unsigned int * splitCoordinateLineColumnCumulativeCount, unsigned int * splitCoordinateLineColumns, RESQML2_NS::AbstractLocal3dCrs * localCrs = nullptr);
 
 		void setGeometryAsParametricSplittedPillarNodesUsingExistingDatasets(
 			gsoap_resqml2_0_1::resqml2__KDirection kDirectionKind, bool isRightHanded,
 			const std::string & parameters, const std::string & controlPoints, const std::string & controlPointParameters, unsigned int controlPointCountPerPillar, short pillarKind, COMMON_NS::AbstractHdfProxy* proxy,
 			unsigned long splitCoordinateLineCount, const std::string & pillarOfCoordinateLine,
-			const std::string & splitCoordinateLineColumnCumulativeCount, const std::string & splitCoordinateLineColumns, RESQML2_NS::AbstractLocal3dCrs const * localCrs = nullptr);
+			const std::string & splitCoordinateLineColumnCumulativeCount, const std::string & splitCoordinateLineColumns, RESQML2_NS::AbstractLocal3dCrs * localCrs = nullptr);
 	};
 	
 #ifdef SWIGPYTHON

--- a/swig/swigWitsml2_0Include.i
+++ b/swig/swigWitsml2_0Include.i
@@ -317,11 +317,11 @@ namespace WITSML2_0_NS
 		
 		unsigned int getDatumCount() const;
 		
-		std::vector<RESQML2_0_1_NS::WellboreFeature const *> getResqmlWellboreFeatures() const;
+		std::vector<RESQML2_0_1_NS::WellboreFeature *> getResqmlWellboreFeatures() const;
 
-		std::vector<Wellbore const *> getWellbores() const;
+		std::vector<Wellbore *> getWellbores() const;
 
-		std::vector<WellCompletion const *> getWellcompletions() const;
+		std::vector<WellCompletion *> getWellcompletions() const;
 	};
 	
 	class WellboreCompletion;
@@ -333,10 +333,10 @@ namespace WITSML2_0_NS
 
 		void setWell(class Well* witsmlWell);
 
-		std::vector<RESQML2_0_1_NS::WellboreFeature const *> getResqmlWellboreFeature() const;
+		std::vector<RESQML2_0_1_NS::WellboreFeature *> getResqmlWellboreFeature() const;
 
-		std::vector<class WellboreCompletion const *> getWellboreCompletions() const;
-		std::vector<class Trajectory const *> getTrajectories() const;
+		std::vector<class WellboreCompletion *> getWellboreCompletions() const;
+		std::vector<class Trajectory *> getTrajectories() const;
 
 		void setShape(gsoap_eml2_1::witsml2__WellboreShape shape);
 	};
@@ -350,7 +350,7 @@ namespace WITSML2_0_NS
 
 		void setWell(class Well* witsmlWell);
 		
-		std::vector<class WellboreCompletion const *> getWellboreCompletions() const;
+		std::vector<class WellboreCompletion *> getWellboreCompletions() const;
 	};
 	
 	class WellboreObject : public AbstractObject


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
* Getters do no more return const pointer.
* Bug fix : wrong but usual EpcExternalPartReference content type is supported back (with warning).

Does this close any currently open issues?
------------------------------------------
No

Where has this been tested?
---------------------------
**Operating System:** Win64 10

**Platform:** VS2015 64
