### PR TITLE
Bug Fix : No CRS representation

### DIFF
--- a/src/resqml2/AbstractRepresentation.cpp
+++ b/src/resqml2/AbstractRepresentation.cpp
@@ -137,7 +137,8 @@ gsoap_resqml2_0_1::resqml2__PointGeometry* AbstractRepresentation::createPointGe
 
 AbstractLocal3dCrs * AbstractRepresentation::getLocalCrs() const
 {
-	return getRepository()->getDataObjectByUuid<AbstractLocal3dCrs>(getLocalCrsUuid());
+	const std::string & uuid = getLocalCrsUuid();
+	return uuid.empty() ? nullptr : getRepository()->getDataObjectByUuid<AbstractLocal3dCrs>(uuid);
 }
 
 gsoap_resqml2_0_1::eml20__DataObjectReference* AbstractRepresentation::getLocalCrsDor() const


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
In new unstable version 1.0.0, CRS management has been modified and consequently also the inference to determine if an interpretation is all in time or all in depth.
When a rep has no CRS, this inference is more tricky to run. This tricky aspect was error prone!

Does this close any currently open issues?
------------------------------------------
No

Where has this been tested?
---------------------------
**Operating System:** WIN64 10 

**Platform:** VS 2015 64
