### PR TITLE
Support for reading multiple CRS of a single rep

### DIFF
--- a/src/resqml2/AbstractFeatureInterpretation.cpp
+++ b/src/resqml2/AbstractFeatureInterpretation.cpp
@@ -91,13 +91,17 @@ const gsoap_resqml2_0_1::resqml2__Domain & AbstractFeatureInterpretation::initDo
 		bool isTimeDomain = false;
 		bool isDepthDomain = false;
 		for (unsigned int repIndex = 0; repIndex < repCount && (!isTimeDomain || !isDepthDomain); ++repIndex) {
-			AbstractLocal3dCrs* local3dCrs = getRepresentation(repIndex)->getLocalCrs();
-			if (local3dCrs != nullptr) {
-				if (local3dCrs->getGsoapType() == SOAP_TYPE_gsoap_resqml2_0_1_resqml2__obj_USCORELocalTime3dCrs) {
-					isTimeDomain = true;
-				}
-				else if (local3dCrs->getGsoapType() == SOAP_TYPE_gsoap_resqml2_0_1_resqml2__obj_USCORELocalDepth3dCrs) {
-					isDepthDomain = true;
+			AbstractRepresentation const * rep = getRepresentation(repIndex);
+			const unsigned int patchCount = rep->getPatchCount();
+			for (unsigned int patchIndex = 0; patchIndex < patchCount && (!isTimeDomain || !isDepthDomain); ++patchIndex) {
+				AbstractLocal3dCrs* local3dCrs = rep->getLocalCrs(patchIndex);
+				if (local3dCrs != nullptr) {
+					if (local3dCrs->getGsoapType() == SOAP_TYPE_gsoap_resqml2_0_1_resqml2__obj_USCORELocalTime3dCrs) {
+						isTimeDomain = true;
+					}
+					else if (local3dCrs->getGsoapType() == SOAP_TYPE_gsoap_resqml2_0_1_resqml2__obj_USCORELocalDepth3dCrs) {
+						isDepthDomain = true;
+					}
 				}
 			}
 		}

--- a/src/resqml2/AbstractRepresentation.cpp
+++ b/src/resqml2/AbstractRepresentation.cpp
@@ -137,7 +137,7 @@ gsoap_resqml2_0_1::resqml2__PointGeometry* AbstractRepresentation::createPointGe
 
 AbstractLocal3dCrs * AbstractRepresentation::getLocalCrs(unsigned int patchIndex) const
 {
-	const std::string & uuid = getLocalCrsUuid();
+	const std::string & uuid = getLocalCrsUuid(patchIndex);
 	return uuid.empty() ? nullptr : getRepository()->getDataObjectByUuid<AbstractLocal3dCrs>(uuid);
 }
 

--- a/src/resqml2/AbstractRepresentation.h
+++ b/src/resqml2/AbstractRepresentation.h
@@ -78,17 +78,17 @@ namespace RESQML2_NS
 		/**
 		* Getter (read/write access) for the localCrs
 		*/
-		DLL_IMPORT_OR_EXPORT class AbstractLocal3dCrs* getLocalCrs() const;
+		DLL_IMPORT_OR_EXPORT class AbstractLocal3dCrs* getLocalCrs(unsigned int patchIndex) const;
 
 		/**
 		* Get the Local 3d CRS dor where the reference point ordinals are given
 		*/
-		virtual gsoap_resqml2_0_1::eml20__DataObjectReference* getLocalCrsDor() const;
+		virtual gsoap_resqml2_0_1::eml20__DataObjectReference* getLocalCrsDor(unsigned int patchIndex) const;
 		
 		/**
 		* Get the Local 3d CRS uuid where the reference point ordinals are given
 		*/
-		DLL_IMPORT_OR_EXPORT std::string getLocalCrsUuid() const;
+		DLL_IMPORT_OR_EXPORT std::string getLocalCrsUuid(unsigned int patchIndex) const;
 
 		/*
 		* Getter for the uuid of the hdf proxy which is used for storing the numerical values of this representation i.e. geometry.
@@ -214,6 +214,16 @@ namespace RESQML2_NS
 		* @param xyzPoints A linearized 2d array where the first (quickest) dimension is coordinate dimension (XYZ) and second dimension is vertex dimension. It must be pre allocated.
 		*/
 		DLL_IMPORT_OR_EXPORT void getXyzPointsOfAllPatches(double * xyzPoints) const;
+
+		/**
+		* Check if the representation (i.e. all its patches/geometries) is defined in a single local CRS.
+		*/
+		DLL_IMPORT_OR_EXPORT bool isInSingleLocalCrs() const;
+
+		/**
+		* Check if the representation (i.e. all its patches/geometries) is defined in a single global CRS.
+		*/
+		DLL_IMPORT_OR_EXPORT bool isInSingleGlobalCrs() const;
 
 		/**
 		* Get all the XYZ points of all patches of this individual representation

--- a/src/resqml2_0_1/Grid2dRepresentation.cpp
+++ b/src/resqml2_0_1/Grid2dRepresentation.cpp
@@ -259,9 +259,10 @@ double Grid2dRepresentation::getComponentInGlobalCrs(double x, double y, double 
 		return result[componentIndex];
 	}
 
+	// there can be only one patch in a 2d grid repesentation
 	RESQML2_NS::AbstractLocal3dCrs* localCrs = componentIndex != 2 && getSupportingRepresentationDor() != nullptr
-		? getSupportingRepresentation()->getLocalCrs()
-		: getLocalCrs();
+		? getSupportingRepresentation()->getLocalCrs(0)
+		: getLocalCrs(0);
 
 	localCrs->convertXyzPointsToGlobalCrs(result, 1, withoutTranslation);
 

--- a/src/resqml2_0_1/IjkGridLatticeRepresentation.cpp
+++ b/src/resqml2_0_1/IjkGridLatticeRepresentation.cpp
@@ -138,7 +138,8 @@ double IjkGridLatticeRepresentation::getXOriginInGlobalCrs() const
 	if (result[0] != result[0])
 		return result[0];
 
-	getLocalCrs()->convertXyzPointsToGlobalCrs(result, 1);
+	// Only one patch is allowed for an IJK Grid lattice
+	getLocalCrs(0)->convertXyzPointsToGlobalCrs(result, 1);
 
 	return result[0];
 }
@@ -158,7 +159,8 @@ double IjkGridLatticeRepresentation::getYOriginInGlobalCrs() const
 	if (result[0] != result[0])
 		return result[0];
 
-	getLocalCrs()->convertXyzPointsToGlobalCrs(result, 1);
+	// Only one patch is allowed for an IJK Grid lattice
+	getLocalCrs(0)->convertXyzPointsToGlobalCrs(result, 1);
 
 	return result[1];
 }
@@ -178,7 +180,8 @@ double IjkGridLatticeRepresentation::getZOriginInGlobalCrs() const
 	if (result != result) {
 		return result;
 	}
-	RESQML2_NS::AbstractLocal3dCrs const * localCrs = getLocalCrs();
+	// Only one patch is allowed for an IJK Grid lattice
+	RESQML2_NS::AbstractLocal3dCrs const * localCrs = getLocalCrs(0);
 	if (localCrs->getGsoapType() == SOAP_TYPE_gsoap_resqml2_0_1_resqml2__obj_USCORELocalTime3dCrs) {
 		return result;
 	}

--- a/src/resqml2_0_1/PlaneSetRepresentation.cpp
+++ b/src/resqml2_0_1/PlaneSetRepresentation.cpp
@@ -47,10 +47,10 @@ PlaneSetRepresentation::PlaneSetRepresentation(RESQML2_NS::AbstractFeatureInterp
 	setInterpretation(interp);
 }
 
-gsoap_resqml2_0_1::eml20__DataObjectReference* PlaneSetRepresentation::getLocalCrsDor() const
+gsoap_resqml2_0_1::eml20__DataObjectReference* PlaneSetRepresentation::getLocalCrsDor(unsigned int patchIndex) const
 {
 	_resqml2__PlaneSetRepresentation* rep = static_cast<_resqml2__PlaneSetRepresentation*>(gsoapProxy2_0_1);
-	gsoap_resqml2_0_1::eml20__DataObjectReference* result = rep->Planes[0]->LocalCrs;
+	gsoap_resqml2_0_1::eml20__DataObjectReference* result = rep->Planes[patchIndex]->LocalCrs;
 	for (size_t geomIndex = 1; geomIndex < rep->Planes.size(); ++geomIndex) {
 		if (result->UUID != rep->Planes[geomIndex]->LocalCrs->UUID) {
 			throw std::invalid_argument("A multi CRS plane set representaiton is not supported yet");

--- a/src/resqml2_0_1/PlaneSetRepresentation.h
+++ b/src/resqml2_0_1/PlaneSetRepresentation.h
@@ -59,7 +59,7 @@ namespace RESQML2_0_1_NS
 		* Get the Local 3d CRS dor where the reference point ordinals are given
 		* It assumes there is only one CRS used by this instance.
 		*/
-		gsoap_resqml2_0_1::eml20__DataObjectReference* getLocalCrsDor() const;
+		gsoap_resqml2_0_1::eml20__DataObjectReference* getLocalCrsDor(unsigned int patchIndex) const;
 
 		/**
 		* Get the xyz point count in a given patch.

--- a/src/resqml2_0_1/WellboreFrameRepresentation.cpp
+++ b/src/resqml2_0_1/WellboreFrameRepresentation.cpp
@@ -240,9 +240,9 @@ std::string WellboreFrameRepresentation::getWellboreTrajectoryUuid() const
 	return static_cast<_resqml2__WellboreFrameRepresentation*>(gsoapProxy2_0_1)->Trajectory->UUID;
 }
 
-gsoap_resqml2_0_1::eml20__DataObjectReference* WellboreFrameRepresentation::getLocalCrsDor() const
+gsoap_resqml2_0_1::eml20__DataObjectReference* WellboreFrameRepresentation::getLocalCrsDor(unsigned int patchIndex) const
 {
-	return getWellboreTrajectory()->getLocalCrsDor();
+	return getWellboreTrajectory()->getLocalCrsDor(patchIndex);
 }
 
 gsoap_resqml2_0_1::eml20__DataObjectReference* WellboreFrameRepresentation::getHdfProxyDor() const

--- a/src/resqml2_0_1/WellboreFrameRepresentation.h
+++ b/src/resqml2_0_1/WellboreFrameRepresentation.h
@@ -130,7 +130,7 @@ namespace RESQML2_0_1_NS
 		*/
 		DLL_IMPORT_OR_EXPORT class WellboreTrajectoryRepresentation* getWellboreTrajectory() const;
 
-		gsoap_resqml2_0_1::eml20__DataObjectReference* getLocalCrsDor() const;
+		gsoap_resqml2_0_1::eml20__DataObjectReference* getLocalCrsDor(unsigned int patchIndex) const;
 
 		gsoap_resqml2_0_1::eml20__DataObjectReference* getHdfProxyDor() const;
 

--- a/src/resqml2_0_1/WellboreTrajectoryRepresentation.cpp
+++ b/src/resqml2_0_1/WellboreTrajectoryRepresentation.cpp
@@ -383,8 +383,12 @@ gsoap_resqml2_0_1::_resqml2__WellboreTrajectoryRepresentation* WellboreTrajector
 	return static_cast<_resqml2__WellboreTrajectoryRepresentation*>(gsoapProxy2_0_1);
 }
 
-gsoap_resqml2_0_1::eml20__DataObjectReference* WellboreTrajectoryRepresentation::getLocalCrsDor() const
+gsoap_resqml2_0_1::eml20__DataObjectReference* WellboreTrajectoryRepresentation::getLocalCrsDor(unsigned int patchIndex) const
 {
+	if (patchIndex > 0) {
+		throw out_of_range("There is no more than one patch in a wellbore trajectory.");
+	}
+
 	_resqml2__WellboreTrajectoryRepresentation* rep = getSpecializedGsoapProxy();
 	return rep->Geometry != nullptr ? static_cast<resqml2__ParametricLineGeometry*>(rep->Geometry)->LocalCrs : nullptr;
 }

--- a/src/resqml2_0_1/WellboreTrajectoryRepresentation.h
+++ b/src/resqml2_0_1/WellboreTrajectoryRepresentation.h
@@ -218,7 +218,7 @@ namespace RESQML2_0_1_NS
 		/**
 		* Get the information to resolve the associated local CRS.
 		*/
-		gsoap_resqml2_0_1::eml20__DataObjectReference* getLocalCrsDor() const;
+		gsoap_resqml2_0_1::eml20__DataObjectReference* getLocalCrsDor(unsigned int patchIndex) const;
 
 		gsoap_resqml2_0_1::eml20__DataObjectReference* getHdfProxyDor() const;
 

--- a/swig/swigResqml2Include.i
+++ b/swig/swigResqml2Include.i
@@ -250,8 +250,8 @@ namespace RESQML2_NS
 		
 		AbstractFeatureInterpretation* getInterpretation() const;
 		std::string getInterpretationUuid() const;
-		AbstractLocal3dCrs * getLocalCrs();
-		std::string getLocalCrsUuid() const;
+		AbstractLocal3dCrs * getLocalCrs(unsigned int patchIndex);
+		std::string getLocalCrsUuid(unsigned int patchIndex) const;
 		unsigned int getValuesPropertyCount() const;
 		AbstractValuesProperty* getValuesProperty(const unsigned int & index) const;
 		
@@ -265,6 +265,8 @@ namespace RESQML2_NS
 		void getXyzPointsOfPatch(const unsigned int & patchIndex, double * xyzPoints) const;
 		void getXyzPointsOfPatchInGlobalCrs(const unsigned int & patchIndex, double * xyzPoints) const;
 		void getXyzPointsOfAllPatches(double * xyzPoints) const;
+		bool isInSingleLocalCrs() const;
+		bool isInSingleGlobalCrs() const;
 		void getXyzPointsOfAllPatchesInGlobalCrs(double * xyzPoints) const;
 		virtual unsigned int getPatchCount() const;
 		


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Now Fesapi provides a way to read multiple CRSs which would be associated to a single representation.
Fesapi also prevents to get XYZ in a single global CRS if it exists different global CRS associated to a single rep.

Does this close any currently open issues?
------------------------------------------
Fix #164 

Where has this been tested?
---------------------------
**Operating System:** WIN64 10

**Platform:** VS2015 64
