### PR TITLE
Do not export rel file to partial object

### DIFF
--- a/src/common/EpcDocument.cpp
+++ b/src/common/EpcDocument.cpp
@@ -100,21 +100,25 @@ namespace {
 
 		const std::vector<COMMON_NS::AbstractObject *>& srcObj = repo.getSourceObjects(dataObj);
 		for (size_t index = 0; index < srcObj.size(); ++index) {
-			epc::Relationship relRep(srcObj[index]->getPartNameInEpcDocument(), "", srcObj[index]->getUuid());
-			relRep.setSourceObjectType();
-			result.push_back(relRep);
+			if (!srcObj[index]->isPartial()) {
+				epc::Relationship relRep(srcObj[index]->getPartNameInEpcDocument(), "", srcObj[index]->getUuid());
+				relRep.setSourceObjectType();
+				result.push_back(relRep);
+			}
 		}
 
 		const std::vector<COMMON_NS::AbstractObject *>& targetObj = repo.getTargetObjects(dataObj);
 		for (size_t index = 0; index < targetObj.size(); ++index) {
-			epc::Relationship relRep(targetObj[index]->getPartNameInEpcDocument(), "", targetObj[index]->getUuid());
-			relRep.setDestinationObjectType();
-			result.push_back(relRep);
+			if (!targetObj[index]->isPartial()) {
+				epc::Relationship relRep(targetObj[index]->getPartNameInEpcDocument(), "", targetObj[index]->getUuid());
+				relRep.setDestinationObjectType();
+				result.push_back(relRep);
+			}
 		}
 
 		// External part
 		COMMON_NS::AbstractHdfProxy const * hdfProxy = dynamic_cast<COMMON_NS::AbstractHdfProxy const *>(dataObj);
-		if (hdfProxy != nullptr) {
+		if (hdfProxy != nullptr && !hdfProxy->isPartial()) {
 			epc::Relationship relExt(hdfProxy->getRelativePath(), "", "Hdf5File", false);
 			relExt.setExternalResourceType();
 			result.push_back(relExt);


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
A partial object does not exist in the EPC document.
Thus, by default, it cannot exist a rel file to a partial object part in an EPC document.
It could exist such a rel file if we would know where the partial object can be resolved but by default we assume that we don't know.

Does this close any currently open issues?
------------------------------------------
No

Where has this been tested?
---------------------------
**Operating System:** WIN64 10

**Platform:** VS 2015 64
