### PR TITLE
Avoid uncompressing twice the epc

### DIFF
--- a/example/example.cpp
+++ b/example/example.cpp
@@ -423,6 +423,9 @@ void serializeBoundaries(COMMON_NS::DataObjectRepository * pck, COMMON_NS::Abstr
 	timeStruct.tm_mday = 8;
 	timeStruct.tm_mon = 1;
 	timeStruct.tm_year = 0;
+	timeStruct.tm_isdst = 0;
+	timeStruct.tm_wday = 0;
+	timeStruct.tm_yday = 0;
 	horizon1->setCreation(timeStruct);
 	horizon1->setAge(300000000);
 	horizon2 = pck->createHorizon("fd7950a6-f62e-4e47-96c4-048820a61c59", "Horizon2");
@@ -795,6 +798,9 @@ void serializeGrid(COMMON_NS::DataObjectRepository * pck, COMMON_NS::AbstractHdf
 	timeStruct.tm_mday = 8;
 	timeStruct.tm_mon = 1;
 	timeStruct.tm_year = 0;
+	timeStruct.tm_isdst = 0;
+	timeStruct.tm_wday = 0;
+	timeStruct.tm_yday = 0;
 	timeSeries->pushBackTimestamp(timeStruct);
 	timeSeries->pushBackTimestamp(1409753895);
 	timeSeries->pushBackTimestamp(1441289895);

--- a/src/epc/Package.cpp
+++ b/src/epc/Package.cpp
@@ -244,22 +244,6 @@ std::vector<std::string> Package::openForReading(const std::string & pkgPathName
 		throw invalid_argument("Cannot unzip " + pkgPathName + ". Please verify the path of the file and if you can open it with a third party archiver.");
     }
 
-#ifdef CACHE_FILE_DESCRIPTOR
-	// Speedup part lookup, by caching zipped file descriptor using file name
-
-#ifndef UNZ_MAXFILENAMEINZIP
-#define UNZ_MAXFILENAMEINZIP (256)
-#endif
-
-    char current_filename[UNZ_MAXFILENAMEINZIP+1];
-	int err = unzGoToFirstFile(d_ptr->unzipped);
-    while (err == UNZ_OK)
-    {
-		d_ptr->name2file[current_filename] = *(unz64_s*)d_ptr->unzipped;
-		err = unzGoToNextFile(d_ptr->unzipped);
-    }
-#endif
-
 	// Package relationships : core properties
 	string relFile = extractFile("_rels/.rels", "");
 	d_ptr->filePrincipalRelationship.readFromString(relFile);


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Avoid uncompressing twice the epc
Also minor fix: uninitialized values in example.cpp

Does this close any currently open issues?
------------------------------------------
No

Any relevant logs, error output, etc?
-------------------------------------
No

Any other comments?
-------------------
No

Where has this been tested?
---------------------------
**Operating System:** WSL Ubuntu 18.04 

**Platform:** clang 5.0
