### PR TITLE
Honor gSOAP soap_new_T calls documentation

### DIFF
--- a/src/common/AbstractHdfProxy.cpp
+++ b/src/common/AbstractHdfProxy.cpp
@@ -33,7 +33,7 @@ void AbstractHdfProxy::initGsoapProxy(COMMON_NS::DataObjectRepository * repo, co
 	}
 	else {
 		gsoapProxy2_1 = gsoap_eml2_1::soap_new_eml21__EpcExternalPartReference(repo->getGsoapContext());
-		static_cast<gsoap_eml2_1::_eml21__EpcExternalPartReference*>(gsoapProxy2_1)->MimeType = gsoap_eml2_1::soap_new_std__string(repo->getGsoapContext(), 1);
+		static_cast<gsoap_eml2_1::_eml21__EpcExternalPartReference*>(gsoapProxy2_1)->MimeType = gsoap_eml2_1::soap_new_std__string(repo->getGsoapContext());
 		static_cast<gsoap_eml2_1::_eml21__EpcExternalPartReference*>(gsoapProxy2_1)->MimeType->assign("application/x-hdf5");
 	}
 

--- a/src/common/AbstractObject.cpp
+++ b/src/common/AbstractObject.cpp
@@ -101,7 +101,7 @@ void AbstractObject::changeToPartialObject()
 	string uuid = getUuid();
 	string title = getTitle();
 	string contentType = getContentType();
-	partialObject = gsoapProxy2_0_1 != nullptr ? gsoap_resqml2_0_1::soap_new_eml20__DataObjectReference(gsoapProxy2_0_1->soap, 1) : gsoap_resqml2_0_1::soap_new_eml20__DataObjectReference(gsoapProxy2_1->soap, 1);
+	partialObject = gsoapProxy2_0_1 != nullptr ? gsoap_resqml2_0_1::soap_new_eml20__DataObjectReference(gsoapProxy2_0_1->soap, 1) : gsoap_resqml2_0_1::soap_new_eml20__DataObjectReference(gsoapProxy2_1->soap);
 	partialObject->UUID = uuid;
 	partialObject->Title = title;
 	partialObject->ContentType = contentType;
@@ -425,18 +425,18 @@ void AbstractObject::setEditor(const std::string & editor)
 	if (!editor.empty()) {
 		if (gsoapProxy2_0_1 != nullptr) {
 			if (gsoapProxy2_0_1->Citation->Editor == nullptr)
-				gsoapProxy2_0_1->Citation->Editor = gsoap_resqml2_0_1::soap_new_std__string(gsoapProxy2_0_1->soap, 1);
+				gsoapProxy2_0_1->Citation->Editor = gsoap_resqml2_0_1::soap_new_std__string(gsoapProxy2_0_1->soap);
 			gsoapProxy2_0_1->Citation->Editor->assign(editor);
 		}
 		else if (gsoapProxy2_1 != nullptr) {
 			if (gsoapProxy2_1->Citation->Editor == nullptr)
-				gsoapProxy2_1->Citation->Editor = gsoap_eml2_1::soap_new_std__string(gsoapProxy2_1->soap, 1);
+				gsoapProxy2_1->Citation->Editor = gsoap_eml2_1::soap_new_std__string(gsoapProxy2_1->soap);
 			gsoapProxy2_1->Citation->Editor->assign(editor);
 		}
 #if WITH_EXPERIMENTAL
 		else if (gsoapProxy2_2 != nullptr) {
 			if (gsoapProxy2_2->Citation->Editor == nullptr)
-				gsoapProxy2_2->Citation->Editor = gsoap_eml2_2::soap_new_std__string(gsoapProxy2_2->soap, 1);
+				gsoapProxy2_2->Citation->Editor = gsoap_eml2_2::soap_new_std__string(gsoapProxy2_2->soap);
 			gsoapProxy2_2->Citation->Editor->assign(editor);
 		}
 #endif
@@ -520,18 +520,18 @@ void AbstractObject::setDescription(const std::string & description)
 	{
 		if (gsoapProxy2_0_1 != nullptr) {
 			if (gsoapProxy2_0_1->Citation->Description == nullptr)
-				gsoapProxy2_0_1->Citation->Description = gsoap_resqml2_0_1::soap_new_std__string(gsoapProxy2_0_1->soap, 1);
+				gsoapProxy2_0_1->Citation->Description = gsoap_resqml2_0_1::soap_new_std__string(gsoapProxy2_0_1->soap);
 			gsoapProxy2_0_1->Citation->Description->assign(description);
 		}
 		else if (gsoapProxy2_1 != nullptr) {
 			if (gsoapProxy2_1->Citation->Description == nullptr)
-				gsoapProxy2_1->Citation->Description = gsoap_eml2_1::soap_new_std__string(gsoapProxy2_1->soap, 1);
+				gsoapProxy2_1->Citation->Description = gsoap_eml2_1::soap_new_std__string(gsoapProxy2_1->soap);
 			gsoapProxy2_1->Citation->Description->assign(description);
 		}
 #if WITH_EXPERIMENTAL
 		else if (gsoapProxy2_2 != nullptr) {
 			if (gsoapProxy2_2->Citation->Description == nullptr)
-				gsoapProxy2_2->Citation->Description = gsoap_eml2_2::soap_new_std__string(gsoapProxy2_2->soap, 1);
+				gsoapProxy2_2->Citation->Description = gsoap_eml2_2::soap_new_std__string(gsoapProxy2_2->soap);
 			gsoapProxy2_2->Citation->Description->assign(description);
 		}
 #endif
@@ -601,18 +601,18 @@ void AbstractObject::setDescriptiveKeywords(const std::string & descriptiveKeywo
 	{
 		if (gsoapProxy2_0_1 != nullptr) {
 			if (gsoapProxy2_0_1->Citation->DescriptiveKeywords == nullptr)
-				gsoapProxy2_0_1->Citation->DescriptiveKeywords = gsoap_resqml2_0_1::soap_new_std__string(gsoapProxy2_0_1->soap, 1);
+				gsoapProxy2_0_1->Citation->DescriptiveKeywords = gsoap_resqml2_0_1::soap_new_std__string(gsoapProxy2_0_1->soap);
 			gsoapProxy2_0_1->Citation->DescriptiveKeywords->assign(descriptiveKeywords);
 		}
 		else if(gsoapProxy2_1 != nullptr) {
 			if (gsoapProxy2_1->Citation->DescriptiveKeywords == nullptr)
-				gsoapProxy2_1->Citation->DescriptiveKeywords = gsoap_eml2_1::soap_new_std__string(gsoapProxy2_1->soap, 1);
+				gsoapProxy2_1->Citation->DescriptiveKeywords = gsoap_eml2_1::soap_new_std__string(gsoapProxy2_1->soap);
 			gsoapProxy2_1->Citation->DescriptiveKeywords->assign(descriptiveKeywords);
 		}
 #if WITH_EXPERIMENTAL
 		else if (gsoapProxy2_2 != nullptr) {
 			if (gsoapProxy2_2->Citation->DescriptiveKeywords == nullptr)
-				gsoapProxy2_2->Citation->DescriptiveKeywords = gsoap_eml2_2::soap_new_std__string(gsoapProxy2_2->soap, 1);
+				gsoapProxy2_2->Citation->DescriptiveKeywords = gsoap_eml2_2::soap_new_std__string(gsoapProxy2_2->soap);
 			gsoapProxy2_2->Citation->DescriptiveKeywords->assign(descriptiveKeywords);
 		}
 #endif
@@ -623,24 +623,24 @@ void AbstractObject::setVersion(const std::string & version)
 {
 	if (gsoapProxy2_0_1 != nullptr) {
 		if (gsoapProxy2_0_1->Citation->VersionString == nullptr)
-			gsoapProxy2_0_1->Citation->VersionString = gsoap_resqml2_0_1::soap_new_std__string(gsoapProxy2_0_1->soap, 1);
+			gsoapProxy2_0_1->Citation->VersionString = gsoap_resqml2_0_1::soap_new_std__string(gsoapProxy2_0_1->soap);
 		gsoapProxy2_0_1->Citation->VersionString->assign(version);
 	}
 	else if (gsoapProxy2_1 != nullptr) {
 		if (gsoapProxy2_1->objectVersion == nullptr)
-			gsoapProxy2_1->objectVersion = gsoap_eml2_1::soap_new_std__string(gsoapProxy2_1->soap, 1);
+			gsoapProxy2_1->objectVersion = gsoap_eml2_1::soap_new_std__string(gsoapProxy2_1->soap);
 		gsoapProxy2_1->objectVersion->assign(version);
 	}
 #if WITH_EXPERIMENTAL
 	else if (gsoapProxy2_2 != nullptr) {
 		if (gsoapProxy2_2->objectVersion == nullptr)
-			gsoapProxy2_2->objectVersion = gsoap_eml2_2::soap_new_std__string(gsoapProxy2_2->soap, 1);
+			gsoapProxy2_2->objectVersion = gsoap_eml2_2::soap_new_std__string(gsoapProxy2_2->soap);
 		gsoapProxy2_2->objectVersion->assign(version);
 	}
 #endif
 	else if (partialObject != nullptr) {
 		if (partialObject->VersionString == nullptr)
-			partialObject->VersionString = gsoap_resqml2_0_1::soap_new_std__string(partialObject->soap, 1);
+			partialObject->VersionString = gsoap_resqml2_0_1::soap_new_std__string(partialObject->soap);
 		partialObject->VersionString->assign(version);
 	}
 }
@@ -652,17 +652,17 @@ void AbstractObject::initMandatoryMetadata()
 
 	if (gsoapProxy2_0_1 != nullptr) {
 		gsoapProxy2_0_1->schemaVersion = getXmlNamespaceVersion();
-		gsoapProxy2_0_1->Citation = gsoap_resqml2_0_1::soap_new_eml20__Citation(gsoapProxy2_0_1->soap, 1);
+		gsoapProxy2_0_1->Citation = gsoap_resqml2_0_1::soap_new_eml20__Citation(gsoapProxy2_0_1->soap);
 	}
 	else if (gsoapProxy2_1 != nullptr) {
 		// currently, WITSML and RESQML are by chance in v2.0 as well
 		gsoapProxy2_1->schemaVersion = getXmlNamespaceVersion();
-		gsoapProxy2_1->Citation = gsoap_eml2_1::soap_new_eml21__Citation(gsoapProxy2_1->soap, 1);
+		gsoapProxy2_1->Citation = gsoap_eml2_1::soap_new_eml21__Citation(gsoapProxy2_1->soap);
 	}
 #if WITH_EXPERIMENTAL
 	else if (gsoapProxy2_2 != nullptr) {
 		gsoapProxy2_2->schemaVersion = getXmlNamespaceVersion();
-		gsoapProxy2_2->Citation = gsoap_eml2_2::soap_new_eml22__Citation(gsoapProxy2_2->soap, 1);
+		gsoapProxy2_2->Citation = gsoap_eml2_2::soap_new_eml22__Citation(gsoapProxy2_2->soap);
 	}
 #endif
 
@@ -750,13 +750,13 @@ void AbstractObject::setGsoapProxy(gsoap_resqml2_0_1::eml20__AbstractCitedDataOb
 
 gsoap_resqml2_0_1::eml20__DataObjectReference* AbstractObject::newResqmlReference() const
 {
-	gsoap_resqml2_0_1::eml20__DataObjectReference* result = gsoap_resqml2_0_1::soap_new_eml20__DataObjectReference(getGsoapContext(), 1);
+	gsoap_resqml2_0_1::eml20__DataObjectReference* result = gsoap_resqml2_0_1::soap_new_eml20__DataObjectReference(getGsoapContext());
 	result->UUID = getUuid();
 	result->Title = getTitle();
 	result->ContentType = getContentType();
 	if (gsoapProxy2_0_1 != nullptr && hasVersion())
 	{
-		result->VersionString = gsoap_resqml2_0_1::soap_new_std__string(gsoapProxy2_0_1->soap, 1);
+		result->VersionString = gsoap_resqml2_0_1::soap_new_std__string(gsoapProxy2_0_1->soap);
 		result->VersionString->assign(getVersion());
 	}
 
@@ -765,13 +765,13 @@ gsoap_resqml2_0_1::eml20__DataObjectReference* AbstractObject::newResqmlReferenc
 
 gsoap_eml2_1::eml21__DataObjectReference* AbstractObject::newEmlReference() const
 {
-	gsoap_eml2_1::eml21__DataObjectReference* result = gsoap_eml2_1::soap_new_eml21__DataObjectReference(getGsoapContext(), 1);
+	gsoap_eml2_1::eml21__DataObjectReference* result = gsoap_eml2_1::soap_new_eml21__DataObjectReference(getGsoapContext());
 	result->Uuid = getUuid();
 	result->Title = getTitle();
 	result->ContentType = getContentType();
 	if (gsoapProxy2_0_1 != nullptr && hasVersion()) // Not partial transfer
 	{
-		result->VersionString = gsoap_eml2_1::soap_new_std__string(gsoapProxy2_0_1->soap, 1);
+		result->VersionString = gsoap_eml2_1::soap_new_std__string(gsoapProxy2_0_1->soap);
 		result->VersionString->assign(getVersion());
 	}
 
@@ -783,13 +783,13 @@ gsoap_eml2_2::eml22__DataObjectReference* AbstractObject::newEml22Reference() co
 {
 	ostringstream oss;
 
-	gsoap_eml2_2::eml22__DataObjectReference* result = gsoap_eml2_2::soap_new_eml22__DataObjectReference(getGsoapContext(), 1);
+	gsoap_eml2_2::eml22__DataObjectReference* result = gsoap_eml2_2::soap_new_eml22__DataObjectReference(getGsoapContext());
 	result->Uuid = getUuid();
 	result->Title = getTitle();
 	result->ContentType = getContentType();
 	if (gsoapProxy2_2 != nullptr) // Not partial transfer
 	{
-		result->ObjectVersion = gsoap_eml2_1::soap_new_std__string(gsoapProxy2_2->soap, 1);
+		result->ObjectVersion = gsoap_eml2_1::soap_new_std__string(gsoapProxy2_2->soap);
 		if (getLastUpdate() != -1)
 			oss << getLastUpdate();
 		else
@@ -806,11 +806,11 @@ gsoap_resqml2_0_1::resqml20__ContactElementReference* AbstractObject::newResqmlC
 	if (partialObject != nullptr)
 		throw invalid_argument("The wrapped gsoap proxy must not be null");
 
-	gsoap_resqml2_0_1::resqml20__ContactElementReference* result = gsoap_resqml2_0_1::soap_new_resqml20__ContactElementReference(gsoapProxy2_0_1->soap, 1);
+	gsoap_resqml2_0_1::resqml20__ContactElementReference* result = gsoap_resqml2_0_1::soap_new_resqml20__ContactElementReference(gsoapProxy2_0_1->soap);
 	result->UUID = getUuid();
 	if (gsoapProxy2_0_1 != nullptr && hasVersion()) // Not partial transfer
 	{
-		result->VersionString = gsoap_eml2_1::soap_new_std__string(gsoapProxy2_0_1->soap, 1);
+		result->VersionString = gsoap_eml2_1::soap_new_std__string(gsoapProxy2_0_1->soap);
 		result->VersionString->assign(getVersion());
 	}
 	result->Title = gsoapProxy2_0_1->Citation->Title;
@@ -887,21 +887,21 @@ void AbstractObject::addAlias(const std::string & authority, const std::string &
 		throw invalid_argument("The wrapped gsoap proxy must not be null");
 
 	if (gsoapProxy2_0_1 != nullptr) {
-		gsoap_resqml2_0_1::eml20__ObjectAlias* alias = gsoap_resqml2_0_1::soap_new_eml20__ObjectAlias(gsoapProxy2_0_1->soap, 1);
-		alias->authority = gsoap_resqml2_0_1::soap_new_std__string(gsoapProxy2_0_1->soap, 1);
+		gsoap_resqml2_0_1::eml20__ObjectAlias* alias = gsoap_resqml2_0_1::soap_new_eml20__ObjectAlias(gsoapProxy2_0_1->soap);
+		alias->authority = gsoap_resqml2_0_1::soap_new_std__string(gsoapProxy2_0_1->soap);
 		alias->authority->assign(authority);
 		alias->Identifier = title;
 		gsoapProxy2_0_1->Aliases.push_back(alias);
 	}
 	else if (gsoapProxy2_1 != nullptr) {
-		gsoap_eml2_1::eml21__ObjectAlias* alias = gsoap_eml2_1::soap_new_eml21__ObjectAlias(gsoapProxy2_1->soap, 1);
+		gsoap_eml2_1::eml21__ObjectAlias* alias = gsoap_eml2_1::soap_new_eml21__ObjectAlias(gsoapProxy2_1->soap);
 		alias->authority = authority;
 		alias->Identifier = title;
 		gsoapProxy2_1->Aliases.push_back(alias);
 	}
 #if WITH_EXPERIMENTAL
 	else if (gsoapProxy2_2 != nullptr) {
-		gsoap_eml2_2::eml22__ObjectAlias* alias = gsoap_eml2_2::soap_new_eml22__ObjectAlias(gsoapProxy2_2->soap, 1);
+		gsoap_eml2_2::eml22__ObjectAlias* alias = gsoap_eml2_2::soap_new_eml22__ObjectAlias(gsoapProxy2_2->soap);
 		alias->authority = authority;
 		alias->Identifier = title;
 		gsoapProxy2_2->Aliases.push_back(alias);
@@ -1013,7 +1013,7 @@ RESQML2_NS::Activity * AbstractObject::getActivity(unsigned int index) const
 
 void AbstractObject::pushBackExtraMetadataV2_0_1(const std::string & key, const std::string & value)
 {
-	gsoap_resqml2_0_1::resqml20__NameValuePair* stringPair = gsoap_resqml2_0_1::soap_new_resqml20__NameValuePair(gsoapProxy2_0_1->soap, 1);
+	gsoap_resqml2_0_1::resqml20__NameValuePair* stringPair = gsoap_resqml2_0_1::soap_new_resqml20__NameValuePair(gsoapProxy2_0_1->soap);
 	stringPair->Name = key;
 	stringPair->Value = value;
 	static_cast<gsoap_resqml2_0_1::resqml20__AbstractResqmlDataObject*>(gsoapProxy2_0_1)->ExtraMetadata.push_back(stringPair);
@@ -1025,9 +1025,9 @@ void AbstractObject::pushBackExtraMetadataV2_1(const std::string & key, const st
 		throw invalid_argument("An extra metadata value cannot be greater than 64 chars.");
 	}
 
-	gsoap_eml2_1::eml21__ExtensionNameValue* stringPair = gsoap_eml2_1::soap_new_eml21__ExtensionNameValue(gsoapProxy2_1->soap, 1);
+	gsoap_eml2_1::eml21__ExtensionNameValue* stringPair = gsoap_eml2_1::soap_new_eml21__ExtensionNameValue(gsoapProxy2_1->soap);
 	stringPair->Name = key;
-	stringPair->Value = gsoap_eml2_1::soap_new_eml21__StringMeasure(gsoapProxy2_1->soap, 1);
+	stringPair->Value = gsoap_eml2_1::soap_new_eml21__StringMeasure(gsoapProxy2_1->soap);
 	stringPair->Value->__item = value;
 	gsoapProxy2_1->ExtensionNameValue.push_back(stringPair);
 }
@@ -1039,9 +1039,9 @@ void AbstractObject::pushBackExtraMetadataV2_2(const std::string & key, const st
 		throw invalid_argument("An extra metadata value cannot be greater than 64 chars.");
 	}
 
-	gsoap_eml2_2::eml22__ExtensionNameValue* stringPair = gsoap_eml2_2::soap_new_eml22__ExtensionNameValue(gsoapProxy2_2->soap, 1);
+	gsoap_eml2_2::eml22__ExtensionNameValue* stringPair = gsoap_eml2_2::soap_new_eml22__ExtensionNameValue(gsoapProxy2_2->soap);
 	stringPair->Name = key;
-	stringPair->Value = gsoap_eml2_2::soap_new_eml22__StringMeasure(gsoapProxy2_2->soap, 1);
+	stringPair->Value = gsoap_eml2_2::soap_new_eml22__StringMeasure(gsoapProxy2_2->soap);
 	stringPair->Value->__item = value;
 	gsoapProxy2_2->ExtensionNameValue.push_back(stringPair);
 }

--- a/src/common/DataObjectRepository.cpp
+++ b/src/common/DataObjectRepository.cpp
@@ -154,7 +154,7 @@ namespace {
 /////// RESQML //////
 /////////////////////
 #define GET_RESQML_2_0_1_GSOAP_PROXY_FROM_GSOAP_CONTEXT(className)\
-	gsoap_resqml2_0_1::_resqml20__##className* read = gsoap_resqml2_0_1::soap_new_resqml20__obj_USCORE##className(gsoapContext, 1);\
+	gsoap_resqml2_0_1::_resqml20__##className* read = gsoap_resqml2_0_1::soap_new_resqml20__obj_USCORE##className(gsoapContext);\
 	soap_read_resqml20__obj_USCORE##className(gsoapContext, read);
 
 
@@ -172,7 +172,7 @@ namespace {
 /////// RESQML 2.2 //////
 ///////////////////////////
 #define GET_RESQML_2_2_GSOAP_PROXY_FROM_GSOAP_CONTEXT(className)\
-	gsoap_eml2_2::_resqml22__##className* read = gsoap_eml2_2::soap_new_resqml22__##className(gsoapContext, 1);\
+	gsoap_eml2_2::_resqml22__##className* read = gsoap_eml2_2::soap_new_resqml22__##className(gsoapContext);\
 	soap_read_resqml22__##className(gsoapContext, read);
 
 #define GET_RESQML_2_2_FESAPI_WRAPPER_FROM_GSOAP_CONTEXT(className)\
@@ -189,7 +189,7 @@ namespace {
 ///// WITSML 2.1 ////
 /////////////////////
 #define GET_WITSML_2_GSOAP_PROXY_FROM_GSOAP_CONTEXT(className, gsoapNameSpace)\
-	gsoapNameSpace::_witsml20__##className* read = gsoapNameSpace::soap_new_witsml20__##className(gsoapContext, 1);\
+	gsoapNameSpace::_witsml20__##className* read = gsoapNameSpace::soap_new_witsml20__##className(gsoapContext);\
 	gsoapNameSpace::soap_read_witsml20__##className(gsoapContext, read);
 
 #define GET_WITSML_2_FESAPI_WRAPPER_FROM_GSOAP_CONTEXT(classNamespace, className, gsoapNameSpace)\
@@ -206,7 +206,7 @@ namespace {
 ////// EML 2.2 //////
 /////////////////////
 #define GET_EML_2_2_GSOAP_PROXY_FROM_GSOAP_CONTEXT(className, gsoapNameSpace)\
-	gsoapNameSpace::_eml22__##className* read = gsoapNameSpace::soap_new_eml22__##className(gsoapContext, 1);\
+	gsoapNameSpace::_eml22__##className* read = gsoapNameSpace::soap_new_eml22__##className(gsoapContext);\
 	gsoapNameSpace::soap_read_eml22__##className(gsoapContext, read);
 #define GET_EML_2_2_FESAPI_WRAPPER_FROM_GSOAP_CONTEXT(classNamespace, className, gsoapNameSpace)\
 	GET_EML_2_2_GSOAP_PROXY_FROM_GSOAP_CONTEXT(className, gsoapNameSpace)\
@@ -1064,7 +1064,7 @@ AbstractIjkGridRepresentation* DataObjectRepository::createPartialIjkGridReprese
 
 AbstractIjkGridRepresentation* DataObjectRepository::createPartialTruncatedIjkGridRepresentation(const std::string & guid, const std::string & title)
 {
-	gsoap_resqml2_0_1::eml20__DataObjectReference* dor = gsoap_resqml2_0_1::soap_new_eml20__DataObjectReference(getGsoapContext(), 1);
+	gsoap_resqml2_0_1::eml20__DataObjectReference* dor = gsoap_resqml2_0_1::soap_new_eml20__DataObjectReference(getGsoapContext());
 	dor->UUID = guid;
 	dor->Title = title;
 	return new AbstractIjkGridRepresentation(dor, true);

--- a/src/common/DataObjectRepository.h
+++ b/src/common/DataObjectRepository.h
@@ -297,7 +297,7 @@ namespace COMMON_NS
 		{
 			std::istringstream iss(xml);
 			setGsoapStream(&iss);
-			gsoap_resqml2_0_1::_eml20__EpcExternalPartReference* read = gsoap_resqml2_0_1::soap_new_eml20__obj_USCOREEpcExternalPartReference(gsoapContext, 1);
+			gsoap_resqml2_0_1::_eml20__EpcExternalPartReference* read = gsoap_resqml2_0_1::soap_new_eml20__obj_USCOREEpcExternalPartReference(gsoapContext);
 			soap_read_eml20__obj_USCOREEpcExternalPartReference(gsoapContext, read);
 
 			if (gsoapContext->error != SOAP_OK) {
@@ -708,7 +708,7 @@ namespace COMMON_NS
 		template <class valueType>
 		valueType* createPartial(const std::string & guid, const std::string & title)
 		{
-			gsoap_resqml2_0_1::eml20__DataObjectReference* dor = gsoap_resqml2_0_1::soap_new_eml20__DataObjectReference(gsoapContext, 1);
+			gsoap_resqml2_0_1::eml20__DataObjectReference* dor = gsoap_resqml2_0_1::soap_new_eml20__DataObjectReference(gsoapContext);
 			dor->UUID = guid.empty() ? generateRandomUuidAsString() : guid;
 			dor->Title = title;
 			valueType* result = new valueType(dor);
@@ -724,10 +724,10 @@ namespace COMMON_NS
 		template <class valueType>
 		valueType* createPartial(const std::string & guid, const std::string & title, const std::string & version)
 		{
-			gsoap_resqml2_0_1::eml20__DataObjectReference* dor = gsoap_resqml2_0_1::soap_new_eml20__DataObjectReference(gsoapContext, 1);
+			gsoap_resqml2_0_1::eml20__DataObjectReference* dor = gsoap_resqml2_0_1::soap_new_eml20__DataObjectReference(gsoapContext);
 			dor->UUID = guid.empty() ? generateRandomUuidAsString() : guid;
 			dor->Title = title;
-			dor->VersionString = gsoap_resqml2_0_1::soap_new_std__string(gsoapContext, 1);
+			dor->VersionString = gsoap_resqml2_0_1::soap_new_std__string(gsoapContext);
 			dor->VersionString->assign(version);
 			valueType* result = new valueType(dor);
 			addOrReplaceDataObject(result);

--- a/src/resqml2/AbstractColumnLayerGridRepresentation.cpp
+++ b/src/resqml2/AbstractColumnLayerGridRepresentation.cpp
@@ -81,12 +81,12 @@ void AbstractColumnLayerGridRepresentation::setIntervalAssociationWithStratigrap
 
 	if (gsoapProxy2_0_1 != nullptr) {
 		resqml20__AbstractColumnLayerGridRepresentation* rep = static_cast<resqml20__AbstractColumnLayerGridRepresentation*>(gsoapProxy2_0_1);
-		rep->IntervalStratigraphicUnits = soap_new_resqml20__IntervalStratigraphicUnits(rep->soap, 1);
+		rep->IntervalStratigraphicUnits = soap_new_resqml20__IntervalStratigraphicUnits(rep->soap);
 		rep->IntervalStratigraphicUnits->StratigraphicOrganization = stratiOrgInterp->newResqmlReference();
 
-		resqml20__IntegerHdf5Array* xmlDataset = soap_new_resqml20__IntegerHdf5Array(rep->soap, 1);
+		resqml20__IntegerHdf5Array* xmlDataset = soap_new_resqml20__IntegerHdf5Array(rep->soap);
 		xmlDataset->NullValue = nullValue;
-		xmlDataset->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+		xmlDataset->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 		xmlDataset->Values->HdfProxy = hdfProxy->newResqmlReference();
 		xmlDataset->Values->PathInHdfFile = "/RESQML/" + rep->uuid + "/IntervalStratigraphicUnits";
 		rep->IntervalStratigraphicUnits->UnitIndices = xmlDataset;

--- a/src/resqml2/AbstractGridRepresentation.cpp
+++ b/src/resqml2/AbstractGridRepresentation.cpp
@@ -147,21 +147,21 @@ AbstractGridRepresentation * AbstractGridRepresentation::getChildGrid(unsigned i
 gsoap_resqml2_0_1::resqml20__Regrid* AbstractGridRepresentation::createRegrid(unsigned int indexRegridStart, unsigned int * childCellCountPerInterval, unsigned int * parentCellCountPerInterval, unsigned int intervalCount, double * childCellWeights,
 	const std::string & dimension, COMMON_NS::AbstractHdfProxy * proxy, bool forceConstantCellCountPerInterval)
 {
-	gsoap_resqml2_0_1::resqml20__Regrid* regrid = gsoap_resqml2_0_1::soap_new_resqml20__Regrid(gsoapProxy2_0_1->soap, 1);
+	gsoap_resqml2_0_1::resqml20__Regrid* regrid = gsoap_resqml2_0_1::soap_new_resqml20__Regrid(gsoapProxy2_0_1->soap);
 	regrid->InitialIndexOnParentGrid = indexRegridStart;
-	regrid->Intervals = gsoap_resqml2_0_1::soap_new_resqml20__Intervals(gsoapProxy2_0_1->soap, 1);
+	regrid->Intervals = gsoap_resqml2_0_1::soap_new_resqml20__Intervals(gsoapProxy2_0_1->soap);
 	regrid->Intervals->IntervalCount = intervalCount;
 	
 	if (intervalCount == 0) {
 		throw invalid_argument("Cannot regrid an empty list of intervals.");
 	}
 	else if (intervalCount == 1 || forceConstantCellCountPerInterval) {
-		gsoap_resqml2_0_1::resqml20__IntegerConstantArray* xmlChildCountPerInterval = gsoap_resqml2_0_1::soap_new_resqml20__IntegerConstantArray(gsoapProxy2_0_1->soap, 1);
+		gsoap_resqml2_0_1::resqml20__IntegerConstantArray* xmlChildCountPerInterval = gsoap_resqml2_0_1::soap_new_resqml20__IntegerConstantArray(gsoapProxy2_0_1->soap);
 		xmlChildCountPerInterval->Value = *childCellCountPerInterval;
 		xmlChildCountPerInterval->Count = intervalCount;
 		regrid->Intervals->ChildCountPerInterval = xmlChildCountPerInterval;
 
-		gsoap_resqml2_0_1::resqml20__IntegerConstantArray* xmlParentCountPerInterval = gsoap_resqml2_0_1::soap_new_resqml20__IntegerConstantArray(gsoapProxy2_0_1->soap, 1);
+		gsoap_resqml2_0_1::resqml20__IntegerConstantArray* xmlParentCountPerInterval = gsoap_resqml2_0_1::soap_new_resqml20__IntegerConstantArray(gsoapProxy2_0_1->soap);
 		xmlParentCountPerInterval->Value = *parentCellCountPerInterval;
 		xmlParentCountPerInterval->Count = intervalCount;
 		regrid->Intervals->ParentCountPerInterval = xmlParentCountPerInterval;
@@ -176,17 +176,17 @@ gsoap_resqml2_0_1::resqml20__Regrid* AbstractGridRepresentation::createRegrid(un
 		}
 		getRepository()->addRelationship(this, proxy);
 
-		gsoap_resqml2_0_1::resqml20__IntegerHdf5Array* hdf5ChildCountPerInterval = gsoap_resqml2_0_1::soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap, 1);
+		gsoap_resqml2_0_1::resqml20__IntegerHdf5Array* hdf5ChildCountPerInterval = gsoap_resqml2_0_1::soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap);
 		regrid->Intervals->ChildCountPerInterval = hdf5ChildCountPerInterval;
 		hdf5ChildCountPerInterval->NullValue = (numeric_limits<unsigned int>::max)();
-		hdf5ChildCountPerInterval->Values = gsoap_resqml2_0_1::soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+		hdf5ChildCountPerInterval->Values = gsoap_resqml2_0_1::soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 		hdf5ChildCountPerInterval->Values->HdfProxy = proxy->newResqmlReference();
 		hdf5ChildCountPerInterval->Values->PathInHdfFile = "/RESQML/" + gsoapProxy2_0_1->uuid + "/ParentWindow_" + dimension + "Regrid_ChildCountPerInterval";
 
-		gsoap_resqml2_0_1::resqml20__IntegerHdf5Array* hdf5ParentCountPerInterval = gsoap_resqml2_0_1::soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap, 1);
+		gsoap_resqml2_0_1::resqml20__IntegerHdf5Array* hdf5ParentCountPerInterval = gsoap_resqml2_0_1::soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap);
 		regrid->Intervals->ParentCountPerInterval = hdf5ParentCountPerInterval;
 		hdf5ParentCountPerInterval->NullValue = (numeric_limits<unsigned int>::max)();
-		hdf5ParentCountPerInterval->Values = gsoap_resqml2_0_1::soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+		hdf5ParentCountPerInterval->Values = gsoap_resqml2_0_1::soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 		hdf5ParentCountPerInterval->Values->HdfProxy = proxy->newResqmlReference();
 		hdf5ParentCountPerInterval->Values->PathInHdfFile = "/RESQML/" + gsoapProxy2_0_1->uuid + "/ParentWindow_" + dimension + "Regrid_ParentCountPerInterval";
 		
@@ -205,9 +205,9 @@ gsoap_resqml2_0_1::resqml20__Regrid* AbstractGridRepresentation::createRegrid(un
 		}
 		getRepository()->addRelationship(this, proxy);
 
-		gsoap_resqml2_0_1::resqml20__DoubleHdf5Array* hdf5ChildCellWeights = gsoap_resqml2_0_1::soap_new_resqml20__DoubleHdf5Array(gsoapProxy2_0_1->soap, 1);
+		gsoap_resqml2_0_1::resqml20__DoubleHdf5Array* hdf5ChildCellWeights = gsoap_resqml2_0_1::soap_new_resqml20__DoubleHdf5Array(gsoapProxy2_0_1->soap);
 		regrid->Intervals->ChildCellWeights = hdf5ChildCellWeights;
-		hdf5ChildCellWeights->Values = gsoap_resqml2_0_1::soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+		hdf5ChildCellWeights->Values = gsoap_resqml2_0_1::soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 		hdf5ChildCellWeights->Values->HdfProxy = proxy->newResqmlReference();
 		hdf5ChildCellWeights->Values->PathInHdfFile = "/RESQML/" + gsoapProxy2_0_1->uuid + "/ParentWindow_" + dimension + "Regrid_ChildCellWeights";
 		
@@ -231,7 +231,7 @@ void AbstractGridRepresentation::setParentWindow(ULONG64 * cellIndices, ULONG64 
 	if (gsoapProxy2_0_1 != nullptr) {
 		gsoap_resqml2_0_1::resqml20__AbstractGridRepresentation* rep = static_cast<gsoap_resqml2_0_1::resqml20__AbstractGridRepresentation*>(gsoapProxy2_0_1);
 
-		gsoap_resqml2_0_1::resqml20__CellParentWindow* cpw = gsoap_resqml2_0_1::soap_new_resqml20__CellParentWindow(rep->soap, 1);
+		gsoap_resqml2_0_1::resqml20__CellParentWindow* cpw = gsoap_resqml2_0_1::soap_new_resqml20__CellParentWindow(rep->soap);
 		rep->ParentWindow = cpw;
 
 		cpw->ParentGrid = parentGrid->newResqmlReference();
@@ -245,11 +245,11 @@ void AbstractGridRepresentation::setParentWindow(ULONG64 * cellIndices, ULONG64 
 			}
 			getRepository()->addRelationship(this, proxy);
 
-			gsoap_resqml2_0_1::resqml20__IntegerHdf5Array* hdf5CellIndices = gsoap_resqml2_0_1::soap_new_resqml20__IntegerHdf5Array(rep->soap, 1);
+			gsoap_resqml2_0_1::resqml20__IntegerHdf5Array* hdf5CellIndices = gsoap_resqml2_0_1::soap_new_resqml20__IntegerHdf5Array(rep->soap);
 			cpw->CellIndices = hdf5CellIndices;
 
 			hdf5CellIndices->NullValue = (numeric_limits<ULONG64>::max)();
-			hdf5CellIndices->Values = gsoap_resqml2_0_1::soap_new_eml20__Hdf5Dataset(rep->soap, 1);
+			hdf5CellIndices->Values = gsoap_resqml2_0_1::soap_new_eml20__Hdf5Dataset(rep->soap);
 			hdf5CellIndices->Values->HdfProxy = proxy->newResqmlReference();
 			hdf5CellIndices->Values->PathInHdfFile = "/RESQML/" + gsoapProxy2_0_1->uuid + "/ParentWindow_CellIndices";
 		
@@ -258,7 +258,7 @@ void AbstractGridRepresentation::setParentWindow(ULONG64 * cellIndices, ULONG64 
 			proxy->writeArrayNdOfGSoapULong64Values(gsoapProxy2_0_1->uuid, "ParentWindow_CellIndices", cellIndices, &numValues, 1);
 		}
 		else { // cellIndexCount == 1
-			gsoap_resqml2_0_1::resqml20__IntegerConstantArray* xmlCellIndices = gsoap_resqml2_0_1::soap_new_resqml20__IntegerConstantArray(rep->soap, 1);
+			gsoap_resqml2_0_1::resqml20__IntegerConstantArray* xmlCellIndices = gsoap_resqml2_0_1::soap_new_resqml20__IntegerConstantArray(rep->soap);
 			xmlCellIndices->Value = *cellIndices;
 			xmlCellIndices->Count = 1;
 			cpw->CellIndices = xmlCellIndices;
@@ -285,7 +285,7 @@ void AbstractGridRepresentation::setParentWindow(unsigned int * columnIndices, u
 	if (gsoapProxy2_0_1 != nullptr) {
 		gsoap_resqml2_0_1::resqml20__AbstractGridRepresentation* rep = static_cast<gsoap_resqml2_0_1::resqml20__AbstractGridRepresentation*>(gsoapProxy2_0_1);
 
-		gsoap_resqml2_0_1::resqml20__ColumnLayerParentWindow* clpw = gsoap_resqml2_0_1::soap_new_resqml20__ColumnLayerParentWindow(rep->soap, 1);
+		gsoap_resqml2_0_1::resqml20__ColumnLayerParentWindow* clpw = gsoap_resqml2_0_1::soap_new_resqml20__ColumnLayerParentWindow(rep->soap);
 		rep->ParentWindow = clpw;
 
 		clpw->ParentGrid = parentGrid->newResqmlReference();
@@ -301,11 +301,11 @@ void AbstractGridRepresentation::setParentWindow(unsigned int * columnIndices, u
 			}
 			getRepository()->addRelationship(this, proxy);
 
-			gsoap_resqml2_0_1::resqml20__IntegerHdf5Array* hdf5ColumnIndices = gsoap_resqml2_0_1::soap_new_resqml20__IntegerHdf5Array(rep->soap, 1);
+			gsoap_resqml2_0_1::resqml20__IntegerHdf5Array* hdf5ColumnIndices = gsoap_resqml2_0_1::soap_new_resqml20__IntegerHdf5Array(rep->soap);
 			clpw->ColumnIndices = hdf5ColumnIndices;
 
 			hdf5ColumnIndices->NullValue = (numeric_limits<unsigned int>::max)();
-			hdf5ColumnIndices->Values = gsoap_resqml2_0_1::soap_new_eml20__Hdf5Dataset(rep->soap, 1);
+			hdf5ColumnIndices->Values = gsoap_resqml2_0_1::soap_new_eml20__Hdf5Dataset(rep->soap);
 			hdf5ColumnIndices->Values->HdfProxy = proxy->newResqmlReference();
 			hdf5ColumnIndices->Values->PathInHdfFile = "/RESQML/" + gsoapProxy2_0_1->uuid + "/ParentWindow_ColumnIndices";
 
@@ -315,7 +315,7 @@ void AbstractGridRepresentation::setParentWindow(unsigned int * columnIndices, u
 		}
 		else if (columnIndexCount == 1)
 		{
-			gsoap_resqml2_0_1::resqml20__IntegerConstantArray* xmlColumnIndices = gsoap_resqml2_0_1::soap_new_resqml20__IntegerConstantArray(rep->soap, 1);
+			gsoap_resqml2_0_1::resqml20__IntegerConstantArray* xmlColumnIndices = gsoap_resqml2_0_1::soap_new_resqml20__IntegerConstantArray(rep->soap);
 			xmlColumnIndices->Value = *columnIndices;
 			xmlColumnIndices->Count = 1;
 			clpw->ColumnIndices = xmlColumnIndices;
@@ -347,7 +347,7 @@ void AbstractGridRepresentation::setParentWindow(
 	if (gsoapProxy2_0_1 != nullptr) {
 		gsoap_resqml2_0_1::resqml20__AbstractGridRepresentation* rep = static_cast<gsoap_resqml2_0_1::resqml20__AbstractGridRepresentation*>(gsoapProxy2_0_1);
 
-		gsoap_resqml2_0_1::resqml20__IjkParentWindow* ijkpw = gsoap_resqml2_0_1::soap_new_resqml20__IjkParentWindow(rep->soap, 1);
+		gsoap_resqml2_0_1::resqml20__IjkParentWindow* ijkpw = gsoap_resqml2_0_1::soap_new_resqml20__IjkParentWindow(rep->soap);
 		rep->ParentWindow = ijkpw;
 
 		ijkpw->ParentGrid = parentGrid->newResqmlReference();
@@ -380,7 +380,7 @@ void AbstractGridRepresentation::setParentWindow(
 	if (gsoapProxy2_0_1 != nullptr) {
 		gsoap_resqml2_0_1::resqml20__AbstractGridRepresentation* rep = static_cast<gsoap_resqml2_0_1::resqml20__AbstractGridRepresentation*>(gsoapProxy2_0_1);
 
-		gsoap_resqml2_0_1::resqml20__IjkParentWindow* ijkpw = gsoap_resqml2_0_1::soap_new_resqml20__IjkParentWindow(rep->soap, 1);
+		gsoap_resqml2_0_1::resqml20__IjkParentWindow* ijkpw = gsoap_resqml2_0_1::soap_new_resqml20__IjkParentWindow(rep->soap);
 		rep->ParentWindow = ijkpw;
 
 		ijkpw->ParentGrid = parentGrid->newResqmlReference();
@@ -423,9 +423,9 @@ void AbstractGridRepresentation::setForcedNonRegridedParentCell(ULONG64 * cellIn
 			if (cellIndexCount > 1 && proxy != nullptr)
 			{
 				getRepository()->addRelationship(this, proxy);
-				xmlCellIndices = gsoap_resqml2_0_1::soap_new_resqml20__IntegerHdf5Array(parentWindow->soap, 1);
+				xmlCellIndices = gsoap_resqml2_0_1::soap_new_resqml20__IntegerHdf5Array(parentWindow->soap);
 				static_cast<gsoap_resqml2_0_1::resqml20__IntegerHdf5Array*>(xmlCellIndices)->NullValue = (numeric_limits<ULONG64>::max)();
-				static_cast<gsoap_resqml2_0_1::resqml20__IntegerHdf5Array*>(xmlCellIndices)->Values = gsoap_resqml2_0_1::soap_new_eml20__Hdf5Dataset(parentWindow->soap, 1);
+				static_cast<gsoap_resqml2_0_1::resqml20__IntegerHdf5Array*>(xmlCellIndices)->Values = gsoap_resqml2_0_1::soap_new_eml20__Hdf5Dataset(parentWindow->soap);
 				static_cast<gsoap_resqml2_0_1::resqml20__IntegerHdf5Array*>(xmlCellIndices)->Values->HdfProxy = proxy->newResqmlReference();
 				static_cast<gsoap_resqml2_0_1::resqml20__IntegerHdf5Array*>(xmlCellIndices)->Values->PathInHdfFile = "/RESQML/" + gsoapProxy2_0_1->uuid + "/ParentWindow_CellIndices";
 			
@@ -435,7 +435,7 @@ void AbstractGridRepresentation::setForcedNonRegridedParentCell(ULONG64 * cellIn
 			}
 			else if (cellIndexCount == 1)
 			{
-				xmlCellIndices = gsoap_resqml2_0_1::soap_new_resqml20__IntegerConstantArray(parentWindow->soap, 1);
+				xmlCellIndices = gsoap_resqml2_0_1::soap_new_resqml20__IntegerConstantArray(parentWindow->soap);
 				static_cast<gsoap_resqml2_0_1::resqml20__IntegerConstantArray*>(xmlCellIndices)->Value = *cellIndices;
 				static_cast<gsoap_resqml2_0_1::resqml20__IntegerConstantArray*>(xmlCellIndices)->Count = 1;
 			}
@@ -500,14 +500,14 @@ void AbstractGridRepresentation::setCellOverlap(const ULONG64 & parentChildCellP
 			if (parentChildCellPairCount > 0 && proxy != nullptr)
 			{
 				getRepository()->addRelationship(this, proxy);
-				parentWindow->CellOverlap = gsoap_resqml2_0_1::soap_new_resqml20__CellOverlap(gsoapProxy2_0_1->soap, 1);
+				parentWindow->CellOverlap = gsoap_resqml2_0_1::soap_new_resqml20__CellOverlap(gsoapProxy2_0_1->soap);
 
-				gsoap_resqml2_0_1::resqml20__IntegerHdf5Array* hdf5CellPairs = gsoap_resqml2_0_1::soap_new_resqml20__IntegerHdf5Array(parentWindow->soap, 1);
-				parentWindow->CellOverlap->__CellOverlap_sequence = gsoap_resqml2_0_1::soap_new___resqml20__CellOverlap_sequence(parentWindow->soap, 1);
+				gsoap_resqml2_0_1::resqml20__IntegerHdf5Array* hdf5CellPairs = gsoap_resqml2_0_1::soap_new_resqml20__IntegerHdf5Array(parentWindow->soap);
+				parentWindow->CellOverlap->__CellOverlap_sequence = gsoap_resqml2_0_1::soap_new___resqml20__CellOverlap_sequence(parentWindow->soap);
 				parentWindow->CellOverlap->__CellOverlap_sequence->Count = parentChildCellPairCount;
 				parentWindow->CellOverlap->__CellOverlap_sequence->ParentChildCellPairs = hdf5CellPairs;
 				hdf5CellPairs->NullValue = (numeric_limits<ULONG64>::max)();
-				hdf5CellPairs->Values = gsoap_resqml2_0_1::soap_new_eml20__Hdf5Dataset(parentWindow->soap, 1);
+				hdf5CellPairs->Values = gsoap_resqml2_0_1::soap_new_eml20__Hdf5Dataset(parentWindow->soap);
 				hdf5CellPairs->Values->HdfProxy = proxy->newResqmlReference();
 				hdf5CellPairs->Values->PathInHdfFile = "/RESQML/" + gsoapProxy2_0_1->uuid + "/ParentWindow_CellOverlap";
 		
@@ -522,13 +522,13 @@ void AbstractGridRepresentation::setCellOverlap(const ULONG64 & parentChildCellP
 
 			if (overlapVolumes != nullptr)
 			{
-				parentWindow->CellOverlap->__CellOverlap_sequence->OverlapVolume = gsoap_resqml2_0_1::soap_new_resqml20__OverlapVolume(parentWindow->soap, 1);
-				parentWindow->CellOverlap->__CellOverlap_sequence->OverlapVolume->__OverlapVolume_sequence = gsoap_resqml2_0_1::soap_new___resqml20__OverlapVolume_sequence(parentWindow->soap, 1);
+				parentWindow->CellOverlap->__CellOverlap_sequence->OverlapVolume = gsoap_resqml2_0_1::soap_new_resqml20__OverlapVolume(parentWindow->soap);
+				parentWindow->CellOverlap->__CellOverlap_sequence->OverlapVolume->__OverlapVolume_sequence = gsoap_resqml2_0_1::soap_new___resqml20__OverlapVolume_sequence(parentWindow->soap);
 				parentWindow->CellOverlap->__CellOverlap_sequence->OverlapVolume->__OverlapVolume_sequence->VolumeUom = volumeUom;
 
-				gsoap_resqml2_0_1::resqml20__DoubleHdf5Array* hdf5OverlapVolume = gsoap_resqml2_0_1::soap_new_resqml20__DoubleHdf5Array(parentWindow->soap, 1);
+				gsoap_resqml2_0_1::resqml20__DoubleHdf5Array* hdf5OverlapVolume = gsoap_resqml2_0_1::soap_new_resqml20__DoubleHdf5Array(parentWindow->soap);
 				parentWindow->CellOverlap->__CellOverlap_sequence->OverlapVolume->__OverlapVolume_sequence->OverlapVolumes = hdf5OverlapVolume;
-				hdf5OverlapVolume->Values = gsoap_resqml2_0_1::soap_new_eml20__Hdf5Dataset(parentWindow->soap, 1);
+				hdf5OverlapVolume->Values = gsoap_resqml2_0_1::soap_new_eml20__Hdf5Dataset(parentWindow->soap);
 				hdf5OverlapVolume->Values->HdfProxy = proxy->newResqmlReference();
 				hdf5OverlapVolume->Values->PathInHdfFile = "/RESQML/" + gsoapProxy2_0_1->uuid + "/ParentWindow_OverlapVolume";
 		
@@ -1112,16 +1112,16 @@ void AbstractGridRepresentation::setCellAssociationWithStratigraphicOrganization
 {
 	if (gsoapProxy2_0_1 != nullptr) {
 		gsoap_resqml2_0_1::resqml20__AbstractGridRepresentation* rep = static_cast<gsoap_resqml2_0_1::resqml20__AbstractGridRepresentation*>(gsoapProxy2_0_1);
-		rep->CellStratigraphicUnits = gsoap_resqml2_0_1::soap_new_resqml20__CellStratigraphicUnits(rep->soap, 1);
+		rep->CellStratigraphicUnits = gsoap_resqml2_0_1::soap_new_resqml20__CellStratigraphicUnits(rep->soap);
 		rep->CellStratigraphicUnits->StratigraphicOrganization = stratiOrgInterp->newResqmlReference();
 
 		COMMON_NS::AbstractHdfProxy * proxy = getRepository()->getDefaultHdfProxy();
 		if (proxy == nullptr) {
 			throw invalid_argument("The HDF proxy is missing.");
 		}
-		gsoap_resqml2_0_1::resqml20__IntegerHdf5Array* xmlDataset = gsoap_resqml2_0_1::soap_new_resqml20__IntegerHdf5Array(rep->soap, 1);
+		gsoap_resqml2_0_1::resqml20__IntegerHdf5Array* xmlDataset = gsoap_resqml2_0_1::soap_new_resqml20__IntegerHdf5Array(rep->soap);
 		xmlDataset->NullValue = nullValue;
-		xmlDataset->Values = gsoap_resqml2_0_1::soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+		xmlDataset->Values = gsoap_resqml2_0_1::soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 		xmlDataset->Values->HdfProxy = proxy->newResqmlReference();
 		xmlDataset->Values->PathInHdfFile = "/RESQML/" + rep->uuid + "/CellStratigraphicUnits";
 		rep->CellStratigraphicUnits->UnitIndices = xmlDataset;
@@ -1140,16 +1140,16 @@ void AbstractGridRepresentation::setCellAssociationWithRockFluidOrganizationInte
 
 	if (gsoapProxy2_0_1 != nullptr) {
 		gsoap_resqml2_0_1::resqml20__AbstractGridRepresentation* rep = static_cast<gsoap_resqml2_0_1::resqml20__AbstractGridRepresentation*>(gsoapProxy2_0_1);
-		rep->CellFluidPhaseUnits = gsoap_resqml2_0_1::soap_new_resqml20__CellFluidPhaseUnits(rep->soap, 1);
+		rep->CellFluidPhaseUnits = gsoap_resqml2_0_1::soap_new_resqml20__CellFluidPhaseUnits(rep->soap);
 		rep->CellFluidPhaseUnits->FluidOrganization = rockfluidOrgInterp->newResqmlReference();
 
 		COMMON_NS::AbstractHdfProxy * proxy = getRepository()->getDefaultHdfProxy();
 		if (proxy == nullptr) {
 			throw invalid_argument("The HDF proxy is missing.");
 		}
-		gsoap_resqml2_0_1::resqml20__IntegerHdf5Array* xmlDataset = gsoap_resqml2_0_1::soap_new_resqml20__IntegerHdf5Array(rep->soap, 1);
+		gsoap_resqml2_0_1::resqml20__IntegerHdf5Array* xmlDataset = gsoap_resqml2_0_1::soap_new_resqml20__IntegerHdf5Array(rep->soap);
 		xmlDataset->NullValue = nullValue;
-		xmlDataset->Values = gsoap_resqml2_0_1::soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+		xmlDataset->Values = gsoap_resqml2_0_1::soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 		xmlDataset->Values->HdfProxy = proxy->newResqmlReference();
 		xmlDataset->Values->PathInHdfFile = "/RESQML/" + rep->uuid + "/CellFluidPhaseUnits";
 		rep->CellFluidPhaseUnits->PhaseUnitIndices = xmlDataset;

--- a/src/resqml2/AbstractProperty.cpp
+++ b/src/resqml2/AbstractProperty.cpp
@@ -247,7 +247,7 @@ std::string AbstractProperty::getTimeSeriesTitle() const
 void AbstractProperty::setTimeIndex(const unsigned int & timeIndex, TimeSeries * ts)
 {
 	if (gsoapProxy2_0_1 != nullptr) {
-		static_cast<gsoap_resqml2_0_1::resqml20__AbstractProperty*>(gsoapProxy2_0_1)->TimeIndex = gsoap_resqml2_0_1::soap_new_resqml20__TimeIndex(gsoapProxy2_0_1->soap, 1);
+		static_cast<gsoap_resqml2_0_1::resqml20__AbstractProperty*>(gsoapProxy2_0_1)->TimeIndex = gsoap_resqml2_0_1::soap_new_resqml20__TimeIndex(gsoapProxy2_0_1->soap);
 		static_cast<gsoap_resqml2_0_1::resqml20__AbstractProperty*>(gsoapProxy2_0_1)->TimeIndex->Index = timeIndex;
 	}
 	else {
@@ -420,7 +420,7 @@ void AbstractProperty::setLocalPropertyKind(PropertyKind* propKind)
 
 	// XML
 	if (gsoapProxy2_0_1 != nullptr) {
-		gsoap_resqml2_0_1::resqml20__LocalPropertyKind* xmlLocalPropKind = gsoap_resqml2_0_1::soap_new_resqml20__LocalPropertyKind(gsoapProxy2_0_1->soap, 1);
+		gsoap_resqml2_0_1::resqml20__LocalPropertyKind* xmlLocalPropKind = gsoap_resqml2_0_1::soap_new_resqml20__LocalPropertyKind(gsoapProxy2_0_1->soap);
 		xmlLocalPropKind->LocalPropertyKind = propKind->newResqmlReference();
 		static_cast<gsoap_resqml2_0_1::resqml20__AbstractProperty*>(gsoapProxy2_0_1)->PropertyKind = xmlLocalPropKind;
 	}

--- a/src/resqml2/AbstractRepresentation.cpp
+++ b/src/resqml2/AbstractRepresentation.cpp
@@ -105,12 +105,12 @@ gsoap_resqml2_0_1::resqml20__PointGeometry* AbstractRepresentation::createPointG
 	getRepository()->addRelationship(this, proxy);
 
 	if (gsoapProxy2_0_1 != nullptr) {
-		gsoap_resqml2_0_1::resqml20__PointGeometry* const geom = gsoap_resqml2_0_1::soap_new_resqml20__PointGeometry(gsoapProxy2_0_1->soap, 1);
+		gsoap_resqml2_0_1::resqml20__PointGeometry* const geom = gsoap_resqml2_0_1::soap_new_resqml20__PointGeometry(gsoapProxy2_0_1->soap);
 		geom->LocalCrs = localCrs->newResqmlReference();
 
 		// XML
-		gsoap_resqml2_0_1::resqml20__Point3dHdf5Array* xmlPts = gsoap_resqml2_0_1::soap_new_resqml20__Point3dHdf5Array(gsoapProxy2_0_1->soap, 1);
-		xmlPts->Coordinates = gsoap_resqml2_0_1::soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+		gsoap_resqml2_0_1::resqml20__Point3dHdf5Array* xmlPts = gsoap_resqml2_0_1::soap_new_resqml20__Point3dHdf5Array(gsoapProxy2_0_1->soap);
+		xmlPts->Coordinates = gsoap_resqml2_0_1::soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 		xmlPts->Coordinates->HdfProxy = proxy->newResqmlReference();
 		ostringstream oss;
 		oss << "points_patch" << patchIndex;
@@ -482,7 +482,7 @@ void AbstractRepresentation::addSeismic3dCoordinatesToPatch(const unsigned int p
 		}
 
 		if (geom->SeismicCoordinates == nullptr) {
-			geom->SeismicCoordinates = gsoap_resqml2_0_1::soap_new_resqml20__Seismic3dCoordinates(gsoapProxy2_0_1->soap, 1);
+			geom->SeismicCoordinates = gsoap_resqml2_0_1::soap_new_resqml20__Seismic3dCoordinates(gsoapProxy2_0_1->soap);
 		}
 		else if (geom->SeismicCoordinates->soap_type() == SOAP_TYPE_gsoap_resqml2_0_1_resqml20__Seismic2dCoordinates) {
 			throw invalid_argument("It already exists some seismic 2d coordinates for this patch.");
@@ -496,8 +496,8 @@ void AbstractRepresentation::addSeismic3dCoordinatesToPatch(const unsigned int p
 		getRepository()->addRelationship(this, seismicSupport);
 
 		// inlines XML
-		gsoap_resqml2_0_1::resqml20__DoubleHdf5Array* inlineValues = gsoap_resqml2_0_1::soap_new_resqml20__DoubleHdf5Array(gsoapProxy2_0_1->soap, 1);
-		inlineValues->Values = gsoap_resqml2_0_1::soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+		gsoap_resqml2_0_1::resqml20__DoubleHdf5Array* inlineValues = gsoap_resqml2_0_1::soap_new_resqml20__DoubleHdf5Array(gsoapProxy2_0_1->soap);
+		inlineValues->Values = gsoap_resqml2_0_1::soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 		inlineValues->Values->HdfProxy = proxy->newResqmlReference();
 		ostringstream oss;
 		oss << "inlineCoordinates_patch" << patchIndex;
@@ -509,8 +509,8 @@ void AbstractRepresentation::addSeismic3dCoordinatesToPatch(const unsigned int p
 		proxy->writeArrayNdOfDoubleValues(getUuid(), oss.str(), inlines, dim, 1);
 
 		// crosslines XML
-		gsoap_resqml2_0_1::resqml20__DoubleHdf5Array* crosslineValues = gsoap_resqml2_0_1::soap_new_resqml20__DoubleHdf5Array(gsoapProxy2_0_1->soap, 1);
-		crosslineValues->Values = gsoap_resqml2_0_1::soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+		gsoap_resqml2_0_1::resqml20__DoubleHdf5Array* crosslineValues = gsoap_resqml2_0_1::soap_new_resqml20__DoubleHdf5Array(gsoapProxy2_0_1->soap);
+		crosslineValues->Values = gsoap_resqml2_0_1::soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 		crosslineValues->Values->HdfProxy = proxy->newResqmlReference();
 		ostringstream oss2;
 		oss2 << "crosslineCoordinates_patch" << patchIndex;
@@ -535,7 +535,7 @@ void AbstractRepresentation::addSeismic3dCoordinatesToPatch(const unsigned int p
 			throw invalid_argument("The patchIndex does not identify a point geometry.");
 
 		if (geom->SeismicCoordinates == nullptr) {
-			geom->SeismicCoordinates = gsoap_resqml2_0_1::soap_new_resqml20__Seismic3dCoordinates(gsoapProxy2_0_1->soap, 1);
+			geom->SeismicCoordinates = gsoap_resqml2_0_1::soap_new_resqml20__Seismic3dCoordinates(gsoapProxy2_0_1->soap);
 		}
 		else if (geom->SeismicCoordinates->soap_type() == SOAP_TYPE_gsoap_resqml2_0_1_resqml20__Seismic2dCoordinates) {
 			throw invalid_argument("It already exists some seismic 2d coordinates for this patch.");
@@ -549,19 +549,19 @@ void AbstractRepresentation::addSeismic3dCoordinatesToPatch(const unsigned int p
 		getRepository()->addRelationship(this, seismicSupport);
 
 		// inlines XML
-		gsoap_resqml2_0_1::resqml20__DoubleLatticeArray* inlineValues = gsoap_resqml2_0_1::soap_new_resqml20__DoubleLatticeArray(gsoapProxy2_0_1->soap, 1);
+		gsoap_resqml2_0_1::resqml20__DoubleLatticeArray* inlineValues = gsoap_resqml2_0_1::soap_new_resqml20__DoubleLatticeArray(gsoapProxy2_0_1->soap);
 		patch->InlineCoordinates = inlineValues;
 		inlineValues->StartValue = startInline;
-		gsoap_resqml2_0_1::resqml20__DoubleConstantArray * spacInline = gsoap_resqml2_0_1::soap_new_resqml20__DoubleConstantArray(gsoapProxy2_0_1->soap, 1);
+		gsoap_resqml2_0_1::resqml20__DoubleConstantArray * spacInline = gsoap_resqml2_0_1::soap_new_resqml20__DoubleConstantArray(gsoapProxy2_0_1->soap);
 		spacInline->Count = countInline - 1;
 		spacInline->Value = incrInline;
 		inlineValues->Offset.push_back(spacInline);
 
 		// crosslines XML
-		gsoap_resqml2_0_1::resqml20__DoubleLatticeArray* crosslineValues = gsoap_resqml2_0_1::soap_new_resqml20__DoubleLatticeArray(gsoapProxy2_0_1->soap, 1);
+		gsoap_resqml2_0_1::resqml20__DoubleLatticeArray* crosslineValues = gsoap_resqml2_0_1::soap_new_resqml20__DoubleLatticeArray(gsoapProxy2_0_1->soap);
 		patch->CrosslineCoordinates = crosslineValues;
 		crosslineValues->StartValue = startCrossline;
-		gsoap_resqml2_0_1::resqml20__DoubleConstantArray * spacCrossline = gsoap_resqml2_0_1::soap_new_resqml20__DoubleConstantArray(gsoapProxy2_0_1->soap, 1);
+		gsoap_resqml2_0_1::resqml20__DoubleConstantArray * spacCrossline = gsoap_resqml2_0_1::soap_new_resqml20__DoubleConstantArray(gsoapProxy2_0_1->soap);
 		spacCrossline->Count = countCrossline - 1;
 		spacCrossline->Value = incrCrossline;
 		crosslineValues->Offset.push_back(spacCrossline);
@@ -582,7 +582,7 @@ void AbstractRepresentation::addSeismic2dCoordinatesToPatch(const unsigned int p
 			throw invalid_argument("The patchIndex does not identify a point geometry.");
 
 		if (geom->SeismicCoordinates == nullptr) {
-			geom->SeismicCoordinates = gsoap_resqml2_0_1::soap_new_resqml20__Seismic2dCoordinates(gsoapProxy2_0_1->soap, 1);
+			geom->SeismicCoordinates = gsoap_resqml2_0_1::soap_new_resqml20__Seismic2dCoordinates(gsoapProxy2_0_1->soap);
 		}
 		else if (geom->SeismicCoordinates->soap_type() == SOAP_TYPE_gsoap_resqml2_0_1_resqml20__Seismic3dCoordinates) {
 			throw invalid_argument("It already exists some seismic 3d coordinates for this patch.");
@@ -596,8 +596,8 @@ void AbstractRepresentation::addSeismic2dCoordinatesToPatch(const unsigned int p
 		getRepository()->addRelationship(this, seismicSupport);
 
 		// abscissa XML
-		gsoap_resqml2_0_1::resqml20__DoubleHdf5Array* abscissaValues = gsoap_resqml2_0_1::soap_new_resqml20__DoubleHdf5Array(gsoapProxy2_0_1->soap, 1);
-		abscissaValues->Values = gsoap_resqml2_0_1::soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+		gsoap_resqml2_0_1::resqml20__DoubleHdf5Array* abscissaValues = gsoap_resqml2_0_1::soap_new_resqml20__DoubleHdf5Array(gsoapProxy2_0_1->soap);
+		abscissaValues->Values = gsoap_resqml2_0_1::soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 		abscissaValues->Values->HdfProxy = proxy->newResqmlReference();
 		ostringstream oss;
 		oss << "lineAbscissa_patch" << patchIndex;

--- a/src/resqml2/AbstractValuesProperty.cpp
+++ b/src/resqml2/AbstractValuesProperty.cpp
@@ -110,14 +110,14 @@ std::string AbstractValuesProperty::pushBackRefToExistingIntegerDataset(COMMON_N
 	if (gsoapProxy2_0_1 != nullptr) {
 		gsoap_resqml2_0_1::resqml20__AbstractValuesProperty* prop = static_cast<gsoap_resqml2_0_1::resqml20__AbstractValuesProperty*>(gsoapProxy2_0_1);
 
-		gsoap_resqml2_0_1::resqml20__PatchOfValues* patch = gsoap_resqml2_0_1::soap_new_resqml20__PatchOfValues(gsoapProxy2_0_1->soap, 1);
+		gsoap_resqml2_0_1::resqml20__PatchOfValues* patch = gsoap_resqml2_0_1::soap_new_resqml20__PatchOfValues(gsoapProxy2_0_1->soap);
 		patch->RepresentationPatchIndex = static_cast<ULONG64*>(soap_malloc(gsoapProxy2_0_1->soap, sizeof(ULONG64)));
 		*(patch->RepresentationPatchIndex) = prop->PatchOfValues.size();
 
 		// XML
-		gsoap_resqml2_0_1::resqml20__IntegerHdf5Array* xmlValues = gsoap_resqml2_0_1::soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap, 1);
+		gsoap_resqml2_0_1::resqml20__IntegerHdf5Array* xmlValues = gsoap_resqml2_0_1::soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap);
 		xmlValues->NullValue = nullValue;
-		xmlValues->Values = gsoap_resqml2_0_1::soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+		xmlValues->Values = gsoap_resqml2_0_1::soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 		xmlValues->Values->HdfProxy = hdfProxy->newResqmlReference();
 
 		if (datasetName.empty()) {
@@ -345,7 +345,7 @@ unsigned int AbstractValuesProperty::getDimensionsCountOfPatch(unsigned int patc
 void AbstractValuesProperty::pushBackFacet(const gsoap_resqml2_0_1::resqml20__Facet & facet, const std::string & facetValue)
 {
 	if (gsoapProxy2_0_1 != nullptr) {
-		gsoap_resqml2_0_1::resqml20__PropertyKindFacet* newFacet = gsoap_resqml2_0_1::soap_new_resqml20__PropertyKindFacet(gsoapProxy2_0_1->soap, 1);
+		gsoap_resqml2_0_1::resqml20__PropertyKindFacet* newFacet = gsoap_resqml2_0_1::soap_new_resqml20__PropertyKindFacet(gsoapProxy2_0_1->soap);
 		newFacet->Facet = facet;
 		newFacet->Value = facetValue;
 		static_cast<gsoap_resqml2_0_1::resqml20__AbstractValuesProperty*>(gsoapProxy2_0_1)->Facet.push_back(newFacet);
@@ -446,13 +446,13 @@ void AbstractValuesProperty::createLongHdf5ArrayOfValues(
 	if (gsoapProxy2_0_1 != nullptr) {
 		gsoap_resqml2_0_1::resqml20__AbstractValuesProperty* prop = static_cast<gsoap_resqml2_0_1::resqml20__AbstractValuesProperty*>(gsoapProxy2_0_1);
 
-		gsoap_resqml2_0_1::resqml20__PatchOfValues* patch = gsoap_resqml2_0_1::soap_new_resqml20__PatchOfValues(gsoapProxy2_0_1->soap, 1);
+		gsoap_resqml2_0_1::resqml20__PatchOfValues* patch = gsoap_resqml2_0_1::soap_new_resqml20__PatchOfValues(gsoapProxy2_0_1->soap);
 		patch->RepresentationPatchIndex = static_cast<ULONG64*>(soap_malloc(gsoapProxy2_0_1->soap, sizeof(ULONG64)));
 		*(patch->RepresentationPatchIndex) = prop->PatchOfValues.size();
 
 		// XML
-		gsoap_resqml2_0_1::resqml20__IntegerHdf5Array* xmlValues = gsoap_resqml2_0_1::soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap, 1);
-		xmlValues->Values = gsoap_resqml2_0_1::soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+		gsoap_resqml2_0_1::resqml20__IntegerHdf5Array* xmlValues = gsoap_resqml2_0_1::soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap);
+		xmlValues->Values = gsoap_resqml2_0_1::soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 		xmlValues->Values->HdfProxy = proxy->newResqmlReference();
 		std::ostringstream ossForHdf;
 		ossForHdf << "values_patch" << *(patch->RepresentationPatchIndex);

--- a/src/resqml2/TimeSeries.cpp
+++ b/src/resqml2/TimeSeries.cpp
@@ -37,7 +37,7 @@ void TimeSeries::pushBackTimestamp(time_t timestamp)
 void TimeSeries::pushBackTimestamp(const tm & timestamp)
 {
 	if (gsoapProxy2_0_1 != nullptr) {
-		gsoap_resqml2_0_1::resqml20__Timestamp* ts = gsoap_resqml2_0_1::soap_new_resqml20__Timestamp(gsoapProxy2_0_1->soap, 1);
+		gsoap_resqml2_0_1::resqml20__Timestamp* ts = gsoap_resqml2_0_1::soap_new_resqml20__Timestamp(gsoapProxy2_0_1->soap);
 		ts->DateTime = timestamp;
 		static_cast<gsoap_resqml2_0_1::_resqml20__TimeSeries*>(gsoapProxy2_0_1)->Time.push_back(ts);
 	}

--- a/src/resqml2_0_1/AbstractIjkGridRepresentation.cpp
+++ b/src/resqml2_0_1/AbstractIjkGridRepresentation.cpp
@@ -48,7 +48,7 @@ void AbstractIjkGridRepresentation::init(COMMON_NS::DataObjectRepository * repo,
 	}
 
 	if (!withTruncatedPillars) {
-		gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREIjkGridRepresentation(repo->getGsoapContext(), 1);
+		gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREIjkGridRepresentation(repo->getGsoapContext());
 		_resqml20__IjkGridRepresentation* ijkGrid = getSpecializedGsoapProxy();
 
 		ijkGrid->Ni = iCount;
@@ -56,7 +56,7 @@ void AbstractIjkGridRepresentation::init(COMMON_NS::DataObjectRepository * repo,
 		ijkGrid->Nk = kCount;
 	}
 	else {
-		gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORETruncatedIjkGridRepresentation(repo->getGsoapContext(), 1);
+		gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORETruncatedIjkGridRepresentation(repo->getGsoapContext());
 		_resqml20__TruncatedIjkGridRepresentation* ijkGrid = static_cast<_resqml20__TruncatedIjkGridRepresentation*>(gsoapProxy2_0_1);
 
 		ijkGrid->Ni = iCount;
@@ -960,7 +960,7 @@ void AbstractIjkGridRepresentation::setEnabledCells(unsigned char* enabledCells,
 		throw invalid_argument("There is no geometry on this grid.");
 	}
 
-	resqml20__BooleanHdf5Array* boolArray = soap_new_resqml20__BooleanHdf5Array(gsoapProxy2_0_1->soap, 1);
+	resqml20__BooleanHdf5Array* boolArray = soap_new_resqml20__BooleanHdf5Array(gsoapProxy2_0_1->soap);
 	geom->CellGeometryIsDefined = boolArray;
 
 	if (proxy == nullptr) {
@@ -969,7 +969,7 @@ void AbstractIjkGridRepresentation::setEnabledCells(unsigned char* enabledCells,
 			throw invalid_argument("You miss an HDF proxy");
 		}
 	}
-	boolArray->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	boolArray->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	boolArray->Values->HdfProxy = proxy->newResqmlReference();
 	boolArray->Values->PathInHdfFile = "/RESQML/" + gsoapProxy2_0_1->uuid + "/CellGeometryIsDefined";
 

--- a/src/resqml2_0_1/AbstractOrganizationInterpretation.cpp
+++ b/src/resqml2_0_1/AbstractOrganizationInterpretation.cpp
@@ -36,7 +36,7 @@ void AbstractOrganizationInterpretation::pushBackBinaryContact(const gsoap_resqm
 
 	resqml20__AbstractOrganizationInterpretation* org = static_cast<resqml20__AbstractOrganizationInterpretation*>(gsoapProxy2_0_1);
 
-	resqml20__BinaryContactInterpretationPart* contact = soap_new_resqml20__BinaryContactInterpretationPart(org->soap, 1);
+	resqml20__BinaryContactInterpretationPart* contact = soap_new_resqml20__BinaryContactInterpretationPart(org->soap);
 	contact->Index = org->ContactInterpretation.size();
 	org->ContactInterpretation.push_back(contact);
 

--- a/src/resqml2_0_1/AbstractSurfaceFrameworkRepresentation.cpp
+++ b/src/resqml2_0_1/AbstractSurfaceFrameworkRepresentation.cpp
@@ -39,13 +39,13 @@ void AbstractSurfaceFrameworkRepresentation::pushBackContactIdentity(
 {
 	resqml20__AbstractSurfaceFrameworkRepresentation* orgRep = static_cast<resqml20__AbstractSurfaceFrameworkRepresentation*>(gsoapProxy2_0_1);
 
-	resqml20__ContactIdentity * contactIdentity = soap_new_resqml20__ContactIdentity(gsoapProxy2_0_1->soap, 1);
+	resqml20__ContactIdentity * contactIdentity = soap_new_resqml20__ContactIdentity(gsoapProxy2_0_1->soap);
 	contactIdentity->IdentityKind = kind;
 
 	// ListOfContactRepresentations handling
-	resqml20__IntegerHdf5Array * xmlListOfContactRepresentations = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap, 1);
+	resqml20__IntegerHdf5Array * xmlListOfContactRepresentations = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap);
 	xmlListOfContactRepresentations->NullValue = (std::numeric_limits<unsigned int>::max)();
-	xmlListOfContactRepresentations->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	xmlListOfContactRepresentations->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	xmlListOfContactRepresentations->Values->HdfProxy = proxy->newResqmlReference();
 	ostringstream ossForHdfContactRepresentations;
 	ossForHdfContactRepresentations << "contactIdentity_listOfContactRep_" << orgRep->ContactIdentity.size();
@@ -68,13 +68,13 @@ void AbstractSurfaceFrameworkRepresentation::pushBackContactIdentity(
 {
 	resqml20__AbstractSurfaceFrameworkRepresentation* orgRep = static_cast<resqml20__AbstractSurfaceFrameworkRepresentation*>(gsoapProxy2_0_1);
 
-	resqml20__ContactIdentity * contactIdentity = soap_new_resqml20__ContactIdentity(gsoapProxy2_0_1->soap, 1);
+	resqml20__ContactIdentity * contactIdentity = soap_new_resqml20__ContactIdentity(gsoapProxy2_0_1->soap);
 	contactIdentity->IdentityKind = kind;
 
 	// ListOfContactRepresentations handling
-	resqml20__IntegerHdf5Array * xmlListOfContactRepresentations = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap, 1);
+	resqml20__IntegerHdf5Array * xmlListOfContactRepresentations = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap);
 	xmlListOfContactRepresentations->NullValue = (std::numeric_limits<unsigned int>::max)();
-	xmlListOfContactRepresentations->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	xmlListOfContactRepresentations->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	xmlListOfContactRepresentations->Values->HdfProxy = proxy->newResqmlReference();
 	ostringstream ossForHdfContactRepresentations;
 	ossForHdfContactRepresentations << "contactIdentity_listOfContactRep_" << orgRep->ContactIdentity.size();
@@ -88,9 +88,9 @@ void AbstractSurfaceFrameworkRepresentation::pushBackContactIdentity(
 		dimContactRepresentations, 1);
 
 	// ListOfIdenticalNodes handling
-	resqml20__IntegerHdf5Array * xmlListOfIdenticalNodes = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap, 1);
+	resqml20__IntegerHdf5Array * xmlListOfIdenticalNodes = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap);
 	xmlListOfIdenticalNodes->NullValue = (std::numeric_limits<unsigned int>::max)();
-	xmlListOfIdenticalNodes->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	xmlListOfIdenticalNodes->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	xmlListOfIdenticalNodes->Values->HdfProxy = proxy->newResqmlReference();
 	ostringstream ossForHdfIdenticalNodes;
 	ossForHdfIdenticalNodes << "contactIdentity_listOfIdenticalNodes_" << orgRep->ContactIdentity.size();

--- a/src/resqml2_0_1/AbstractSurfaceRepresentation.cpp
+++ b/src/resqml2_0_1/AbstractSurfaceRepresentation.cpp
@@ -74,35 +74,35 @@ resqml20__PointGeometry* AbstractSurfaceRepresentation::createArray2dOfLatticePo
 		throw invalid_argument("The CRS cannot be the null pointer");
 	}
 
-	resqml20__PointGeometry* geom = soap_new_resqml20__PointGeometry(gsoapProxy2_0_1->soap, 1);
+	resqml20__PointGeometry* geom = soap_new_resqml20__PointGeometry(gsoapProxy2_0_1->soap);
 	geom->LocalCrs = localCrs->newResqmlReference();
 
 	// XML
-	resqml20__Point3dLatticeArray* xmlPoints = soap_new_resqml20__Point3dLatticeArray(gsoapProxy2_0_1->soap, 1);
-	xmlPoints->Origin = soap_new_resqml20__Point3d(gsoapProxy2_0_1->soap, 1);
+	resqml20__Point3dLatticeArray* xmlPoints = soap_new_resqml20__Point3dLatticeArray(gsoapProxy2_0_1->soap);
+	xmlPoints->Origin = soap_new_resqml20__Point3d(gsoapProxy2_0_1->soap);
 	xmlPoints->Origin->Coordinate1 = xOrigin;
 	xmlPoints->Origin->Coordinate2 = yOrigin;
 	xmlPoints->Origin->Coordinate3 = zOrigin;
 
 	// first (slowest) dim : fastest is I (or inline), slowest is J (or crossline)
-	resqml20__Point3dOffset* latticeDim = soap_new_resqml20__Point3dOffset(gsoapProxy2_0_1->soap, 1);
-	latticeDim->Offset = soap_new_resqml20__Point3d(gsoapProxy2_0_1->soap, 1);
+	resqml20__Point3dOffset* latticeDim = soap_new_resqml20__Point3dOffset(gsoapProxy2_0_1->soap);
+	latticeDim->Offset = soap_new_resqml20__Point3d(gsoapProxy2_0_1->soap);
 	latticeDim->Offset->Coordinate1 = xOffsetInSlowestDirection;
 	latticeDim->Offset->Coordinate2 = yOffsetInSlowestDirection;
 	latticeDim->Offset->Coordinate3 = zOffsetInSlowestDirection;
-	resqml20__DoubleConstantArray* spacingInfo = soap_new_resqml20__DoubleConstantArray(gsoapProxy2_0_1->soap, 1);
+	resqml20__DoubleConstantArray* spacingInfo = soap_new_resqml20__DoubleConstantArray(gsoapProxy2_0_1->soap);
 	spacingInfo->Count = numPointsInSlowestDirection-1;
 	spacingInfo->Value = spacingInSlowestDirection;
 	latticeDim->Spacing = spacingInfo;
 	xmlPoints->Offset.push_back(latticeDim);
 
 	// Second (fastest) dimension :fastest is I (or inline), slowest is J (or crossline)
-	latticeDim = soap_new_resqml20__Point3dOffset(gsoapProxy2_0_1->soap, 1);
-	latticeDim->Offset = soap_new_resqml20__Point3d(gsoapProxy2_0_1->soap, 1);
+	latticeDim = soap_new_resqml20__Point3dOffset(gsoapProxy2_0_1->soap);
+	latticeDim->Offset = soap_new_resqml20__Point3d(gsoapProxy2_0_1->soap);
 	latticeDim->Offset->Coordinate1 = xOffsetInFastestDirection;
 	latticeDim->Offset->Coordinate2 = yOffsetInFastestDirection;
 	latticeDim->Offset->Coordinate3 = zOffsetInFastestDirection;
-	spacingInfo = soap_new_resqml20__DoubleConstantArray(gsoapProxy2_0_1->soap, 1);
+	spacingInfo = soap_new_resqml20__DoubleConstantArray(gsoapProxy2_0_1->soap);
 	spacingInfo->Count = numPointsInFastestDirection-1;
 	spacingInfo->Value = spacingInFastestDirection;
 	latticeDim->Spacing = spacingInfo;
@@ -131,32 +131,32 @@ resqml20__PointGeometry* AbstractSurfaceRepresentation::createArray2dOfExplicitZ
 
 	getRepository()->addRelationship(this, supportingRepresentation);
 
-	resqml20__PointGeometry* geom = soap_new_resqml20__PointGeometry(gsoapProxy2_0_1->soap, 1);
+	resqml20__PointGeometry* geom = soap_new_resqml20__PointGeometry(gsoapProxy2_0_1->soap);
 	geom->LocalCrs = localCrs->newResqmlReference();
 
 	// XML
-	resqml20__Point3dZValueArray* xmlPoints = soap_new_resqml20__Point3dZValueArray(gsoapProxy2_0_1->soap, 1);
-	resqml20__Point3dFromRepresentationLatticeArray* patchPoints = soap_new_resqml20__Point3dFromRepresentationLatticeArray(gsoapProxy2_0_1->soap, 1);
+	resqml20__Point3dZValueArray* xmlPoints = soap_new_resqml20__Point3dZValueArray(gsoapProxy2_0_1->soap);
+	resqml20__Point3dFromRepresentationLatticeArray* patchPoints = soap_new_resqml20__Point3dFromRepresentationLatticeArray(gsoapProxy2_0_1->soap);
 	patchPoints->SupportingRepresentation = supportingRepresentation->newResqmlReference();
-	patchPoints->NodeIndicesOnSupportingRepresentation = soap_new_resqml20__IntegerLatticeArray(gsoapProxy2_0_1->soap, 1);
+	patchPoints->NodeIndicesOnSupportingRepresentation = soap_new_resqml20__IntegerLatticeArray(gsoapProxy2_0_1->soap);
 	patchPoints->NodeIndicesOnSupportingRepresentation->StartValue = startGlobalIndex;
 	xmlPoints->SupportingGeometry = patchPoints;
 
 	// first (slowest) dim :fastest is I (or inline), slowest is J (or crossline)
-	resqml20__IntegerConstantArray* offset = soap_new_resqml20__IntegerConstantArray(gsoapProxy2_0_1->soap, 1);
+	resqml20__IntegerConstantArray* offset = soap_new_resqml20__IntegerConstantArray(gsoapProxy2_0_1->soap);
 	offset->Count = numJ-1;
 	offset->Value = indexIncrementJ;
 	patchPoints->NodeIndicesOnSupportingRepresentation->Offset.push_back(offset);
 
 	//second (fastest) dim :fastest is I (or inline), slowest is J (or crossline)
-	offset = soap_new_resqml20__IntegerConstantArray(gsoapProxy2_0_1->soap, 1);
+	offset = soap_new_resqml20__IntegerConstantArray(gsoapProxy2_0_1->soap);
 	offset->Count = numI-1;
 	offset->Value = indexIncrementI;
 	patchPoints->NodeIndicesOnSupportingRepresentation->Offset.push_back(offset);
 
 	// Z Values
-	resqml20__DoubleHdf5Array* xmlZValues = soap_new_resqml20__DoubleHdf5Array(gsoapProxy2_0_1->soap, 1);
-	xmlZValues->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	resqml20__DoubleHdf5Array* xmlZValues = soap_new_resqml20__DoubleHdf5Array(gsoapProxy2_0_1->soap);
+	xmlZValues->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	xmlZValues->Values->HdfProxy = proxy->newResqmlReference();
 	ostringstream oss3;
 	oss3 << "points_patch" << patchIndex;
@@ -191,36 +191,36 @@ resqml20__PointGeometry* AbstractSurfaceRepresentation::createArray2dOfExplicitZ
 	}
 	getRepository()->addRelationship(this, proxy);
 
-	resqml20__PointGeometry* geom = soap_new_resqml20__PointGeometry(gsoapProxy2_0_1->soap, 1);
+	resqml20__PointGeometry* geom = soap_new_resqml20__PointGeometry(gsoapProxy2_0_1->soap);
 	geom->LocalCrs = localCrs->newResqmlReference();
 
 	// XML
-	resqml20__Point3dZValueArray* xmlPoints = soap_new_resqml20__Point3dZValueArray(gsoapProxy2_0_1->soap, 1);
-	resqml20__Point3dLatticeArray* latticePoints = soap_new_resqml20__Point3dLatticeArray(gsoapProxy2_0_1->soap, 1);
-	latticePoints->Origin = soap_new_resqml20__Point3d(gsoapProxy2_0_1->soap, 1);
+	resqml20__Point3dZValueArray* xmlPoints = soap_new_resqml20__Point3dZValueArray(gsoapProxy2_0_1->soap);
+	resqml20__Point3dLatticeArray* latticePoints = soap_new_resqml20__Point3dLatticeArray(gsoapProxy2_0_1->soap);
+	latticePoints->Origin = soap_new_resqml20__Point3d(gsoapProxy2_0_1->soap);
 	latticePoints->Origin->Coordinate1 = originX;
 	latticePoints->Origin->Coordinate2 = originY;
 	latticePoints->Origin->Coordinate3 = originZ;
 
 	// first (slowest) dim :fastest is I (or inline), slowest is J (or crossline)
-	resqml20__Point3dOffset* latticeDimForJ = soap_new_resqml20__Point3dOffset(gsoapProxy2_0_1->soap, 1);
-	latticeDimForJ->Offset = soap_new_resqml20__Point3d(gsoapProxy2_0_1->soap, 1);
+	resqml20__Point3dOffset* latticeDimForJ = soap_new_resqml20__Point3dOffset(gsoapProxy2_0_1->soap);
+	latticeDimForJ->Offset = soap_new_resqml20__Point3d(gsoapProxy2_0_1->soap);
 	latticeDimForJ->Offset->Coordinate1 = offsetJX;
 	latticeDimForJ->Offset->Coordinate2 = offsetJY;
 	latticeDimForJ->Offset->Coordinate3 = offsetJZ;
-	resqml20__DoubleConstantArray* spacingForJ = soap_new_resqml20__DoubleConstantArray(gsoapProxy2_0_1->soap, 1);
+	resqml20__DoubleConstantArray* spacingForJ = soap_new_resqml20__DoubleConstantArray(gsoapProxy2_0_1->soap);
 	spacingForJ->Value = spacingJ;
 	spacingForJ->Count = numJ - 1;
 	latticeDimForJ->Spacing = spacingForJ;
 	latticePoints->Offset.push_back(latticeDimForJ);
 
 	//second (fastest) dim :fastest is I (or inline), slowest is J (or crossline)
-	resqml20__Point3dOffset* latticeDimForI = soap_new_resqml20__Point3dOffset(gsoapProxy2_0_1->soap, 1);
-	latticeDimForI->Offset = soap_new_resqml20__Point3d(gsoapProxy2_0_1->soap, 1);
+	resqml20__Point3dOffset* latticeDimForI = soap_new_resqml20__Point3dOffset(gsoapProxy2_0_1->soap);
+	latticeDimForI->Offset = soap_new_resqml20__Point3d(gsoapProxy2_0_1->soap);
 	latticeDimForI->Offset->Coordinate1 = offsetIX;
 	latticeDimForI->Offset->Coordinate2 = offsetIY;
 	latticeDimForI->Offset->Coordinate3 = offsetIZ;
-	resqml20__DoubleConstantArray* spacingForI = soap_new_resqml20__DoubleConstantArray(gsoapProxy2_0_1->soap, 1);
+	resqml20__DoubleConstantArray* spacingForI = soap_new_resqml20__DoubleConstantArray(gsoapProxy2_0_1->soap);
 	spacingForI->Value = spacingI;
 	spacingForI->Count = numI - 1;
 	latticeDimForI->Spacing = spacingForI;
@@ -229,8 +229,8 @@ resqml20__PointGeometry* AbstractSurfaceRepresentation::createArray2dOfExplicitZ
 	xmlPoints->SupportingGeometry = latticePoints;
 
 	// Z Values
-	resqml20__DoubleHdf5Array* xmlZValues = soap_new_resqml20__DoubleHdf5Array(gsoapProxy2_0_1->soap, 1);
-	xmlZValues->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	resqml20__DoubleHdf5Array* xmlZValues = soap_new_resqml20__DoubleHdf5Array(gsoapProxy2_0_1->soap);
+	xmlZValues->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	xmlZValues->Values->HdfProxy = proxy->newResqmlReference();
 	ostringstream oss3;
 	oss3 << "points_patch" << patchIndex;
@@ -277,7 +277,7 @@ void AbstractSurfaceRepresentation::pushBackOuterRing(PolylineRepresentation * o
 {
 	resqml20__AbstractSurfaceRepresentation* rep = static_cast<resqml20__AbstractSurfaceRepresentation*>(gsoapProxy2_0_1);
 
-	resqml20__PatchBoundaries * boundary = soap_new_resqml20__PatchBoundaries(gsoapProxy2_0_1->soap, 1);
+	resqml20__PatchBoundaries * boundary = soap_new_resqml20__PatchBoundaries(gsoapProxy2_0_1->soap);
 	boundary->ReferencedPatch = rep->Boundaries.size();
 	boundary->OuterRing = outerRing->newResqmlReference();
 	rep->Boundaries.push_back(boundary);

--- a/src/resqml2_0_1/Activity.cpp
+++ b/src/resqml2_0_1/Activity.cpp
@@ -34,7 +34,7 @@ Activity::Activity(RESQML2_NS::ActivityTemplate* activityTemplate, const string 
 		throw invalid_argument("The activity template of an activity must be not null.");
 	}
 
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREActivity(activityTemplate->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREActivity(activityTemplate->getGsoapContext());
 
 	initMandatoryMetadata();
 	setMetadata(guid, title, std::string(), -1, std::string(), std::string(), -1, std::string());
@@ -60,7 +60,7 @@ void Activity::pushBackParameter(const std::string title,
 
 	_resqml20__Activity* activity = static_cast<_resqml20__Activity*>(gsoapProxy2_0_1);
 
-	resqml20__FloatingPointQuantityParameter* fpqp = soap_new_resqml20__FloatingPointQuantityParameter(activity->soap, 1);
+	resqml20__FloatingPointQuantityParameter* fpqp = soap_new_resqml20__FloatingPointQuantityParameter(activity->soap);
 	fpqp->Title = title;
 	fpqp->Value = value;
 	fpqp->Uom = uom;
@@ -84,7 +84,7 @@ void Activity::pushBackParameter(const std::string title, const std::string & va
 
 	_resqml20__Activity* activity = static_cast<_resqml20__Activity*>(gsoapProxy2_0_1);
 
-	resqml20__StringParameter* sp = soap_new_resqml20__StringParameter(activity->soap, 1);
+	resqml20__StringParameter* sp = soap_new_resqml20__StringParameter(activity->soap);
 	sp->Title = title;
 	sp->Value = value;
 	activity->Parameter.push_back(sp);
@@ -107,7 +107,7 @@ void Activity::pushBackParameter(const std::string title, const LONG64 & value)
 
 	_resqml20__Activity* activity = static_cast<_resqml20__Activity*>(gsoapProxy2_0_1);
 
-	resqml20__IntegerQuantityParameter* iqp = soap_new_resqml20__IntegerQuantityParameter(activity->soap, 1);
+	resqml20__IntegerQuantityParameter* iqp = soap_new_resqml20__IntegerQuantityParameter(activity->soap);
 	iqp->Title = title;
 	iqp->Value = value;
 	activity->Parameter.push_back(iqp);
@@ -134,7 +134,7 @@ void Activity::pushBackParameter(const std::string title, AbstractObject* resqml
 
 	_resqml20__Activity* activity = static_cast<_resqml20__Activity*>(gsoapProxy2_0_1);
 
-	resqml20__DataObjectParameter* dop = soap_new_resqml20__DataObjectParameter(activity->soap, 1);
+	resqml20__DataObjectParameter* dop = soap_new_resqml20__DataObjectParameter(activity->soap);
 	dop->Title = title;
 	dop->DataObject = resqmlObject->newResqmlReference();
 	activity->Parameter.push_back(dop);

--- a/src/resqml2_0_1/ActivityTemplate.cpp
+++ b/src/resqml2_0_1/ActivityTemplate.cpp
@@ -28,7 +28,7 @@ const char* ActivityTemplate::XML_TAG = "ActivityTemplate";
 
 ActivityTemplate::ActivityTemplate(COMMON_NS::DataObjectRepository * repo, const string & guid, const string & title)
 {
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREActivityTemplate(repo->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREActivityTemplate(repo->getGsoapContext());
 
 	initMandatoryMetadata();
 	setMetadata(guid, title, std::string(), -1, std::string(), std::string(), -1, std::string());
@@ -47,7 +47,7 @@ void ActivityTemplate::pushBackParameter(const std::string & title,
 
 	_resqml20__ActivityTemplate* activityTemplate = static_cast<_resqml20__ActivityTemplate*>(gsoapProxy2_0_1);
 
-	resqml20__ParameterTemplate* param =soap_new_resqml20__ParameterTemplate(gsoapProxy2_0_1->soap, 1);
+	resqml20__ParameterTemplate* param =soap_new_resqml20__ParameterTemplate(gsoapProxy2_0_1->soap);
 	param->Title = title;
 	param->IsInput = isInput;
 	param->IsOutput = isOutput;
@@ -78,7 +78,7 @@ void ActivityTemplate::pushBackParameter(const std::string & title,
 	if (!resqmlObjectContentType.empty())
 	{
 		_resqml20__ActivityTemplate* activityTemplate = static_cast<_resqml20__ActivityTemplate*>(gsoapProxy2_0_1);
-		activityTemplate->Parameter[activityTemplate->Parameter.size()-1]->DataObjectContentType = soap_new_std__string(gsoapProxy2_0_1->soap, 1);
+		activityTemplate->Parameter[activityTemplate->Parameter.size()-1]->DataObjectContentType = soap_new_std__string(gsoapProxy2_0_1->soap);
 		activityTemplate->Parameter[activityTemplate->Parameter.size()-1]->DataObjectContentType->assign(resqmlObjectContentType);
 	}
 }

--- a/src/resqml2_0_1/BlockedWellboreRepresentation.cpp
+++ b/src/resqml2_0_1/BlockedWellboreRepresentation.cpp
@@ -41,7 +41,7 @@ void BlockedWellboreRepresentation::init(const std::string & guid, const std::st
 		throw invalid_argument("The wellbore trajectory of a blocked wellbore cannot be null.");
 	}
 
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREBlockedWellboreRepresentation(traj->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREBlockedWellboreRepresentation(traj->getGsoapContext());
 	_resqml20__BlockedWellboreRepresentation* frame = static_cast<_resqml20__BlockedWellboreRepresentation*>(gsoapProxy2_0_1);
 
 	initMandatoryMetadata();
@@ -89,9 +89,9 @@ void BlockedWellboreRepresentation::setIntevalGridCells(unsigned int * gridIndic
 
 	// gridIndices
 	// XML
-	resqml20__IntegerHdf5Array* xmlGridIndices = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap, 1);
+	resqml20__IntegerHdf5Array* xmlGridIndices = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap);
 	xmlGridIndices->NullValue = gridIndicesNullValue;
-	xmlGridIndices->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	xmlGridIndices->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	xmlGridIndices->Values->HdfProxy = hdfProxy->newResqmlReference();
 	xmlGridIndices->Values->PathInHdfFile = "/RESQML/" + rep->uuid + "/GridIndices";
 	rep->GridIndices = xmlGridIndices;
@@ -105,9 +105,9 @@ void BlockedWellboreRepresentation::setIntevalGridCells(unsigned int * gridIndic
 
 	// cellIndices
 	// XML
-	resqml20__IntegerHdf5Array* xmlCellIndices = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap, 1);
+	resqml20__IntegerHdf5Array* xmlCellIndices = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap);
 	xmlCellIndices->NullValue = -1;
-	xmlCellIndices->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	xmlCellIndices->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	xmlCellIndices->Values->HdfProxy = hdfProxy->newResqmlReference();
 	xmlCellIndices->Values->PathInHdfFile = "/RESQML/" + rep->uuid + "/CellIndices";
 	rep->CellIndices = xmlCellIndices;
@@ -121,9 +121,9 @@ void BlockedWellboreRepresentation::setIntevalGridCells(unsigned int * gridIndic
 
 	// localFacePairPerCellIndices
 	// XML
-	resqml20__IntegerHdf5Array* xmlLocalFacePairPerCellIndices = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap, 1);
+	resqml20__IntegerHdf5Array* xmlLocalFacePairPerCellIndices = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap);
 	xmlLocalFacePairPerCellIndices->NullValue = localFacePairPerCellIndicesNullValue;
-	xmlLocalFacePairPerCellIndices->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	xmlLocalFacePairPerCellIndices->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	xmlLocalFacePairPerCellIndices->Values->HdfProxy = hdfProxy->newResqmlReference();
 	xmlLocalFacePairPerCellIndices->Values->PathInHdfFile = "/RESQML/" + rep->uuid + "/LocalFacePairPerCellIndices";
 	rep->LocalFacePairPerCellIndices = xmlLocalFacePairPerCellIndices;

--- a/src/resqml2_0_1/BoundaryFeature.cpp
+++ b/src/resqml2_0_1/BoundaryFeature.cpp
@@ -30,7 +30,7 @@ BoundaryFeature::BoundaryFeature(COMMON_NS::DataObjectRepository * repo, const s
 		throw invalid_argument("The repo must exist");
 	}
 
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREBoundaryFeature(repo->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREBoundaryFeature(repo->getGsoapContext());
 
 	initMandatoryMetadata();
 	setMetadata(guid, title, std::string(), -1, std::string(), std::string(), -1, std::string());

--- a/src/resqml2_0_1/BoundaryFeatureInterpretation.cpp
+++ b/src/resqml2_0_1/BoundaryFeatureInterpretation.cpp
@@ -36,7 +36,7 @@ BoundaryFeatureInterpretation::BoundaryFeatureInterpretation(BoundaryFeature * f
 		throw invalid_argument("The interpreted feature cannot be null.");
 	}
 
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREBoundaryFeatureInterpretation(feature->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREBoundaryFeatureInterpretation(feature->getGsoapContext());
 	_resqml20__BoundaryFeatureInterpretation* interp = static_cast<_resqml20__BoundaryFeatureInterpretation*>(gsoapProxy2_0_1);
 	interp->Domain = resqml20__Domain__mixed;
 

--- a/src/resqml2_0_1/CategoricalProperty.cpp
+++ b/src/resqml2_0_1/CategoricalProperty.cpp
@@ -40,12 +40,12 @@ CategoricalProperty::CategoricalProperty(RESQML2_NS::AbstractRepresentation * re
 	const unsigned int & dimension, const gsoap_resqml2_0_1::resqml20__IndexableElements & attachmentKind,
 	StringTableLookup* strLookup, const resqml20__ResqmlPropertyKind & energisticsPropertyKind)
 {
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORECategoricalProperty(rep->getGsoapContext(), 1);	
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORECategoricalProperty(rep->getGsoapContext());	
 	_resqml20__CategoricalProperty* prop = static_cast<_resqml20__CategoricalProperty*>(gsoapProxy2_0_1);
 	prop->IndexableElement = attachmentKind;
 	prop->Count = dimension;
 
-	resqml20__StandardPropertyKind* xmlStandardPropKind = soap_new_resqml20__StandardPropertyKind(gsoapProxy2_0_1->soap, 1);
+	resqml20__StandardPropertyKind* xmlStandardPropKind = soap_new_resqml20__StandardPropertyKind(gsoapProxy2_0_1->soap);
 	xmlStandardPropKind->Kind = energisticsPropertyKind;
 	prop->PropertyKind = xmlStandardPropKind;
 
@@ -62,7 +62,7 @@ CategoricalProperty::CategoricalProperty(RESQML2_NS::AbstractRepresentation * re
 	const unsigned int & dimension, const gsoap_resqml2_0_1::resqml20__IndexableElements & attachmentKind,
 	StringTableLookup* strLookup, RESQML2_NS::PropertyKind * localPropKind)
 {
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORECategoricalProperty(rep->getGsoapContext(), 1);	
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORECategoricalProperty(rep->getGsoapContext());	
 	_resqml20__CategoricalProperty* prop = static_cast<_resqml20__CategoricalProperty*>(gsoapProxy2_0_1);
 	prop->IndexableElement = attachmentKind;
 	prop->Count = dimension;

--- a/src/resqml2_0_1/CategoricalPropertySeries.cpp
+++ b/src/resqml2_0_1/CategoricalPropertySeries.cpp
@@ -37,12 +37,12 @@ CategoricalPropertySeries::CategoricalPropertySeries(RESQML2_NS::AbstractReprese
 	StringTableLookup* strLookup, const resqml20__ResqmlPropertyKind & energisticsPropertyKind,
 	RESQML2_NS::TimeSeries * ts, const bool & useInterval)
 {
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORECategoricalPropertySeries(rep->getGsoapContext(), 1);	
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORECategoricalPropertySeries(rep->getGsoapContext());	
 	_resqml20__CategoricalPropertySeries* prop = static_cast<_resqml20__CategoricalPropertySeries*>(gsoapProxy2_0_1);
 	prop->IndexableElement = attachmentKind;
 	prop->Count = dimension;
 
-	resqml20__StandardPropertyKind* xmlStandardPropKind = soap_new_resqml20__StandardPropertyKind(gsoapProxy2_0_1->soap, 1);
+	resqml20__StandardPropertyKind* xmlStandardPropKind = soap_new_resqml20__StandardPropertyKind(gsoapProxy2_0_1->soap);
 	xmlStandardPropKind->Kind = energisticsPropertyKind;
 	prop->PropertyKind = xmlStandardPropKind;
 
@@ -51,7 +51,7 @@ CategoricalPropertySeries::CategoricalPropertySeries(RESQML2_NS::AbstractReprese
 
 	setRepresentation(rep);
 
-	prop->SeriesTimeIndices = soap_new_resqml20__TimeIndices(gsoapProxy2_0_1->soap, 1);
+	prop->SeriesTimeIndices = soap_new_resqml20__TimeIndices(gsoapProxy2_0_1->soap);
 	prop->SeriesTimeIndices->TimeIndexCount = ts->getTimestampCount();
 	prop->SeriesTimeIndices->UseInterval = useInterval;
 	setTimeSeries(ts);
@@ -65,7 +65,7 @@ CategoricalPropertySeries::CategoricalPropertySeries(RESQML2_NS::AbstractReprese
 	StringTableLookup* strLookup, RESQML2_NS::PropertyKind * localPropKind,
 	RESQML2_NS::TimeSeries * ts, const bool & useInterval)
 {
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORECategoricalPropertySeries(rep->getGsoapContext(), 1);	
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORECategoricalPropertySeries(rep->getGsoapContext());	
 	_resqml20__CategoricalPropertySeries* prop = static_cast<_resqml20__CategoricalPropertySeries*>(gsoapProxy2_0_1);
 	prop->IndexableElement = attachmentKind;
 	prop->Count = dimension;
@@ -75,7 +75,7 @@ CategoricalPropertySeries::CategoricalPropertySeries(RESQML2_NS::AbstractReprese
 
 	setRepresentation(rep);
 
-	prop->SeriesTimeIndices = soap_new_resqml20__TimeIndices(gsoapProxy2_0_1->soap, 1);
+	prop->SeriesTimeIndices = soap_new_resqml20__TimeIndices(gsoapProxy2_0_1->soap);
 	prop->SeriesTimeIndices->TimeIndexCount = ts->getTimestampCount();
 	prop->SeriesTimeIndices->UseInterval = useInterval;
 	setTimeSeries(ts);

--- a/src/resqml2_0_1/CommentProperty.cpp
+++ b/src/resqml2_0_1/CommentProperty.cpp
@@ -38,12 +38,12 @@ const char* CommentProperty::XML_TAG = "CommentProperty";
 CommentProperty::CommentProperty(RESQML2_NS::AbstractRepresentation * rep, const string & guid, const string & title,
 	const unsigned int & dimension, const gsoap_resqml2_0_1::resqml20__IndexableElements & attachmentKind, const resqml20__ResqmlPropertyKind & energisticsPropertyKind)
 {
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORECommentProperty(rep->getGsoapContext(), 1);	
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORECommentProperty(rep->getGsoapContext());	
 	_resqml20__CommentProperty* prop = static_cast<_resqml20__CommentProperty*>(gsoapProxy2_0_1);
 	prop->IndexableElement = attachmentKind;
 	prop->Count = dimension;
 
-	resqml20__StandardPropertyKind* xmlStandardPropKind = soap_new_resqml20__StandardPropertyKind(gsoapProxy2_0_1->soap, 1);
+	resqml20__StandardPropertyKind* xmlStandardPropKind = soap_new_resqml20__StandardPropertyKind(gsoapProxy2_0_1->soap);
 	xmlStandardPropKind->Kind = energisticsPropertyKind;
 	prop->PropertyKind = xmlStandardPropKind;
 
@@ -56,7 +56,7 @@ CommentProperty::CommentProperty(RESQML2_NS::AbstractRepresentation * rep, const
 CommentProperty::CommentProperty(RESQML2_NS::AbstractRepresentation * rep, const string & guid, const string & title,
 	const unsigned int & dimension, const gsoap_resqml2_0_1::resqml20__IndexableElements & attachmentKind, RESQML2_NS::PropertyKind * localPropKind)
 {
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORECommentProperty(rep->getGsoapContext(), 1);	
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORECommentProperty(rep->getGsoapContext());	
 	_resqml20__CommentProperty* prop = static_cast<_resqml20__CommentProperty*>(gsoapProxy2_0_1);
 	prop->IndexableElement = attachmentKind;
 	prop->Count = dimension;
@@ -114,14 +114,14 @@ std::string CommentProperty::pushBackRefToExistingDataset(COMMON_NS::AbstractHdf
 	getRepository()->addRelationship(this, hdfProxy);
 	_resqml20__CommentProperty* prop = static_cast<_resqml20__CommentProperty*>(gsoapProxy2_0_1);
 
-	resqml20__PatchOfValues* patch = soap_new_resqml20__PatchOfValues(gsoapProxy2_0_1->soap, 1);
+	resqml20__PatchOfValues* patch = soap_new_resqml20__PatchOfValues(gsoapProxy2_0_1->soap);
 	patch->RepresentationPatchIndex = static_cast<ULONG64*>(soap_malloc(gsoapProxy2_0_1->soap, sizeof(ULONG64)));
 	*(patch->RepresentationPatchIndex) = prop->PatchOfValues.size();
 
 	// XML
 	ostringstream oss;
-	resqml20__StringHdf5Array* xmlValues = soap_new_resqml20__StringHdf5Array(gsoapProxy2_0_1->soap, 1);
-	xmlValues->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	resqml20__StringHdf5Array* xmlValues = soap_new_resqml20__StringHdf5Array(gsoapProxy2_0_1->soap);
+	xmlValues->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	xmlValues->Values->HdfProxy = hdfProxy->newResqmlReference();
 
 	if (datasetName.empty()) {

--- a/src/resqml2_0_1/ContinuousProperty.cpp
+++ b/src/resqml2_0_1/ContinuousProperty.cpp
@@ -38,7 +38,7 @@ const char* ContinuousProperty::XML_TAG = "ContinuousProperty";
 void ContinuousProperty::init(RESQML2_NS::AbstractRepresentation * rep, const std::string & guid, const std::string & title,
 	const unsigned int & dimension, const gsoap_resqml2_0_1::resqml20__IndexableElements & attachmentKind)
 {
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREContinuousProperty(rep->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREContinuousProperty(rep->getGsoapContext());
 	_resqml20__ContinuousProperty* prop = static_cast<_resqml20__ContinuousProperty*>(gsoapProxy2_0_1);
 	prop->IndexableElement = attachmentKind;
 	prop->Count = dimension;
@@ -56,7 +56,7 @@ ContinuousProperty::ContinuousProperty(RESQML2_NS::AbstractRepresentation * rep,
 
 	static_cast<_resqml20__ContinuousProperty*>(gsoapProxy2_0_1)->UOM = uom;
 
-	resqml20__StandardPropertyKind* xmlStandardPropKind = soap_new_resqml20__StandardPropertyKind(gsoapProxy2_0_1->soap, 1);
+	resqml20__StandardPropertyKind* xmlStandardPropKind = soap_new_resqml20__StandardPropertyKind(gsoapProxy2_0_1->soap);
 	xmlStandardPropKind->Kind = energisticsPropertyKind;
 	static_cast<_resqml20__ContinuousProperty*>(gsoapProxy2_0_1)->PropertyKind = xmlStandardPropKind;
 }
@@ -79,7 +79,7 @@ ContinuousProperty::ContinuousProperty(RESQML2_NS::AbstractRepresentation * rep,
 	static_cast<_resqml20__ContinuousProperty*>(gsoapProxy2_0_1)->UOM = gsoap_resqml2_0_1::resqml20__ResqmlUom__Euc;
 	pushBackExtraMetadata("Uom", nonStandardUom);
 
-	resqml20__StandardPropertyKind* xmlStandardPropKind = soap_new_resqml20__StandardPropertyKind(gsoapProxy2_0_1->soap, 1);
+	resqml20__StandardPropertyKind* xmlStandardPropKind = soap_new_resqml20__StandardPropertyKind(gsoapProxy2_0_1->soap);
 	xmlStandardPropKind->Kind = energisticsPropertyKind;
 	static_cast<_resqml20__ContinuousProperty*>(gsoapProxy2_0_1)->PropertyKind = xmlStandardPropKind;
 }
@@ -226,13 +226,13 @@ std::string ContinuousProperty::pushBackRefToExistingDataset(COMMON_NS::Abstract
 	getRepository()->addRelationship(this, hdfProxy);
 	gsoap_resqml2_0_1::resqml20__AbstractValuesProperty* prop = static_cast<gsoap_resqml2_0_1::resqml20__AbstractValuesProperty*>(gsoapProxy2_0_1);
 
-	gsoap_resqml2_0_1::resqml20__PatchOfValues* patch = gsoap_resqml2_0_1::soap_new_resqml20__PatchOfValues(gsoapProxy2_0_1->soap, 1);
+	gsoap_resqml2_0_1::resqml20__PatchOfValues* patch = gsoap_resqml2_0_1::soap_new_resqml20__PatchOfValues(gsoapProxy2_0_1->soap);
 	patch->RepresentationPatchIndex = static_cast<ULONG64*>(soap_malloc(gsoapProxy2_0_1->soap, sizeof(ULONG64)));
 	*(patch->RepresentationPatchIndex) = prop->PatchOfValues.size();
 
 	// XML
-	gsoap_resqml2_0_1::resqml20__DoubleHdf5Array* xmlValues = gsoap_resqml2_0_1::soap_new_resqml20__DoubleHdf5Array(gsoapProxy2_0_1->soap, 1);
-	xmlValues->Values = gsoap_resqml2_0_1::soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	gsoap_resqml2_0_1::resqml20__DoubleHdf5Array* xmlValues = gsoap_resqml2_0_1::soap_new_resqml20__DoubleHdf5Array(gsoapProxy2_0_1->soap);
+	xmlValues->Values = gsoap_resqml2_0_1::soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	xmlValues->Values->HdfProxy = hdfProxy->newResqmlReference();
 
 	if (datasetName.empty()) {

--- a/src/resqml2_0_1/ContinuousPropertySeries.cpp
+++ b/src/resqml2_0_1/ContinuousPropertySeries.cpp
@@ -35,13 +35,13 @@ ContinuousPropertySeries::ContinuousPropertySeries(RESQML2_NS::AbstractRepresent
 	const gsoap_resqml2_0_1::resqml20__ResqmlUom & uom, const resqml20__ResqmlPropertyKind & energisticsPropertyKind,
 	RESQML2_NS::TimeSeries * ts, const bool & useInterval)
 {
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREContinuousPropertySeries(rep->getGsoapContext(), 1);	
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREContinuousPropertySeries(rep->getGsoapContext());	
 	_resqml20__ContinuousPropertySeries* prop = static_cast<_resqml20__ContinuousPropertySeries*>(gsoapProxy2_0_1);
 	prop->IndexableElement = attachmentKind;
 	prop->Count = dimension;
 	prop->UOM = uom;
 
-	resqml20__StandardPropertyKind* xmlStandardPropKind = soap_new_resqml20__StandardPropertyKind(gsoapProxy2_0_1->soap, 1);
+	resqml20__StandardPropertyKind* xmlStandardPropKind = soap_new_resqml20__StandardPropertyKind(gsoapProxy2_0_1->soap);
 	xmlStandardPropKind->Kind = energisticsPropertyKind;
 	prop->PropertyKind = xmlStandardPropKind;
 
@@ -50,7 +50,7 @@ ContinuousPropertySeries::ContinuousPropertySeries(RESQML2_NS::AbstractRepresent
 
 	setRepresentation(rep);
 
-	prop->SeriesTimeIndices = soap_new_resqml20__TimeIndices(gsoapProxy2_0_1->soap, 1);
+	prop->SeriesTimeIndices = soap_new_resqml20__TimeIndices(gsoapProxy2_0_1->soap);
 	prop->SeriesTimeIndices->TimeIndexCount = ts->getTimestampCount();
 	prop->SeriesTimeIndices->UseInterval = useInterval;
 	setTimeSeries(ts);
@@ -61,7 +61,7 @@ ContinuousPropertySeries::ContinuousPropertySeries(RESQML2_NS::AbstractRepresent
 	const gsoap_resqml2_0_1::resqml20__ResqmlUom & uom, RESQML2_NS::PropertyKind * localPropKind,
 	RESQML2_NS::TimeSeries * ts, const bool & useInterval)
 {
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREContinuousPropertySeries(rep->getGsoapContext(), 1);	
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREContinuousPropertySeries(rep->getGsoapContext());	
 	_resqml20__ContinuousPropertySeries* prop = static_cast<_resqml20__ContinuousPropertySeries*>(gsoapProxy2_0_1);
 	prop->IndexableElement = attachmentKind;
 	prop->Count = dimension;
@@ -72,7 +72,7 @@ ContinuousPropertySeries::ContinuousPropertySeries(RESQML2_NS::AbstractRepresent
 
 	setRepresentation(rep);
 
-	prop->SeriesTimeIndices = soap_new_resqml20__TimeIndices(gsoapProxy2_0_1->soap, 1);
+	prop->SeriesTimeIndices = soap_new_resqml20__TimeIndices(gsoapProxy2_0_1->soap);
 	prop->SeriesTimeIndices->TimeIndexCount = ts->getTimestampCount();
 	prop->SeriesTimeIndices->UseInterval = useInterval;
 	setTimeSeries(ts);

--- a/src/resqml2_0_1/DeviationSurveyRepresentation.cpp
+++ b/src/resqml2_0_1/DeviationSurveyRepresentation.cpp
@@ -37,7 +37,7 @@ const char* DeviationSurveyRepresentation::XML_TAG = "DeviationSurveyRepresentat
 
 DeviationSurveyRepresentation::DeviationSurveyRepresentation(WellboreInterpretation * interp, const string & guid, const std::string & title, bool isFinal, RESQML2_NS::MdDatum * mdInfo)
 {
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREDeviationSurveyRepresentation(interp->getGsoapContext(), 1);	
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREDeviationSurveyRepresentation(interp->getGsoapContext());	
 	_resqml20__DeviationSurveyRepresentation* rep = static_cast<_resqml20__DeviationSurveyRepresentation*>(gsoapProxy2_0_1);
 
 	rep->IsFinal = isFinal;
@@ -75,7 +75,7 @@ void DeviationSurveyRepresentation::setGeometry(double * firstStationLocation, c
 
 	_resqml20__DeviationSurveyRepresentation* rep = static_cast<_resqml20__DeviationSurveyRepresentation*>(gsoapProxy2_0_1);
 
-	rep->FirstStationLocation = soap_new_resqml20__Point3d(gsoapProxy2_0_1->soap, 1);
+	rep->FirstStationLocation = soap_new_resqml20__Point3d(gsoapProxy2_0_1->soap);
 	rep->FirstStationLocation->Coordinate1 = firstStationLocation[0];
 	rep->FirstStationLocation->Coordinate2 = firstStationLocation[1];
 	rep->FirstStationLocation->Coordinate3 = firstStationLocation[2];
@@ -83,8 +83,8 @@ void DeviationSurveyRepresentation::setGeometry(double * firstStationLocation, c
 	rep->StationCount = stationCount;
 
 	rep->MdUom = mdUom;
-	resqml20__DoubleHdf5Array* xmlMds = soap_new_resqml20__DoubleHdf5Array(gsoapProxy2_0_1->soap, 1);
-	xmlMds->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	resqml20__DoubleHdf5Array* xmlMds = soap_new_resqml20__DoubleHdf5Array(gsoapProxy2_0_1->soap);
+	xmlMds->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	xmlMds->Values->HdfProxy = proxy->newResqmlReference();
 	xmlMds->Values->PathInHdfFile = "/RESQML/" + rep->uuid + "/mds";
 	rep->Mds = xmlMds;
@@ -94,16 +94,16 @@ void DeviationSurveyRepresentation::setGeometry(double * firstStationLocation, c
 
 	rep->AngleUom = angleUom;
 	// XML azimuths
-	resqml20__DoubleHdf5Array* xmlAzims = soap_new_resqml20__DoubleHdf5Array(gsoapProxy2_0_1->soap, 1);
-	xmlAzims->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	resqml20__DoubleHdf5Array* xmlAzims = soap_new_resqml20__DoubleHdf5Array(gsoapProxy2_0_1->soap);
+	xmlAzims->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	xmlAzims->Values->HdfProxy = proxy->newResqmlReference();
 	xmlAzims->Values->PathInHdfFile = "/RESQML/" + rep->uuid + "/azimuths";
 	rep->Azimuths = xmlAzims;
 	// HDF azimuths
 	proxy->writeArrayNdOfDoubleValues(rep->uuid, "azimuths", azimuths, dim, 1);
 	// XML inclinations
-	resqml20__DoubleHdf5Array* xmlIncls = soap_new_resqml20__DoubleHdf5Array(gsoapProxy2_0_1->soap, 1);
-	xmlIncls->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	resqml20__DoubleHdf5Array* xmlIncls = soap_new_resqml20__DoubleHdf5Array(gsoapProxy2_0_1->soap);
+	xmlIncls->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	xmlIncls->Values->HdfProxy = proxy->newResqmlReference();
 	xmlIncls->Values->PathInHdfFile = "/RESQML/" + rep->uuid + "/inclinations";
 	rep->Inclinations = xmlIncls;

--- a/src/resqml2_0_1/DiscreteProperty.cpp
+++ b/src/resqml2_0_1/DiscreteProperty.cpp
@@ -40,12 +40,12 @@ const char* DiscreteProperty::XML_TAG = "DiscreteProperty";
 DiscreteProperty::DiscreteProperty(RESQML2_NS::AbstractRepresentation * rep, const string & guid, const string & title,
 	const unsigned int & dimension, const gsoap_resqml2_0_1::resqml20__IndexableElements & attachmentKind, const resqml20__ResqmlPropertyKind & energisticsPropertyKind)
 {
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREDiscreteProperty(rep->getGsoapContext(), 1);	
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREDiscreteProperty(rep->getGsoapContext());	
 	_resqml20__DiscreteProperty* prop = static_cast<_resqml20__DiscreteProperty*>(gsoapProxy2_0_1);
 	prop->IndexableElement = attachmentKind;
 	prop->Count = dimension;
 
-	resqml20__StandardPropertyKind* xmlStandardPropKind = soap_new_resqml20__StandardPropertyKind(gsoapProxy2_0_1->soap, 1);
+	resqml20__StandardPropertyKind* xmlStandardPropKind = soap_new_resqml20__StandardPropertyKind(gsoapProxy2_0_1->soap);
 	xmlStandardPropKind->Kind = energisticsPropertyKind;
 	prop->PropertyKind = xmlStandardPropKind;
 
@@ -58,7 +58,7 @@ DiscreteProperty::DiscreteProperty(RESQML2_NS::AbstractRepresentation * rep, con
 DiscreteProperty::DiscreteProperty(RESQML2_NS::AbstractRepresentation * rep, const string & guid, const string & title,
 	const unsigned int & dimension, const gsoap_resqml2_0_1::resqml20__IndexableElements & attachmentKind, RESQML2_NS::PropertyKind * localPropKind)
 {
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREDiscreteProperty(rep->getGsoapContext(), 1);	
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREDiscreteProperty(rep->getGsoapContext());	
 	_resqml20__DiscreteProperty* prop = static_cast<_resqml20__DiscreteProperty*>(gsoapProxy2_0_1);
 	prop->IndexableElement = attachmentKind;
 	prop->Count = dimension;

--- a/src/resqml2_0_1/DiscretePropertySeries.cpp
+++ b/src/resqml2_0_1/DiscretePropertySeries.cpp
@@ -35,12 +35,12 @@ DiscretePropertySeries::DiscretePropertySeries(RESQML2_NS::AbstractRepresentatio
 	const resqml20__ResqmlPropertyKind & energisticsPropertyKind,
 	RESQML2_NS::TimeSeries * ts, const bool & useInterval)
 {
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREDiscretePropertySeries(rep->getGsoapContext(), 1);	
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREDiscretePropertySeries(rep->getGsoapContext());	
 	_resqml20__DiscretePropertySeries* prop = static_cast<_resqml20__DiscretePropertySeries*>(gsoapProxy2_0_1);
 	prop->IndexableElement = attachmentKind;
 	prop->Count = dimension;
 
-	resqml20__StandardPropertyKind* xmlStandardPropKind = soap_new_resqml20__StandardPropertyKind(gsoapProxy2_0_1->soap, 1);
+	resqml20__StandardPropertyKind* xmlStandardPropKind = soap_new_resqml20__StandardPropertyKind(gsoapProxy2_0_1->soap);
 	xmlStandardPropKind->Kind = energisticsPropertyKind;
 	prop->PropertyKind = xmlStandardPropKind;
 
@@ -49,7 +49,7 @@ DiscretePropertySeries::DiscretePropertySeries(RESQML2_NS::AbstractRepresentatio
 
 	setRepresentation(rep);
 
-	prop->SeriesTimeIndices = soap_new_resqml20__TimeIndices(gsoapProxy2_0_1->soap, 1);
+	prop->SeriesTimeIndices = soap_new_resqml20__TimeIndices(gsoapProxy2_0_1->soap);
 	prop->SeriesTimeIndices->TimeIndexCount = ts->getTimestampCount();
 	prop->SeriesTimeIndices->UseInterval = useInterval;
 	setTimeSeries(ts);
@@ -60,7 +60,7 @@ DiscretePropertySeries::DiscretePropertySeries(RESQML2_NS::AbstractRepresentatio
 	RESQML2_NS::PropertyKind * localPropKind,
 	RESQML2_NS::TimeSeries * ts, const bool & useInterval)
 {
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREDiscretePropertySeries(rep->getGsoapContext(), 1);	
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREDiscretePropertySeries(rep->getGsoapContext());	
 	_resqml20__DiscretePropertySeries* prop = static_cast<_resqml20__DiscretePropertySeries*>(gsoapProxy2_0_1);
 	prop->IndexableElement = attachmentKind;
 	prop->Count = dimension;
@@ -70,7 +70,7 @@ DiscretePropertySeries::DiscretePropertySeries(RESQML2_NS::AbstractRepresentatio
 
 	setRepresentation(rep);
 
-	prop->SeriesTimeIndices = soap_new_resqml20__TimeIndices(gsoapProxy2_0_1->soap, 1);
+	prop->SeriesTimeIndices = soap_new_resqml20__TimeIndices(gsoapProxy2_0_1->soap);
 	prop->SeriesTimeIndices->TimeIndexCount = ts->getTimestampCount();
 	prop->SeriesTimeIndices->UseInterval = useInterval;
 	setTimeSeries(ts);

--- a/src/resqml2_0_1/EarthModelInterpretation.cpp
+++ b/src/resqml2_0_1/EarthModelInterpretation.cpp
@@ -35,7 +35,7 @@ const char* EarthModelInterpretation::XML_TAG = "EarthModelInterpretation";
 
 EarthModelInterpretation::EarthModelInterpretation(OrganizationFeature * orgFeat, const std::string & guid, const string & title)
 {
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREEarthModelInterpretation(orgFeat->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREEarthModelInterpretation(orgFeat->getGsoapContext());
 	_resqml20__EarthModelInterpretation* interp = static_cast<_resqml20__EarthModelInterpretation*>(gsoapProxy2_0_1);
 
 	interp->Domain = resqml20__Domain__mixed;

--- a/src/resqml2_0_1/FaultInterpretation.cpp
+++ b/src/resqml2_0_1/FaultInterpretation.cpp
@@ -40,7 +40,7 @@ FaultInterpretation::FaultInterpretation(TectonicBoundaryFeature * fault, const 
 		throw invalid_argument("The interpreted fault cannot be a fracture.");
 	}
 
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREFaultInterpretation(fault->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREFaultInterpretation(fault->getGsoapContext());
 	_resqml20__FaultInterpretation* interp = static_cast<_resqml20__FaultInterpretation*>(gsoapProxy2_0_1);
 	interp->Domain = resqml20__Domain__mixed;
 
@@ -60,12 +60,12 @@ FaultInterpretation::FaultInterpretation(TectonicBoundaryFeature * fault, const 
 		throw invalid_argument("The interpreted fault cannot be a fracture.");
 	}
 
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREFaultInterpretation(fault->getGsoapContext(), 1);	
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREFaultInterpretation(fault->getGsoapContext());	
 	_resqml20__FaultInterpretation* interp = static_cast<_resqml20__FaultInterpretation*>(gsoapProxy2_0_1);
 	interp->Domain = resqml20__Domain__mixed;
 	interp->InterpretedFeature = fault->newResqmlReference();
 
-	interp->HasOccuredDuring = soap_new_resqml20__TimeInterval(interp->soap, 1);
+	interp->HasOccuredDuring = soap_new_resqml20__TimeInterval(interp->soap);
 	interp->HasOccuredDuring->ChronoBottom = chronoBtm->newResqmlReference();
 	interp->HasOccuredDuring->ChronoTop = chronoTop->newResqmlReference();
 
@@ -79,7 +79,7 @@ void FaultInterpretation::pushBackThrowInterpretation(const gsoap_resqml2_0_1::r
 {
 	_resqml20__FaultInterpretation* interp = static_cast<_resqml20__FaultInterpretation*>(gsoapProxy2_0_1);
 
-	resqml20__FaultThrow * throwInterp = soap_new_resqml20__FaultThrow(gsoapProxy2_0_1->soap, 1);
+	resqml20__FaultThrow * throwInterp = soap_new_resqml20__FaultThrow(gsoapProxy2_0_1->soap);
 	throwInterp->Throw.push_back(throwKind);
 
 	interp->ThrowInterpretation.push_back(throwInterp);

--- a/src/resqml2_0_1/FluidBoundaryFeature.cpp
+++ b/src/resqml2_0_1/FluidBoundaryFeature.cpp
@@ -33,7 +33,7 @@ FluidBoundaryFeature::FluidBoundaryFeature(COMMON_NS::DataObjectRepository * rep
 		throw invalid_argument("The repo cannot be null.");
 	}
 
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREFluidBoundaryFeature(repo->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREFluidBoundaryFeature(repo->getGsoapContext());
 	_resqml20__FluidBoundaryFeature* fbf = static_cast<_resqml20__FluidBoundaryFeature*>(gsoapProxy2_0_1);
 	fbf->FluidContact = fluidContact;
 

--- a/src/resqml2_0_1/FrontierFeature.cpp
+++ b/src/resqml2_0_1/FrontierFeature.cpp
@@ -31,7 +31,7 @@ FrontierFeature::FrontierFeature(COMMON_NS::DataObjectRepository * repo, const s
 	if (repo == nullptr)
 		throw invalid_argument("The repo cannot be null.");
 
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREFrontierFeature(repo->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREFrontierFeature(repo->getGsoapContext());
 
 	initMandatoryMetadata();
 	setMetadata(guid, title, "", -1, "", "", -1, "");

--- a/src/resqml2_0_1/GenericFeatureInterpretation.cpp
+++ b/src/resqml2_0_1/GenericFeatureInterpretation.cpp
@@ -34,7 +34,7 @@ GenericFeatureInterpretation::GenericFeatureInterpretation(RESQML2_NS::AbstractF
 		throw invalid_argument("The interpreted feature cannot be null.");
 	}
 
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREGenericFeatureInterpretation(feature->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREGenericFeatureInterpretation(feature->getGsoapContext());
 
 	static_cast<_resqml20__GenericFeatureInterpretation*>(gsoapProxy2_0_1)->Domain = resqml20__Domain__mixed;
 

--- a/src/resqml2_0_1/GeneticBoundaryFeature.cpp
+++ b/src/resqml2_0_1/GeneticBoundaryFeature.cpp
@@ -28,7 +28,7 @@ GeneticBoundaryFeature::GeneticBoundaryFeature(COMMON_NS::DataObjectRepository *
 	if (repo == nullptr)
 		throw invalid_argument("The soap context cannot be null.");
 
-	gsoapProxy2_0_1 = gsoap_resqml2_0_1::soap_new_resqml20__obj_USCOREGeneticBoundaryFeature(repo->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = gsoap_resqml2_0_1::soap_new_resqml20__obj_USCOREGeneticBoundaryFeature(repo->getGsoapContext());
 	gsoap_resqml2_0_1::_resqml20__GeneticBoundaryFeature* horizon = static_cast<gsoap_resqml2_0_1::_resqml20__GeneticBoundaryFeature*>(gsoapProxy2_0_1);
 	horizon->GeneticBoundaryKind = isAnHorizon ? gsoap_resqml2_0_1::resqml20__GeneticBoundaryKind__horizon : gsoap_resqml2_0_1::resqml20__GeneticBoundaryKind__geobody_x0020boundary;
 

--- a/src/resqml2_0_1/GeobodyBoundaryInterpretation.cpp
+++ b/src/resqml2_0_1/GeobodyBoundaryInterpretation.cpp
@@ -33,7 +33,7 @@ GeobodyBoundaryInterpretation::GeobodyBoundaryInterpretation(GeneticBoundaryFeat
 	if (geobodyBoundary == nullptr)
 		throw invalid_argument("The interpreted geobody boundary cannot be null.");
 
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREGeobodyBoundaryInterpretation(geobodyBoundary->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREGeobodyBoundaryInterpretation(geobodyBoundary->getGsoapContext());
 
 	static_cast<_resqml20__GeobodyBoundaryInterpretation*>(gsoapProxy2_0_1)->Domain = resqml20__Domain__mixed;
 

--- a/src/resqml2_0_1/GeobodyFeature.cpp
+++ b/src/resqml2_0_1/GeobodyFeature.cpp
@@ -29,7 +29,7 @@ GeobodyFeature::GeobodyFeature(COMMON_NS::DataObjectRepository * repo, const str
 	if (repo == nullptr)
 		throw invalid_argument("The repo cannot be null.");
 
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREGeobodyFeature(repo->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREGeobodyFeature(repo->getGsoapContext());
 
 	initMandatoryMetadata();
 	setMetadata(guid, title, std::string(), -1, std::string(), std::string(), -1, std::string());

--- a/src/resqml2_0_1/GeobodyInterpretation.cpp
+++ b/src/resqml2_0_1/GeobodyInterpretation.cpp
@@ -33,7 +33,7 @@ GeobodyInterpretation::GeobodyInterpretation(GeobodyFeature * feature, const str
 	if (!feature)
 		throw invalid_argument("The interpreted feature cannot be null.");
 
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREGeobodyInterpretation(feature->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREGeobodyInterpretation(feature->getGsoapContext());
 	static_cast<_resqml20__GeobodyInterpretation*>(gsoapProxy2_0_1)->Domain = resqml20__Domain__mixed;
 
 	initMandatoryMetadata();

--- a/src/resqml2_0_1/GeologicUnitFeature.cpp
+++ b/src/resqml2_0_1/GeologicUnitFeature.cpp
@@ -29,7 +29,7 @@ GeologicUnitFeature::GeologicUnitFeature(COMMON_NS::DataObjectRepository * repo,
 	if (repo == nullptr)
 		throw invalid_argument("The repo cannot be null.");
 
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREGeologicUnitFeature(repo->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREGeologicUnitFeature(repo->getGsoapContext());
 
 	initMandatoryMetadata();
 	setMetadata(guid, title, std::string(), -1, std::string(), std::string(), -1, std::string());

--- a/src/resqml2_0_1/Grid2dRepresentation.cpp
+++ b/src/resqml2_0_1/Grid2dRepresentation.cpp
@@ -35,7 +35,7 @@ const char* Grid2dRepresentation::XML_TAG = "Grid2dRepresentation";
 Grid2dRepresentation::Grid2dRepresentation(RESQML2_NS::AbstractFeatureInterpretation* interp,
 	const string & guid, const std::string & title)
 {
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREGrid2dRepresentation(interp->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREGrid2dRepresentation(interp->getGsoapContext());
 	_resqml20__Grid2dRepresentation* singleGrid2dRep = static_cast<_resqml20__Grid2dRepresentation*>(gsoapProxy2_0_1);
 
 	initMandatoryMetadata();
@@ -627,7 +627,7 @@ void Grid2dRepresentation::setGeometryAsArray2dOfLatticePoints3d(
 			xOffsetInSlowestDirection, yOffsetInSlowestDirection, zOffsetInSlowestDirection,
 			spacingInFastestDirection, spacingInSlowestDirection, localCrs);
 
-	resqml20__Grid2dPatch* patch = soap_new_resqml20__Grid2dPatch(gsoapProxy2_0_1->soap, 1);
+	resqml20__Grid2dPatch* patch = soap_new_resqml20__Grid2dPatch(gsoapProxy2_0_1->soap);
 	patch->PatchIndex = 0;
 	patch->Geometry = geomPatch;
 	patch->SlowestAxisCount = numPointsInSlowestDirection;
@@ -649,7 +649,7 @@ void Grid2dRepresentation::setGeometryAsArray2dOfExplicitZ(
 		localCrs = getRepository()->getDefaultCrs();
 	}
 
-	resqml20__Grid2dPatch* patch = soap_new_resqml20__Grid2dPatch(gsoapProxy2_0_1->soap, 1);
+	resqml20__Grid2dPatch* patch = soap_new_resqml20__Grid2dPatch(gsoapProxy2_0_1->soap);
 	static_cast<_resqml20__Grid2dRepresentation*>(gsoapProxy2_0_1)->Grid2dPatch = patch;
 
 	patch->PatchIndex = 0;
@@ -678,7 +678,7 @@ void Grid2dRepresentation::setGeometryAsArray2dOfExplicitZ(
 		localCrs = getRepository()->getDefaultCrs();
 	}
 
-	resqml20__Grid2dPatch* patch = soap_new_resqml20__Grid2dPatch(gsoapProxy2_0_1->soap, 1);
+	resqml20__Grid2dPatch* patch = soap_new_resqml20__Grid2dPatch(gsoapProxy2_0_1->soap);
 	static_cast<_resqml20__Grid2dRepresentation*>(gsoapProxy2_0_1)->Grid2dPatch = patch;
 
 	patch->PatchIndex = 0;

--- a/src/resqml2_0_1/GridConnectionSetRepresentation.cpp
+++ b/src/resqml2_0_1/GridConnectionSetRepresentation.cpp
@@ -39,7 +39,7 @@ using namespace gsoap_resqml2_0_1;
 
 void GridConnectionSetRepresentation::init(COMMON_NS::DataObjectRepository * repo, const std::string & guid, const std::string & title)
 {
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREGridConnectionSetRepresentation(repo->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREGridConnectionSetRepresentation(repo->getGsoapContext());
 
     initMandatoryMetadata();
     setMetadata(guid, title, std::string(), -1, std::string(), std::string(), -1, std::string());
@@ -90,8 +90,8 @@ void GridConnectionSetRepresentation::setCellIndexPairsUsingExistingDataset(ULON
 	getRepository()->addRelationship(this, proxy);
 
 	// XML cell index pair
-	resqml20__IntegerHdf5Array* const integerArray = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap, 1);
-	eml20__Hdf5Dataset * const resqmlHDF5dataset = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	resqml20__IntegerHdf5Array* const integerArray = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap);
+	eml20__Hdf5Dataset * const resqmlHDF5dataset = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	resqmlHDF5dataset->HdfProxy = proxy->newResqmlReference();
 	resqmlHDF5dataset->PathInHdfFile = cellIndexPair;
 	integerArray->Values = resqmlHDF5dataset;
@@ -100,8 +100,8 @@ void GridConnectionSetRepresentation::setCellIndexPairsUsingExistingDataset(ULON
 
 	// XML grid index pair
 	if (!gridIndexPair.empty()) {
-		resqml20__IntegerHdf5Array* const gridIndexPairArray = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap, 1);
-		eml20__Hdf5Dataset * const gridIndexPairDataset = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+		resqml20__IntegerHdf5Array* const gridIndexPairArray = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap);
+		eml20__Hdf5Dataset * const gridIndexPairDataset = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 		gridIndexPairDataset->HdfProxy = proxy->newResqmlReference();
 		gridIndexPairDataset->PathInHdfFile = gridIndexPair;
 		gridIndexPairArray->Values = gridIndexPairDataset;
@@ -120,8 +120,8 @@ void GridConnectionSetRepresentation::setLocalFacePerCellIndexPairsUsingExisting
 	getRepository()->addRelationship(this, proxy);
 
 	// XML
-	resqml20__IntegerHdf5Array* integerArray = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap, 1);
-	eml20__Hdf5Dataset * resqmlHDF5dataset = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	resqml20__IntegerHdf5Array* integerArray = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap);
+	eml20__Hdf5Dataset * resqmlHDF5dataset = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	resqmlHDF5dataset->HdfProxy = proxy->newResqmlReference();
 	resqmlHDF5dataset->PathInHdfFile = localFacePerCellIndexPair;
 	integerArray->Values = resqmlHDF5dataset;
@@ -463,22 +463,22 @@ void GridConnectionSetRepresentation::setConnectionInterpretationIndices(unsigne
 
 	_resqml20__GridConnectionSetRepresentation* rep = static_cast<_resqml20__GridConnectionSetRepresentation*>(gsoapProxy2_0_1);
 	if (rep->ConnectionInterpretations == nullptr) {
-		rep->ConnectionInterpretations = soap_new_resqml20__ConnectionInterpretations(gsoapProxy2_0_1->soap, 1);
+		rep->ConnectionInterpretations = soap_new_resqml20__ConnectionInterpretations(gsoapProxy2_0_1->soap);
 	}
-	rep->ConnectionInterpretations->InterpretationIndices = soap_new_resqml20__ResqmlJaggedArray(gsoapProxy2_0_1->soap, 1);
+	rep->ConnectionInterpretations->InterpretationIndices = soap_new_resqml20__ResqmlJaggedArray(gsoapProxy2_0_1->soap);
 	
 	// Cumulative
-	resqml20__IntegerHdf5Array* cumulativeLength = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap, 1);
+	resqml20__IntegerHdf5Array* cumulativeLength = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap);
 	rep->ConnectionInterpretations->InterpretationIndices->CumulativeLength = cumulativeLength;
 	cumulativeLength->NullValue = nullValue;
-	cumulativeLength->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	cumulativeLength->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	cumulativeLength->Values->HdfProxy = proxy->newResqmlReference();
 	cumulativeLength->Values->PathInHdfFile = "/RESQML/" + gsoapProxy2_0_1->uuid + "/InterpretationIndices/" + CUMULATIVE_LENGTH_DS_NAME;
 	// Elements
-	resqml20__IntegerHdf5Array* elements = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap, 1);
+	resqml20__IntegerHdf5Array* elements = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap);
 	rep->ConnectionInterpretations->InterpretationIndices->Elements = elements;
 	elements->NullValue = nullValue;
-	elements->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	elements->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	elements->Values->HdfProxy = proxy->newResqmlReference();
 	elements->Values->PathInHdfFile = "/RESQML/" + gsoapProxy2_0_1->uuid + "/InterpretationIndices/" + ELEMENTS_DS_NAME;
 
@@ -495,7 +495,7 @@ void GridConnectionSetRepresentation::pushBackXmlInterpretation(RESQML2_NS::Abst
 {
 	_resqml20__GridConnectionSetRepresentation* rep = static_cast<_resqml20__GridConnectionSetRepresentation*>(gsoapProxy2_0_1);
 	if (rep->ConnectionInterpretations == nullptr) {
-		rep->ConnectionInterpretations = soap_new_resqml20__ConnectionInterpretations(gsoapProxy2_0_1->soap, 1);
+		rep->ConnectionInterpretations = soap_new_resqml20__ConnectionInterpretations(gsoapProxy2_0_1->soap);
 	}
 
 	rep->ConnectionInterpretations->FeatureInterpretation.push_back(interp->newResqmlReference());

--- a/src/resqml2_0_1/HorizonInterpretation.cpp
+++ b/src/resqml2_0_1/HorizonInterpretation.cpp
@@ -36,7 +36,7 @@ HorizonInterpretation::HorizonInterpretation(Horizon * horizon, const string & g
 		throw invalid_argument("The interpreted horizon cannot be null.");
 	}
 
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREHorizonInterpretation(horizon->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREHorizonInterpretation(horizon->getGsoapContext());
 
 	static_cast<_resqml20__HorizonInterpretation*>(gsoapProxy2_0_1)->Domain = resqml20__Domain__mixed;
 

--- a/src/resqml2_0_1/IjkGridExplicitRepresentation.cpp
+++ b/src/resqml2_0_1/IjkGridExplicitRepresentation.cpp
@@ -364,7 +364,7 @@ void IjkGridExplicitRepresentation::setGeometryAsCoordinateLineNodesUsingExistin
 		localCrs = getRepository()->getDefaultCrs();
 	}
 
-	resqml20__IjkGridGeometry* geom = soap_new_resqml20__IjkGridGeometry(gsoapProxy2_0_1->soap, 1);
+	resqml20__IjkGridGeometry* geom = soap_new_resqml20__IjkGridGeometry(gsoapProxy2_0_1->soap);
 	geom->LocalCrs = localCrs->newResqmlReference();
 	if (!isTruncated()) {
 		getSpecializedGsoapProxy()->Geometry = geom;
@@ -382,54 +382,54 @@ void IjkGridExplicitRepresentation::setGeometryAsCoordinateLineNodesUsingExistin
 	getRepository()->addRelationship(this, proxy);
 	// Pillar defined
 	if (definedPillars.empty()) {
-		resqml20__BooleanConstantArray* xmlDefinedPillars = soap_new_resqml20__BooleanConstantArray(gsoapProxy2_0_1->soap, 1);
+		resqml20__BooleanConstantArray* xmlDefinedPillars = soap_new_resqml20__BooleanConstantArray(gsoapProxy2_0_1->soap);
 		geom->PillarGeometryIsDefined = xmlDefinedPillars;
 		xmlDefinedPillars->Count = (getICellCount() + 1) * (getJCellCount() + 1);
 		xmlDefinedPillars->Value = true;
 	}
 	else {
-		resqml20__BooleanHdf5Array* xmlDefinedPillars = soap_new_resqml20__BooleanHdf5Array(gsoapProxy2_0_1->soap, 1);
+		resqml20__BooleanHdf5Array* xmlDefinedPillars = soap_new_resqml20__BooleanHdf5Array(gsoapProxy2_0_1->soap);
 		geom->PillarGeometryIsDefined = xmlDefinedPillars;
-		xmlDefinedPillars->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+		xmlDefinedPillars->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 		xmlDefinedPillars->Values->HdfProxy = proxy->newResqmlReference();
 		xmlDefinedPillars->Values->PathInHdfFile = definedPillars;
 	}
 
 	// XML coordinate lines
-	resqml20__Point3dHdf5Array* xmlPoints = soap_new_resqml20__Point3dHdf5Array(gsoapProxy2_0_1->soap, 1);
+	resqml20__Point3dHdf5Array* xmlPoints = soap_new_resqml20__Point3dHdf5Array(gsoapProxy2_0_1->soap);
 	geom->Points = xmlPoints;
-	xmlPoints->Coordinates = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	xmlPoints->Coordinates = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	xmlPoints->Coordinates->HdfProxy = proxy->newResqmlReference();
 	xmlPoints->Coordinates->PathInHdfFile = points;
 
 	if (splitCoordinateLineCount > 0)
 	{
 		// XML split coordinate lines
-		geom->SplitCoordinateLines = soap_new_resqml20__ColumnLayerSplitCoordinateLines(gsoapProxy2_0_1->soap, 1);;
+		geom->SplitCoordinateLines = soap_new_resqml20__ColumnLayerSplitCoordinateLines(gsoapProxy2_0_1->soap);;
 		geom->SplitCoordinateLines->Count = splitCoordinateLineCount;
 
 		//XML
-		resqml20__IntegerHdf5Array* pillarIndices = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap, 1);
+		resqml20__IntegerHdf5Array* pillarIndices = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap);
 		geom->SplitCoordinateLines->PillarIndices = pillarIndices;
 		pillarIndices->NullValue = getPillarCount();
-		pillarIndices->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+		pillarIndices->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 		pillarIndices->Values->HdfProxy = proxy->newResqmlReference();
 		pillarIndices->Values->PathInHdfFile = pillarOfCoordinateLine;
 
 		//XML
-		geom->SplitCoordinateLines->ColumnsPerSplitCoordinateLine = soap_new_resqml20__ResqmlJaggedArray(gsoapProxy2_0_1->soap, 1);
+		geom->SplitCoordinateLines->ColumnsPerSplitCoordinateLine = soap_new_resqml20__ResqmlJaggedArray(gsoapProxy2_0_1->soap);
 		// Cumulative
-		resqml20__IntegerHdf5Array* cumulativeLength = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap, 1);
+		resqml20__IntegerHdf5Array* cumulativeLength = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap);
 		geom->SplitCoordinateLines->ColumnsPerSplitCoordinateLine->CumulativeLength = cumulativeLength;
 		cumulativeLength->NullValue = 0;
-		cumulativeLength->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+		cumulativeLength->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 		cumulativeLength->Values->HdfProxy = proxy->newResqmlReference();
 		cumulativeLength->Values->PathInHdfFile = splitCoordinateLineColumnCumulativeCount;
 		// Elements
-		resqml20__IntegerHdf5Array* elements = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap, 1);
+		resqml20__IntegerHdf5Array* elements = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap);
 		geom->SplitCoordinateLines->ColumnsPerSplitCoordinateLine->Elements = elements;
 		elements->NullValue = getColumnCount();
-		elements->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+		elements->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 		elements->Values->HdfProxy = proxy->newResqmlReference();
 		elements->Values->PathInHdfFile = splitCoordinateLineColumns;
 	}

--- a/src/resqml2_0_1/IjkGridLatticeRepresentation.cpp
+++ b/src/resqml2_0_1/IjkGridLatticeRepresentation.cpp
@@ -429,7 +429,7 @@ void IjkGridLatticeRepresentation::setGeometryAsCoordinateLineNodes(
 		localCrs = getRepository()->getDefaultCrs();
 	}
 
-	resqml20__IjkGridGeometry* geom = soap_new_resqml20__IjkGridGeometry(gsoapProxy2_0_1->soap, 1);
+	resqml20__IjkGridGeometry* geom = soap_new_resqml20__IjkGridGeometry(gsoapProxy2_0_1->soap);
 	geom->LocalCrs = localCrs->newResqmlReference();
 	if (!isTruncated()) {
 		getSpecializedGsoapProxy()->Geometry = geom;
@@ -442,55 +442,55 @@ void IjkGridLatticeRepresentation::setGeometryAsCoordinateLineNodes(
 	geom->KDirection = kDirectionKind;
 
 	// Pillar defined
-	resqml20__BooleanConstantArray* definedPillars = soap_new_resqml20__BooleanConstantArray(gsoapProxy2_0_1->soap, 1);
+	resqml20__BooleanConstantArray* definedPillars = soap_new_resqml20__BooleanConstantArray(gsoapProxy2_0_1->soap);
 	geom->PillarGeometryIsDefined = definedPillars;
 	definedPillars->Count = (getICellCount() + 1) * (getJCellCount() + 1);
 	definedPillars->Value = true;
 
 	// XML coordinate lines
-	resqml20__Point3dLatticeArray* xmlPoints = soap_new_resqml20__Point3dLatticeArray(gsoapProxy2_0_1->soap, 1);
+	resqml20__Point3dLatticeArray* xmlPoints = soap_new_resqml20__Point3dLatticeArray(gsoapProxy2_0_1->soap);
 	geom->Points = xmlPoints;
 
 	xmlPoints->AllDimensionsAreOrthogonal = (bool*)soap_malloc(gsoapProxy2_0_1->soap, sizeof(bool));
 	*xmlPoints->AllDimensionsAreOrthogonal = true;
-	xmlPoints->Origin = soap_new_resqml20__Point3d(gsoapProxy2_0_1->soap, 1);
+	xmlPoints->Origin = soap_new_resqml20__Point3d(gsoapProxy2_0_1->soap);
 	xmlPoints->Origin->Coordinate1 = originX;
 	xmlPoints->Origin->Coordinate2 = originY;
 	xmlPoints->Origin->Coordinate3 = originZ;
 
 	// slowest axis to fastest axis so k,j,i 
-	resqml20__Point3dOffset * dimK = soap_new_resqml20__Point3dOffset (gsoapProxy2_0_1->soap, 1);
+	resqml20__Point3dOffset * dimK = soap_new_resqml20__Point3dOffset (gsoapProxy2_0_1->soap);
 	xmlPoints->Offset.push_back(dimK);
 	// the dimension is the index of the axis in the collection. here we start from 0 and goes up by 1
-	dimK->Offset = soap_new_resqml20__Point3d(gsoapProxy2_0_1->soap, 1);
+	dimK->Offset = soap_new_resqml20__Point3d(gsoapProxy2_0_1->soap);
 	dimK->Offset->Coordinate1 = directionKX;
 	dimK->Offset->Coordinate2 = directionKY;
 	dimK->Offset->Coordinate3 = directionKZ;
-	resqml20__DoubleConstantArray * xmlSpacingK = soap_new_resqml20__DoubleConstantArray(gsoapProxy2_0_1->soap, 1);
+	resqml20__DoubleConstantArray * xmlSpacingK = soap_new_resqml20__DoubleConstantArray(gsoapProxy2_0_1->soap);
 	dimK->Spacing = xmlSpacingK;
 	xmlSpacingK->Count = getKCellCount(); // number of cells on K axis
 	xmlSpacingK->Value = spacingK;
 	
-	resqml20__Point3dOffset * dimJ = soap_new_resqml20__Point3dOffset (gsoapProxy2_0_1->soap, 1);
+	resqml20__Point3dOffset * dimJ = soap_new_resqml20__Point3dOffset (gsoapProxy2_0_1->soap);
 	xmlPoints->Offset.push_back(dimJ);
 	// the dimension is the index of the axis in the collection
-	dimJ->Offset = soap_new_resqml20__Point3d(gsoapProxy2_0_1->soap, 1);
+	dimJ->Offset = soap_new_resqml20__Point3d(gsoapProxy2_0_1->soap);
 	dimJ->Offset->Coordinate1 = directionJX;
 	dimJ->Offset->Coordinate2 = directionJY;
 	dimJ->Offset->Coordinate3 = directionJZ;
-	resqml20__DoubleConstantArray * xmlSpacingJ = soap_new_resqml20__DoubleConstantArray(gsoapProxy2_0_1->soap, 1);
+	resqml20__DoubleConstantArray * xmlSpacingJ = soap_new_resqml20__DoubleConstantArray(gsoapProxy2_0_1->soap);
 	dimJ->Spacing = xmlSpacingJ;
 	xmlSpacingJ->Count = getJCellCount(); // number of cells on J axis
 	xmlSpacingJ->Value = spacingJ;
 
-	resqml20__Point3dOffset * dimI = soap_new_resqml20__Point3dOffset (gsoapProxy2_0_1->soap, 1);
+	resqml20__Point3dOffset * dimI = soap_new_resqml20__Point3dOffset (gsoapProxy2_0_1->soap);
 	xmlPoints->Offset.push_back(dimI);
 	// the dimension is the index of the axis in the collection
-	dimI->Offset = soap_new_resqml20__Point3d(gsoapProxy2_0_1->soap, 1);
+	dimI->Offset = soap_new_resqml20__Point3d(gsoapProxy2_0_1->soap);
 	dimI->Offset->Coordinate1 = directionIX;
 	dimI->Offset->Coordinate2 = directionIY;
 	dimI->Offset->Coordinate3 = directionIZ;
-	resqml20__DoubleConstantArray * xmlSpacingI = soap_new_resqml20__DoubleConstantArray(gsoapProxy2_0_1->soap, 1);
+	resqml20__DoubleConstantArray * xmlSpacingI = soap_new_resqml20__DoubleConstantArray(gsoapProxy2_0_1->soap);
 	dimI->Spacing = xmlSpacingI;
 	xmlSpacingI->Count = getICellCount(); // number of cells on I axis
 	xmlSpacingI->Value = spacingI;
@@ -509,7 +509,7 @@ void IjkGridLatticeRepresentation::addSeismic3dCoordinatesToPatch(
 		throw invalid_argument("The patchIndex does not identify a point geometry.");
 
 	if (geom->SeismicCoordinates == nullptr)
-		geom->SeismicCoordinates = soap_new_resqml20__Seismic3dCoordinates(gsoapProxy2_0_1->soap, 1);
+		geom->SeismicCoordinates = soap_new_resqml20__Seismic3dCoordinates(gsoapProxy2_0_1->soap);
 	else if (geom->SeismicCoordinates->soap_type() == SOAP_TYPE_gsoap_resqml2_0_1_resqml20__Seismic2dCoordinates)
 		throw invalid_argument("It already exists some seismic 2d coordinates for this patch.");
 	resqml20__Seismic3dCoordinates* patch = static_cast<resqml20__Seismic3dCoordinates*>(geom->SeismicCoordinates);
@@ -518,20 +518,20 @@ void IjkGridLatticeRepresentation::addSeismic3dCoordinatesToPatch(
 	getRepository()->addRelationship(this, seismicSupport);
 
 	// inlines XML
-	resqml20__DoubleLatticeArray* inlineValues = soap_new_resqml20__DoubleLatticeArray(gsoapProxy2_0_1->soap, 1);
+	resqml20__DoubleLatticeArray* inlineValues = soap_new_resqml20__DoubleLatticeArray(gsoapProxy2_0_1->soap);
 	inlineValues->StartValue = startInline;
 
-	resqml20__DoubleConstantArray * IoffsetInline = soap_new_resqml20__DoubleConstantArray(gsoapProxy2_0_1->soap, 1);
+	resqml20__DoubleConstantArray * IoffsetInline = soap_new_resqml20__DoubleConstantArray(gsoapProxy2_0_1->soap);
 	IoffsetInline->Count = countInline - 1;
 	IoffsetInline->Value = incrInline;
 	inlineValues->Offset.push_back(IoffsetInline);
 
-	resqml20__DoubleConstantArray * IoffsetCrossline = soap_new_resqml20__DoubleConstantArray(gsoapProxy2_0_1->soap, 1);
+	resqml20__DoubleConstantArray * IoffsetCrossline = soap_new_resqml20__DoubleConstantArray(gsoapProxy2_0_1->soap);
 	IoffsetCrossline->Count = countCrossline -1;
 	IoffsetCrossline->Value = 0;
 	inlineValues->Offset.push_back(IoffsetCrossline);
 
-	resqml20__DoubleConstantArray * IoffsetSample = soap_new_resqml20__DoubleConstantArray(gsoapProxy2_0_1->soap, 1);
+	resqml20__DoubleConstantArray * IoffsetSample = soap_new_resqml20__DoubleConstantArray(gsoapProxy2_0_1->soap);
 	IoffsetSample->Count = countSample -1;
 	IoffsetSample->Value = 0;
 	inlineValues->Offset.push_back(IoffsetSample);
@@ -539,18 +539,18 @@ void IjkGridLatticeRepresentation::addSeismic3dCoordinatesToPatch(
 	patch->InlineCoordinates = inlineValues;
 
 	// crosslines XML
-	resqml20__DoubleLatticeArray* crosslineValues = soap_new_resqml20__DoubleLatticeArray(gsoapProxy2_0_1->soap, 1);
+	resqml20__DoubleLatticeArray* crosslineValues = soap_new_resqml20__DoubleLatticeArray(gsoapProxy2_0_1->soap);
 	crosslineValues->StartValue = startCrossline;
 
-	resqml20__DoubleConstantArray * CoffsetInline = soap_new_resqml20__DoubleConstantArray(gsoapProxy2_0_1->soap, 1);
+	resqml20__DoubleConstantArray * CoffsetInline = soap_new_resqml20__DoubleConstantArray(gsoapProxy2_0_1->soap);
 	CoffsetInline->Count = countInline - 1;
 	CoffsetInline->Value = 0;
 	crosslineValues->Offset.push_back(CoffsetInline);
-	resqml20__DoubleConstantArray * CoffsetCrossline = soap_new_resqml20__DoubleConstantArray(gsoapProxy2_0_1->soap, 1);
+	resqml20__DoubleConstantArray * CoffsetCrossline = soap_new_resqml20__DoubleConstantArray(gsoapProxy2_0_1->soap);
 	CoffsetCrossline->Count = countCrossline - 1;
 	CoffsetCrossline->Value = incrCrossline;
 	crosslineValues->Offset.push_back(CoffsetCrossline);
-	resqml20__DoubleConstantArray * CoffsetSample = soap_new_resqml20__DoubleConstantArray(gsoapProxy2_0_1->soap, 1);
+	resqml20__DoubleConstantArray * CoffsetSample = soap_new_resqml20__DoubleConstantArray(gsoapProxy2_0_1->soap);
 	CoffsetSample->Count = countSample - 1;
 	CoffsetSample->Value = 0;
 	crosslineValues->Offset.push_back(CoffsetSample);

--- a/src/resqml2_0_1/IjkGridParametricRepresentation.cpp
+++ b/src/resqml2_0_1/IjkGridParametricRepresentation.cpp
@@ -1375,9 +1375,9 @@ void IjkGridParametricRepresentation::setGeometryAsParametricSplittedPillarNodes
 	geom->PillarShape = mostComplexPillarGeometry;
 
 	// XML Pillar defined
-	resqml20__BooleanHdf5Array* xmlDefinedPillars = soap_new_resqml20__BooleanHdf5Array(gsoapProxy2_0_1->soap, 1);
+	resqml20__BooleanHdf5Array* xmlDefinedPillars = soap_new_resqml20__BooleanHdf5Array(gsoapProxy2_0_1->soap);
 	geom->PillarGeometryIsDefined = xmlDefinedPillars;
-	xmlDefinedPillars->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	xmlDefinedPillars->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	xmlDefinedPillars->Values->HdfProxy = proxy->newResqmlReference();
 	xmlDefinedPillars->Values->PathInHdfFile = "/RESQML/" + gsoapProxy2_0_1->uuid + "/PillarGeometryIsDefined";
 
@@ -1406,10 +1406,10 @@ void IjkGridParametricRepresentation::setGeometryAsParametricSplittedPillarNodes
 	paramLines->KnotCount = controlPointMaxCountPerPillar;
 
 	// XML Line kinds
-	resqml20__IntegerHdf5Array* xmlLineKinds = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap, 1);
+	resqml20__IntegerHdf5Array* xmlLineKinds = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap);
 	paramLines->LineKindIndices = xmlLineKinds;
 	xmlLineKinds->NullValue = -1;
-	xmlLineKinds->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	xmlLineKinds->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	xmlLineKinds->Values->HdfProxy = proxy->newResqmlReference();
 	xmlLineKinds->Values->PathInHdfFile = "/RESQML/" + gsoapProxy2_0_1->uuid + "/LineKindIndices";
 
@@ -1447,9 +1447,9 @@ void IjkGridParametricRepresentation::setGeometryAsParametricSplittedPillarNodes
 	geom->PillarShape = mostComplexPillarGeometry;
 
 	// XML Pillar defined
-	resqml20__BooleanHdf5Array* xmlDefinedPillars = soap_new_resqml20__BooleanHdf5Array(gsoapProxy2_0_1->soap, 1);
+	resqml20__BooleanHdf5Array* xmlDefinedPillars = soap_new_resqml20__BooleanHdf5Array(gsoapProxy2_0_1->soap);
 	geom->PillarGeometryIsDefined = xmlDefinedPillars;
-	xmlDefinedPillars->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	xmlDefinedPillars->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	xmlDefinedPillars->Values->HdfProxy = proxy->newResqmlReference();
 	xmlDefinedPillars->Values->PathInHdfFile = definedPillars;
 
@@ -1461,10 +1461,10 @@ void IjkGridParametricRepresentation::setGeometryAsParametricSplittedPillarNodes
 	paramLines->KnotCount = controlPointMaxCountPerPillar;
 
 	// XML Line kinds
-	resqml20__IntegerHdf5Array* xmlLineKinds = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap, 1);
+	resqml20__IntegerHdf5Array* xmlLineKinds = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap);
 	paramLines->LineKindIndices = xmlLineKinds;
 	xmlLineKinds->NullValue = -1;
-	xmlLineKinds->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	xmlLineKinds->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	xmlLineKinds->Values->HdfProxy = proxy->newResqmlReference();
 	xmlLineKinds->Values->PathInHdfFile = pillarKind;
 }
@@ -1578,7 +1578,7 @@ void IjkGridParametricRepresentation::setGeometryAsParametricSplittedPillarNodes
 		}
 	}
 
-	resqml20__IjkGridGeometry* geom = soap_new_resqml20__IjkGridGeometry(gsoapProxy2_0_1->soap, 1);
+	resqml20__IjkGridGeometry* geom = soap_new_resqml20__IjkGridGeometry(gsoapProxy2_0_1->soap);
 	geom->LocalCrs = localCrs->newResqmlReference();
 	if (!isTruncated()) {
 		getSpecializedGsoapProxy()->Geometry = geom;
@@ -1597,41 +1597,41 @@ void IjkGridParametricRepresentation::setGeometryAsParametricSplittedPillarNodes
 	}
 	getRepository()->addRelationship(this, proxy);
 	// XML parametric nodes
-	resqml20__Point3dParametricArray* xmlPoints = soap_new_resqml20__Point3dParametricArray(gsoapProxy2_0_1->soap, 1);
+	resqml20__Point3dParametricArray* xmlPoints = soap_new_resqml20__Point3dParametricArray(gsoapProxy2_0_1->soap);
 	geom->Points = xmlPoints;
-	resqml20__DoubleHdf5Array* xmlParameters = soap_new_resqml20__DoubleHdf5Array(gsoapProxy2_0_1->soap, 1);
+	resqml20__DoubleHdf5Array* xmlParameters = soap_new_resqml20__DoubleHdf5Array(gsoapProxy2_0_1->soap);
 	xmlPoints->Parameters = xmlParameters;
-	xmlParameters->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	xmlParameters->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	xmlParameters->Values->HdfProxy = proxy->newResqmlReference();
 	xmlParameters->Values->PathInHdfFile = parameters;
 
 	if (splitCoordinateLineCount > 0) {
 		// XML split coordinate lines
-		geom->SplitCoordinateLines = soap_new_resqml20__ColumnLayerSplitCoordinateLines(gsoapProxy2_0_1->soap, 1);;
+		geom->SplitCoordinateLines = soap_new_resqml20__ColumnLayerSplitCoordinateLines(gsoapProxy2_0_1->soap);;
 		geom->SplitCoordinateLines->Count = splitCoordinateLineCount;
 
 		//XML
-		resqml20__IntegerHdf5Array* pillarIndices = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap, 1);
+		resqml20__IntegerHdf5Array* pillarIndices = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap);
 		geom->SplitCoordinateLines->PillarIndices = pillarIndices;
 		pillarIndices->NullValue = getPillarCount();
-		pillarIndices->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+		pillarIndices->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 		pillarIndices->Values->HdfProxy = proxy->newResqmlReference();
 		pillarIndices->Values->PathInHdfFile = pillarOfCoordinateLine;
 
 		//XML
-		geom->SplitCoordinateLines->ColumnsPerSplitCoordinateLine = soap_new_resqml20__ResqmlJaggedArray(gsoapProxy2_0_1->soap, 1);
+		geom->SplitCoordinateLines->ColumnsPerSplitCoordinateLine = soap_new_resqml20__ResqmlJaggedArray(gsoapProxy2_0_1->soap);
 		// Cumulative
-		resqml20__IntegerHdf5Array* cumulativeLength = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap, 1);
+		resqml20__IntegerHdf5Array* cumulativeLength = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap);
 		geom->SplitCoordinateLines->ColumnsPerSplitCoordinateLine->CumulativeLength = cumulativeLength;
 		cumulativeLength->NullValue = 0;
-		cumulativeLength->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+		cumulativeLength->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 		cumulativeLength->Values->HdfProxy = proxy->newResqmlReference();
 		cumulativeLength->Values->PathInHdfFile = splitCoordinateLineColumnCumulativeCount;
 		// Elements
-		resqml20__IntegerHdf5Array* elements = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap, 1);
+		resqml20__IntegerHdf5Array* elements = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap);
 		geom->SplitCoordinateLines->ColumnsPerSplitCoordinateLine->Elements = elements;
 		elements->NullValue = getColumnCount();
-		elements->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+		elements->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 		elements->Values->HdfProxy = proxy->newResqmlReference();
 		elements->Values->PathInHdfFile = splitCoordinateLineColumns;
 	}
@@ -1639,14 +1639,14 @@ void IjkGridParametricRepresentation::setGeometryAsParametricSplittedPillarNodes
 	// *********************************
 	// Parametric coordinate lines
 	// *********************************
-	resqml20__ParametricLineArray* paramLines = soap_new_resqml20__ParametricLineArray(gsoapProxy2_0_1->soap, 1);
+	resqml20__ParametricLineArray* paramLines = soap_new_resqml20__ParametricLineArray(gsoapProxy2_0_1->soap);
 	xmlPoints->ParametricLines = paramLines;
 	paramLines->KnotCount = controlPointCountPerPillar;
 
 	// XML control points
-	resqml20__Point3dHdf5Array* xmlcontrolPoints = soap_new_resqml20__Point3dHdf5Array(gsoapProxy2_0_1->soap, 1);
+	resqml20__Point3dHdf5Array* xmlcontrolPoints = soap_new_resqml20__Point3dHdf5Array(gsoapProxy2_0_1->soap);
 	paramLines->ControlPoints = xmlcontrolPoints;
-	xmlcontrolPoints->Coordinates = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	xmlcontrolPoints->Coordinates = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	xmlcontrolPoints->Coordinates->HdfProxy = proxy->newResqmlReference();
 	xmlcontrolPoints->Coordinates->PathInHdfFile = controlPoints;
 
@@ -1655,9 +1655,9 @@ void IjkGridParametricRepresentation::setGeometryAsParametricSplittedPillarNodes
 	// *********************************
 	if (!controlPointParameters.empty()) {
 		// XML control point parameters
-		resqml20__DoubleHdf5Array* xmlcontrolPointParams = soap_new_resqml20__DoubleHdf5Array(gsoapProxy2_0_1->soap, 1);
+		resqml20__DoubleHdf5Array* xmlcontrolPointParams = soap_new_resqml20__DoubleHdf5Array(gsoapProxy2_0_1->soap);
 		paramLines->ControlPointParameters = xmlcontrolPointParams;
-		xmlcontrolPointParams->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+		xmlcontrolPointParams->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 		xmlcontrolPointParams->Values->HdfProxy = proxy->newResqmlReference();
 		xmlcontrolPointParams->Values->PathInHdfFile = controlPointParameters;
 	}
@@ -1697,7 +1697,7 @@ void IjkGridParametricRepresentation::setGeometryAsParametricSplittedPillarNodes
 	}
 
 	// XML Pillar defined
-	resqml20__BooleanConstantArray* xmlDefinedPillars = soap_new_resqml20__BooleanConstantArray(gsoapProxy2_0_1->soap, 1);
+	resqml20__BooleanConstantArray* xmlDefinedPillars = soap_new_resqml20__BooleanConstantArray(gsoapProxy2_0_1->soap);
 	geom->PillarGeometryIsDefined = xmlDefinedPillars;
 	xmlDefinedPillars->Value = true;
 	xmlDefinedPillars->Count = getPillarCount();
@@ -1706,7 +1706,7 @@ void IjkGridParametricRepresentation::setGeometryAsParametricSplittedPillarNodes
 	resqml20__ParametricLineArray* paramLines = static_cast<resqml20__ParametricLineArray*>(xmlPoints->ParametricLines);
 
 	// XML Line kinds
-	resqml20__IntegerConstantArray* xmlLineKinds = soap_new_resqml20__IntegerConstantArray(gsoapProxy2_0_1->soap, 1);
+	resqml20__IntegerConstantArray* xmlLineKinds = soap_new_resqml20__IntegerConstantArray(gsoapProxy2_0_1->soap);
 	paramLines->LineKindIndices = xmlLineKinds;
 	xmlLineKinds->Value = pillarKind;
 	xmlLineKinds->Count = getPillarCount();

--- a/src/resqml2_0_1/LocalDepth3dCrs.cpp
+++ b/src/resqml2_0_1/LocalDepth3dCrs.cpp
@@ -36,9 +36,9 @@ void LocalDepth3dCrs::init(COMMON_NS::DataObjectRepository * repo, const std::st
 		throw invalid_argument("The soap context where the local CRS will be instantiated must exist.");
 	}
 
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORELocalDepth3dCrs(repo->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORELocalDepth3dCrs(repo->getGsoapContext());
 	_resqml20__LocalDepth3dCrs* local3dCrs = static_cast<_resqml20__LocalDepth3dCrs*>(gsoapProxy2_0_1);
-	local3dCrs->ArealRotation = soap_new_eml20__PlaneAngleMeasure(gsoapProxy2_0_1->soap, 1);
+	local3dCrs->ArealRotation = soap_new_eml20__PlaneAngleMeasure(gsoapProxy2_0_1->soap);
 	local3dCrs->ArealRotation->__item = arealRotation;
 	local3dCrs->ArealRotation->uom = eml20__PlaneAngleUom__rad;
 	local3dCrs->ProjectedAxisOrder = eml20__AxisOrder2d__easting_x0020northing;
@@ -68,12 +68,12 @@ LocalDepth3dCrs::LocalDepth3dCrs(COMMON_NS::DataObjectRepository * repo, const s
 	_resqml20__LocalDepth3dCrs* local3dCrs = static_cast<_resqml20__LocalDepth3dCrs*>(gsoapProxy2_0_1);
 
 	// Projected CRS
-	eml20__ProjectedCrsEpsgCode* projCrs = soap_new_eml20__ProjectedCrsEpsgCode(gsoapProxy2_0_1->soap, 1);
+	eml20__ProjectedCrsEpsgCode* projCrs = soap_new_eml20__ProjectedCrsEpsgCode(gsoapProxy2_0_1->soap);
 	local3dCrs->ProjectedCrs = projCrs;
 	projCrs->EpsgCode = projectedEpsgCode;
 
 	// Vertical CRS
-	eml20__VerticalCrsEpsgCode* vertCrs = soap_new_eml20__VerticalCrsEpsgCode(gsoapProxy2_0_1->soap, 1);
+	eml20__VerticalCrsEpsgCode* vertCrs = soap_new_eml20__VerticalCrsEpsgCode(gsoapProxy2_0_1->soap);
 	local3dCrs->VerticalCrs = vertCrs;
 	vertCrs->EpsgCode = verticalEpsgCode;
 }
@@ -88,12 +88,12 @@ LocalDepth3dCrs::LocalDepth3dCrs(COMMON_NS::DataObjectRepository * repo, const s
 	_resqml20__LocalDepth3dCrs* local3dCrs = static_cast<_resqml20__LocalDepth3dCrs*>(gsoapProxy2_0_1);
 
 	// Projected CRS
-	eml20__ProjectedUnknownCrs* projCrs = soap_new_eml20__ProjectedUnknownCrs(gsoapProxy2_0_1->soap, 1);
+	eml20__ProjectedUnknownCrs* projCrs = soap_new_eml20__ProjectedUnknownCrs(gsoapProxy2_0_1->soap);
 	local3dCrs->ProjectedCrs = projCrs;
 	projCrs->Unknown = projectedUnknownReason;
 
 	// Vertical CRS
-	eml20__VerticalUnknownCrs* vertCrs = soap_new_eml20__VerticalUnknownCrs(gsoapProxy2_0_1->soap, 1);
+	eml20__VerticalUnknownCrs* vertCrs = soap_new_eml20__VerticalUnknownCrs(gsoapProxy2_0_1->soap);
 	local3dCrs->VerticalCrs = vertCrs;
 	vertCrs->Unknown = verticalUnknownReason;
 }
@@ -111,12 +111,12 @@ LocalDepth3dCrs::LocalDepth3dCrs(COMMON_NS::DataObjectRepository * repo, const s
 	_resqml20__LocalDepth3dCrs* local3dCrs = static_cast<_resqml20__LocalDepth3dCrs*>(gsoapProxy2_0_1);
 
 	// Projected CRS
-	eml20__ProjectedCrsEpsgCode* projCrs = soap_new_eml20__ProjectedCrsEpsgCode(gsoapProxy2_0_1->soap, 1);
+	eml20__ProjectedCrsEpsgCode* projCrs = soap_new_eml20__ProjectedCrsEpsgCode(gsoapProxy2_0_1->soap);
 	local3dCrs->ProjectedCrs = projCrs;
 	projCrs->EpsgCode = projectedEpsgCode;
 
 	// Vertical CRS
-	eml20__VerticalUnknownCrs* vertCrs = soap_new_eml20__VerticalUnknownCrs(gsoapProxy2_0_1->soap, 1);
+	eml20__VerticalUnknownCrs* vertCrs = soap_new_eml20__VerticalUnknownCrs(gsoapProxy2_0_1->soap);
 	local3dCrs->VerticalCrs = vertCrs;
 	vertCrs->Unknown = verticalUnknownReason;
 }
@@ -134,12 +134,12 @@ LocalDepth3dCrs::LocalDepth3dCrs(COMMON_NS::DataObjectRepository * repo, const s
 	_resqml20__LocalDepth3dCrs* local3dCrs = static_cast<_resqml20__LocalDepth3dCrs*>(gsoapProxy2_0_1);
 
 	// Projected CRS
-	eml20__ProjectedUnknownCrs* projCrs = soap_new_eml20__ProjectedUnknownCrs(gsoapProxy2_0_1->soap, 1);
+	eml20__ProjectedUnknownCrs* projCrs = soap_new_eml20__ProjectedUnknownCrs(gsoapProxy2_0_1->soap);
 	local3dCrs->ProjectedCrs = projCrs;
 	projCrs->Unknown = projectedUnknownReason;
 
 	// Vertical CRS
-	eml20__VerticalCrsEpsgCode* vertCrs = soap_new_eml20__VerticalCrsEpsgCode(gsoapProxy2_0_1->soap, 1);
+	eml20__VerticalCrsEpsgCode* vertCrs = soap_new_eml20__VerticalCrsEpsgCode(gsoapProxy2_0_1->soap);
 	local3dCrs->VerticalCrs = vertCrs;
 	vertCrs->EpsgCode = verticalEpsgCode;
 }

--- a/src/resqml2_0_1/LocalTime3dCrs.cpp
+++ b/src/resqml2_0_1/LocalTime3dCrs.cpp
@@ -37,9 +37,9 @@ void LocalTime3dCrs::init(COMMON_NS::DataObjectRepository * repo, const std::str
 		throw invalid_argument("The repo cannot be null.");
 	}
 
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORELocalTime3dCrs(repo->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORELocalTime3dCrs(repo->getGsoapContext());
 	_resqml20__LocalTime3dCrs* local3dCrs = static_cast<_resqml20__LocalTime3dCrs*>(gsoapProxy2_0_1);
-	local3dCrs->ArealRotation = soap_new_eml20__PlaneAngleMeasure(gsoapProxy2_0_1->soap, 1);
+	local3dCrs->ArealRotation = soap_new_eml20__PlaneAngleMeasure(gsoapProxy2_0_1->soap);
 	local3dCrs->ArealRotation->__item = arealRotation;
 	local3dCrs->ArealRotation->uom = eml20__PlaneAngleUom__rad;
 	local3dCrs->ProjectedAxisOrder = eml20__AxisOrder2d__easting_x0020northing;
@@ -71,12 +71,12 @@ LocalTime3dCrs::LocalTime3dCrs(COMMON_NS::DataObjectRepository * repo, const std
 	_resqml20__LocalTime3dCrs* local3dCrs = static_cast<_resqml20__LocalTime3dCrs*>(gsoapProxy2_0_1);
 
 	// Projected CRS
-	eml20__ProjectedCrsEpsgCode* projCrs = soap_new_eml20__ProjectedCrsEpsgCode(gsoapProxy2_0_1->soap, 1);
+	eml20__ProjectedCrsEpsgCode* projCrs = soap_new_eml20__ProjectedCrsEpsgCode(gsoapProxy2_0_1->soap);
 	local3dCrs->ProjectedCrs = projCrs;
 	projCrs->EpsgCode = projectedEpsgCode;
 
 	// Vertical CRS
-	eml20__VerticalCrsEpsgCode* vertCrs = soap_new_eml20__VerticalCrsEpsgCode(gsoapProxy2_0_1->soap, 1);
+	eml20__VerticalCrsEpsgCode* vertCrs = soap_new_eml20__VerticalCrsEpsgCode(gsoapProxy2_0_1->soap);
 	local3dCrs->VerticalCrs = vertCrs;
 	vertCrs->EpsgCode = verticalEpsgCode;
 }
@@ -92,12 +92,12 @@ LocalTime3dCrs::LocalTime3dCrs(COMMON_NS::DataObjectRepository * repo, const std
 	_resqml20__LocalTime3dCrs* local3dCrs = static_cast<_resqml20__LocalTime3dCrs*>(gsoapProxy2_0_1);
 
 	// Projected CRS
-	eml20__ProjectedUnknownCrs* projCrs = soap_new_eml20__ProjectedUnknownCrs(gsoapProxy2_0_1->soap, 1);
+	eml20__ProjectedUnknownCrs* projCrs = soap_new_eml20__ProjectedUnknownCrs(gsoapProxy2_0_1->soap);
 	local3dCrs->ProjectedCrs = projCrs;
 	projCrs->Unknown = projectedUnknownReason;
 
 	// Vertical CRS
-	eml20__VerticalUnknownCrs* vertCrs = soap_new_eml20__VerticalUnknownCrs(gsoapProxy2_0_1->soap, 1);
+	eml20__VerticalUnknownCrs* vertCrs = soap_new_eml20__VerticalUnknownCrs(gsoapProxy2_0_1->soap);
 	local3dCrs->VerticalCrs = vertCrs;
 	vertCrs->Unknown = verticalUnknownReason;
 }
@@ -116,12 +116,12 @@ LocalTime3dCrs::LocalTime3dCrs(COMMON_NS::DataObjectRepository * repo, const std
 	_resqml20__LocalTime3dCrs* local3dCrs = static_cast<_resqml20__LocalTime3dCrs*>(gsoapProxy2_0_1);
 
 	// Projected CRS
-	eml20__ProjectedCrsEpsgCode* projCrs = soap_new_eml20__ProjectedCrsEpsgCode(gsoapProxy2_0_1->soap, 1);
+	eml20__ProjectedCrsEpsgCode* projCrs = soap_new_eml20__ProjectedCrsEpsgCode(gsoapProxy2_0_1->soap);
 	local3dCrs->ProjectedCrs = projCrs;
 	projCrs->EpsgCode = projectedEpsgCode;
 
 	// Vertical CRS
-	eml20__VerticalUnknownCrs* vertCrs = soap_new_eml20__VerticalUnknownCrs(gsoapProxy2_0_1->soap, 1);
+	eml20__VerticalUnknownCrs* vertCrs = soap_new_eml20__VerticalUnknownCrs(gsoapProxy2_0_1->soap);
 	local3dCrs->VerticalCrs = vertCrs;
 	vertCrs->Unknown = verticalUnknownReason;
 }
@@ -140,12 +140,12 @@ LocalTime3dCrs::LocalTime3dCrs(COMMON_NS::DataObjectRepository * repo, const std
 	_resqml20__LocalTime3dCrs* local3dCrs = static_cast<_resqml20__LocalTime3dCrs*>(gsoapProxy2_0_1);
 
 	// Projected CRS
-	eml20__ProjectedUnknownCrs* projCrs = soap_new_eml20__ProjectedUnknownCrs(gsoapProxy2_0_1->soap, 1);
+	eml20__ProjectedUnknownCrs* projCrs = soap_new_eml20__ProjectedUnknownCrs(gsoapProxy2_0_1->soap);
 	local3dCrs->ProjectedCrs = projCrs;
 	projCrs->Unknown = projectedUnknownReason;
 
 	// Vertical CRS
-	eml20__VerticalCrsEpsgCode* vertCrs = soap_new_eml20__VerticalCrsEpsgCode(gsoapProxy2_0_1->soap, 1);
+	eml20__VerticalCrsEpsgCode* vertCrs = soap_new_eml20__VerticalCrsEpsgCode(gsoapProxy2_0_1->soap);
 	local3dCrs->VerticalCrs = vertCrs;
 	vertCrs->EpsgCode = verticalEpsgCode;
 }

--- a/src/resqml2_0_1/MdDatum.cpp
+++ b/src/resqml2_0_1/MdDatum.cpp
@@ -34,11 +34,11 @@ MdDatum::MdDatum(COMMON_NS::DataObjectRepository * repo, const string & guid, co
 	if (repo == nullptr)
 		throw invalid_argument("The repo must exist");
 
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREMdDatum(repo->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREMdDatum(repo->getGsoapContext());
 	_resqml20__MdDatum* mdInfo = static_cast<_resqml20__MdDatum*>(gsoapProxy2_0_1);
 
 	mdInfo->MdReference = originKind;
-	mdInfo->Location = soap_new_resqml20__Point3d(repo->getGsoapContext(), 1);
+	mdInfo->Location = soap_new_resqml20__Point3d(repo->getGsoapContext());
 	mdInfo->Location->Coordinate1 = referenceLocationOrdinal1;
 	mdInfo->Location->Coordinate2 = referenceLocationOrdinal2;
 	mdInfo->Location->Coordinate3 = referenceLocationOrdinal3;

--- a/src/resqml2_0_1/NonSealedSurfaceFrameworkRepresentation.cpp
+++ b/src/resqml2_0_1/NonSealedSurfaceFrameworkRepresentation.cpp
@@ -44,11 +44,11 @@ NonSealedSurfaceFrameworkRepresentation::NonSealedSurfaceFrameworkRepresentation
 	}
 
 	// proxy constructor
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORENonSealedSurfaceFrameworkRepresentation(interp->getGsoapContext(), 1);	
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORENonSealedSurfaceFrameworkRepresentation(interp->getGsoapContext());	
 	_resqml20__NonSealedSurfaceFrameworkRepresentation* orgRep = static_cast<_resqml20__NonSealedSurfaceFrameworkRepresentation*>(gsoapProxy2_0_1);
 
 	orgRep->IsHomogeneous = true;
-	orgRep->RepresentedInterpretation = soap_new_eml20__DataObjectReference(gsoapProxy2_0_1->soap, 1);
+	orgRep->RepresentedInterpretation = soap_new_eml20__DataObjectReference(gsoapProxy2_0_1->soap);
     orgRep->RepresentedInterpretation->UUID.assign(interp->getUuid());
 
 	initMandatoryMetadata();
@@ -75,15 +75,15 @@ void NonSealedSurfaceFrameworkRepresentation::pushBackNonSealedContactRepresenta
 
 	_resqml20__NonSealedSurfaceFrameworkRepresentation* orgRep = static_cast<_resqml20__NonSealedSurfaceFrameworkRepresentation*>(gsoapProxy2_0_1);
 
-	resqml20__NonSealedContactRepresentationPart* contactRep = soap_new_resqml20__NonSealedContactRepresentationPart(gsoapProxy2_0_1->soap, 1);
+	resqml20__NonSealedContactRepresentationPart* contactRep = soap_new_resqml20__NonSealedContactRepresentationPart(gsoapProxy2_0_1->soap);
 	contactRep->Index = orgRep->NonSealedContactRepresentation.size();
 	orgRep->NonSealedContactRepresentation.push_back(contactRep);
-	resqml20__PointGeometry* contactGeom = soap_new_resqml20__PointGeometry(gsoapProxy2_0_1->soap, 1);
+	resqml20__PointGeometry* contactGeom = soap_new_resqml20__PointGeometry(gsoapProxy2_0_1->soap);
 	contactRep->Geometry = contactGeom;
 	contactGeom->LocalCrs = localCrs->newResqmlReference();
-	resqml20__Point3dHdf5Array* contactGeomPoints = soap_new_resqml20__Point3dHdf5Array(gsoapProxy2_0_1->soap, 1);
+	resqml20__Point3dHdf5Array* contactGeomPoints = soap_new_resqml20__Point3dHdf5Array(gsoapProxy2_0_1->soap);
 	contactGeom->Points = contactGeomPoints;
-	contactGeomPoints->Coordinates = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	contactGeomPoints->Coordinates = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	contactGeomPoints->Coordinates->HdfProxy = proxy->newResqmlReference();
 	ostringstream oss;
 	oss << "points_contact_representation" << orgRep->NonSealedContactRepresentation.size()-1;

--- a/src/resqml2_0_1/OrganizationFeature.cpp
+++ b/src/resqml2_0_1/OrganizationFeature.cpp
@@ -32,7 +32,7 @@ OrganizationFeature::OrganizationFeature(COMMON_NS::DataObjectRepository * repo,
 		throw invalid_argument("The repo cannot be null.");
 	}
 
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREOrganizationFeature(repo->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREOrganizationFeature(repo->getGsoapContext());
 	static_cast<_resqml20__OrganizationFeature*>(gsoapProxy2_0_1)->OrganizationKind = orgType;
 
 	initMandatoryMetadata();

--- a/src/resqml2_0_1/PlaneSetRepresentation.cpp
+++ b/src/resqml2_0_1/PlaneSetRepresentation.cpp
@@ -39,7 +39,7 @@ PlaneSetRepresentation::PlaneSetRepresentation(RESQML2_NS::AbstractFeatureInterp
 		throw invalid_argument("You must provide an interpretation");
 	}
 
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREPlaneSetRepresentation(interp->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREPlaneSetRepresentation(interp->getGsoapContext());
 
 	initMandatoryMetadata();
 	setMetadata(guid, title, "", -1, "", "", -1, "");
@@ -65,7 +65,7 @@ void PlaneSetRepresentation::pushBackHorizontalPlaneGeometryPatch(double zCoordi
 		localCrs = getRepository()->getDefaultCrs();
 	}
 
-	resqml20__HorizontalPlaneGeometry* patch = soap_new_resqml20__HorizontalPlaneGeometry(gsoapProxy2_0_1->soap, 1);
+	resqml20__HorizontalPlaneGeometry* patch = soap_new_resqml20__HorizontalPlaneGeometry(gsoapProxy2_0_1->soap);
 	patch->LocalCrs = localCrs->newResqmlReference();
 	patch->Coordinate = zCoordinate;
 
@@ -84,7 +84,7 @@ void PlaneSetRepresentation::pushBackTiltedPlaneGeometryPatch(
 		localCrs = getRepository()->getDefaultCrs();
 	}
 
-	resqml20__TiltedPlaneGeometry* patch = soap_new_resqml20__TiltedPlaneGeometry(gsoapProxy2_0_1->soap, 1);
+	resqml20__TiltedPlaneGeometry* patch = soap_new_resqml20__TiltedPlaneGeometry(gsoapProxy2_0_1->soap);
 	patch->LocalCrs = localCrs->newResqmlReference();
 
 	patch->Plane.push_back(soap_new_resqml20__ThreePoint3d(gsoapProxy2_0_1->soap, 1));

--- a/src/resqml2_0_1/PointSetRepresentation.cpp
+++ b/src/resqml2_0_1/PointSetRepresentation.cpp
@@ -39,7 +39,7 @@ PointSetRepresentation::PointSetRepresentation(RESQML2_NS::AbstractFeatureInterp
 		throw invalid_argument("You must provide an interpretation");
 	}
 
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREPointSetRepresentation(interp->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREPointSetRepresentation(interp->getGsoapContext());
 
 	initMandatoryMetadata();
 	setMetadata(guid, title, "", -1, "", "", -1, "");
@@ -51,7 +51,7 @@ void PointSetRepresentation::pushBackGeometryPatch(
 	unsigned int xyzPointCount, double * xyzPoints,
 	COMMON_NS::AbstractHdfProxy * proxy, RESQML2_NS::AbstractLocal3dCrs * localCrs)
 {
-	resqml20__NodePatch* patch = soap_new_resqml20__NodePatch(gsoapProxy2_0_1->soap, 1);
+	resqml20__NodePatch* patch = soap_new_resqml20__NodePatch(gsoapProxy2_0_1->soap);
 	patch->PatchIndex = static_cast<_resqml20__PointSetRepresentation*>(gsoapProxy2_0_1)->NodePatch.size();
 	patch->Count = xyzPointCount;
 

--- a/src/resqml2_0_1/PolylineRepresentation.cpp
+++ b/src/resqml2_0_1/PolylineRepresentation.cpp
@@ -36,7 +36,7 @@ const char* PolylineRepresentation::XML_TAG = "PolylineRepresentation";
 
 void PolylineRepresentation::init(COMMON_NS::DataObjectRepository * repo, const std::string & guid, const std::string & title, bool isClosed)
 {
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREPolylineRepresentation(repo->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREPolylineRepresentation(repo->getGsoapContext());
 	_resqml20__PolylineRepresentation* polylineRep = static_cast<_resqml20__PolylineRepresentation*>(gsoapProxy2_0_1);
 
 	polylineRep->IsClosed = isClosed;
@@ -117,7 +117,7 @@ void PolylineRepresentation::getXyzPointsOfPatch(const unsigned int & patchIndex
 void PolylineRepresentation::setGeometry(double * points, unsigned int pointCount, COMMON_NS::AbstractHdfProxy * proxy, RESQML2_NS::AbstractLocal3dCrs* localCrs)
 {
 	_resqml20__PolylineRepresentation* polylineRep = static_cast<_resqml20__PolylineRepresentation*>(gsoapProxy2_0_1);
-	polylineRep->NodePatch = soap_new_resqml20__NodePatch(gsoapProxy2_0_1->soap, 1);
+	polylineRep->NodePatch = soap_new_resqml20__NodePatch(gsoapProxy2_0_1->soap);
 	polylineRep->NodePatch->Count = pointCount;
 	polylineRep->NodePatch->PatchIndex = 0;
 

--- a/src/resqml2_0_1/PolylineSetRepresentation.cpp
+++ b/src/resqml2_0_1/PolylineSetRepresentation.cpp
@@ -37,7 +37,7 @@ const char* PolylineSetRepresentation::XML_TAG = "PolylineSetRepresentation";
 void PolylineSetRepresentation::init(COMMON_NS::DataObjectRepository * repo,
 									 const std::string & guid, const std::string & title)
 {
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREPolylineSetRepresentation(repo->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREPolylineSetRepresentation(repo->getGsoapContext());
 
 	initMandatoryMetadata();
 	setMetadata(guid, title, std::string(), -1, std::string(), std::string(), -1, std::string());
@@ -80,7 +80,7 @@ void PolylineSetRepresentation::pushBackGeometryPatch(
 				unsigned int polylineCount, bool allPolylinesClosedFlag,
 				COMMON_NS::AbstractHdfProxy * proxy, RESQML2_NS::AbstractLocal3dCrs* localCrs)
 {
-	resqml20__PolylineSetPatch* patch = soap_new_resqml20__PolylineSetPatch(gsoapProxy2_0_1->soap, 1);
+	resqml20__PolylineSetPatch* patch = soap_new_resqml20__PolylineSetPatch(gsoapProxy2_0_1->soap);
 	patch->PatchIndex = static_cast<_resqml20__PolylineSetRepresentation*>(gsoapProxy2_0_1)->LinePatch.size();
 
 	if (proxy == nullptr) {
@@ -89,9 +89,9 @@ void PolylineSetRepresentation::pushBackGeometryPatch(
 	getRepository()->addRelationship(this, proxy);
 
 	// node count
-	resqml20__IntegerHdf5Array* xmlNodeCountPerPolyline = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap, 1);
+	resqml20__IntegerHdf5Array* xmlNodeCountPerPolyline = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap);
 	xmlNodeCountPerPolyline->NullValue = (std::numeric_limits<int>::max)();
-	xmlNodeCountPerPolyline->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	xmlNodeCountPerPolyline->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	xmlNodeCountPerPolyline->Values->HdfProxy = proxy->newResqmlReference();
 	ostringstream ossForHdf;
 	ossForHdf << "NodeCountPerPolyline_patch" << patch->PatchIndex;
@@ -105,7 +105,7 @@ void PolylineSetRepresentation::pushBackGeometryPatch(
 		&dim, 1);
 
 	// closed polylines
-	resqml20__BooleanConstantArray* xmlClosedPolylines = soap_new_resqml20__BooleanConstantArray(gsoapProxy2_0_1->soap, 1);
+	resqml20__BooleanConstantArray* xmlClosedPolylines = soap_new_resqml20__BooleanConstantArray(gsoapProxy2_0_1->soap);
 	xmlClosedPolylines->Count = polylineCount;
 	xmlClosedPolylines->Value = allPolylinesClosedFlag;
 	patch->ClosedPolylines = xmlClosedPolylines;
@@ -129,7 +129,7 @@ void PolylineSetRepresentation::pushBackGeometryPatch(
 				unsigned int polylineCount, bool * polylineClosedFlags,
 				COMMON_NS::AbstractHdfProxy * proxy, RESQML2_NS::AbstractLocal3dCrs* localCrs)
 {
-	resqml20__PolylineSetPatch* patch = soap_new_resqml20__PolylineSetPatch(gsoapProxy2_0_1->soap, 1);
+	resqml20__PolylineSetPatch* patch = soap_new_resqml20__PolylineSetPatch(gsoapProxy2_0_1->soap);
 	patch->PatchIndex = static_cast<_resqml20__PolylineSetRepresentation*>(gsoapProxy2_0_1)->LinePatch.size();
 
 	if (proxy == nullptr) {
@@ -138,9 +138,9 @@ void PolylineSetRepresentation::pushBackGeometryPatch(
 	getRepository()->addRelationship(this, proxy);
 
 	// node count
-	resqml20__IntegerHdf5Array* xmlNodeCountPerPolyline = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap, 1);
+	resqml20__IntegerHdf5Array* xmlNodeCountPerPolyline = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap);
 	xmlNodeCountPerPolyline->NullValue = (std::numeric_limits<int>::max)();
-	xmlNodeCountPerPolyline->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	xmlNodeCountPerPolyline->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	xmlNodeCountPerPolyline->Values->HdfProxy = proxy->newResqmlReference();
 	ostringstream ossForHdf;
 	ossForHdf << "NodeCountPerPolyline_patch" << patch->PatchIndex;
@@ -154,8 +154,8 @@ void PolylineSetRepresentation::pushBackGeometryPatch(
 		&dim, 1);
 
 	// closed polylines
-	resqml20__BooleanHdf5Array* xmlClosedPolylines = soap_new_resqml20__BooleanHdf5Array(gsoapProxy2_0_1->soap, 1);
-	xmlClosedPolylines->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	resqml20__BooleanHdf5Array* xmlClosedPolylines = soap_new_resqml20__BooleanHdf5Array(gsoapProxy2_0_1->soap);
+	xmlClosedPolylines->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	xmlClosedPolylines->Values->HdfProxy = proxy->newResqmlReference();
 	ossForHdf.str("");
 	ossForHdf.clear();

--- a/src/resqml2_0_1/PropertyKind.cpp
+++ b/src/resqml2_0_1/PropertyKind.cpp
@@ -31,7 +31,7 @@ void PropertyKind::init(COMMON_NS::DataObjectRepository * repo, const std::strin
 	if (repo == nullptr)
 		throw invalid_argument("The repo cannot be null.");
 
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREPropertyKind(repo->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREPropertyKind(repo->getGsoapContext());
 	_resqml20__PropertyKind* propType = getSpecializedGsoapProxy();
 
 	propType->NamingSystem = namingSystem;
@@ -48,7 +48,7 @@ PropertyKind::PropertyKind(COMMON_NS::DataObjectRepository * repo, const string 
 	init(repo, guid, title, namingSystem);
 	static_cast<_resqml20__PropertyKind*>(gsoapProxy2_0_1)->RepresentativeUom = uom;
 
-	resqml20__StandardPropertyKind* xmlStandardPropKind = soap_new_resqml20__StandardPropertyKind(gsoapProxy2_0_1->soap, 1);
+	resqml20__StandardPropertyKind* xmlStandardPropKind = soap_new_resqml20__StandardPropertyKind(gsoapProxy2_0_1->soap);
 	xmlStandardPropKind->Kind = parentEnergisticsPropertyKind;
 	static_cast<_resqml20__PropertyKind*>(gsoapProxy2_0_1)->ParentPropertyKind = xmlStandardPropKind;
 }
@@ -69,7 +69,7 @@ PropertyKind::PropertyKind(COMMON_NS::DataObjectRepository * repo, const string 
 	static_cast<_resqml20__PropertyKind*>(gsoapProxy2_0_1)->RepresentativeUom = gsoap_resqml2_0_1::resqml20__ResqmlUom__Euc;
 	pushBackExtraMetadata("Uom", nonStandardUom);
 
-	resqml20__StandardPropertyKind* xmlStandardPropKind = soap_new_resqml20__StandardPropertyKind(gsoapProxy2_0_1->soap, 1);
+	resqml20__StandardPropertyKind* xmlStandardPropKind = soap_new_resqml20__StandardPropertyKind(gsoapProxy2_0_1->soap);
 	xmlStandardPropKind->Kind = parentEnergisticsPropertyKind;
 	static_cast<_resqml20__PropertyKind*>(gsoapProxy2_0_1)->ParentPropertyKind = xmlStandardPropKind;
 }
@@ -97,7 +97,7 @@ void PropertyKind::setXmlParentPropertyKind(RESQML2_NS::PropertyKind* parentProp
 {
 	_resqml20__PropertyKind* propType = getSpecializedGsoapProxy();
 
-	resqml20__LocalPropertyKind* xmlLocalPropKind = soap_new_resqml20__LocalPropertyKind(gsoapProxy2_0_1->soap, 1);
+	resqml20__LocalPropertyKind* xmlLocalPropKind = soap_new_resqml20__LocalPropertyKind(gsoapProxy2_0_1->soap);
 	xmlLocalPropKind->LocalPropertyKind = parentPropertyKind->newResqmlReference();
 	propType->ParentPropertyKind = xmlLocalPropKind;
 }

--- a/src/resqml2_0_1/PropertyKindMapper.cpp
+++ b/src/resqml2_0_1/PropertyKindMapper.cpp
@@ -64,7 +64,7 @@ string PropertyKindMapper::loadMappingFilesFromDirectory(const string & director
 
 					if ( file ) {
 						dataObjRepo->getGsoapContext()->is = &file;
-						gsoap_resqml2_0_1::_ptm__standardEnergisticsPropertyTypeSet* read = gsoap_resqml2_0_1::soap_new_ptm__standardEnergisticsPropertyTypeSet(dataObjRepo->getGsoapContext(), 1);
+						gsoap_resqml2_0_1::_ptm__standardEnergisticsPropertyTypeSet* read = gsoap_resqml2_0_1::soap_new_ptm__standardEnergisticsPropertyTypeSet(dataObjRepo->getGsoapContext());
 						soap_read_ptm__standardEnergisticsPropertyTypeSet(dataObjRepo->getGsoapContext(), read);
 						file.close();
 
@@ -94,7 +94,7 @@ string PropertyKindMapper::loadMappingFilesFromDirectory(const string & director
 
 					if ( file ) {
 						dataObjRepo->getGsoapContext()->is = &file;
-						gsoap_resqml2_0_1::_resqml20__PropertyKind* read = gsoap_resqml2_0_1::soap_new_resqml20__obj_USCOREPropertyKind(dataObjRepo->getGsoapContext(), 1);
+						gsoap_resqml2_0_1::_resqml20__PropertyKind* read = gsoap_resqml2_0_1::soap_new_resqml20__obj_USCOREPropertyKind(dataObjRepo->getGsoapContext());
 						soap_read_resqml20__obj_USCOREPropertyKind(dataObjRepo->getGsoapContext(), read);
 						file.close();
 

--- a/src/resqml2_0_1/PropertySet.cpp
+++ b/src/resqml2_0_1/PropertySet.cpp
@@ -32,7 +32,7 @@ PropertySet::PropertySet(COMMON_NS::DataObjectRepository* repo, const std::strin
 	}
 
 	// proxy constructor
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREPropertySet(repo->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREPropertySet(repo->getGsoapContext());
 	static_cast<_resqml20__PropertySet*>(gsoapProxy2_0_1)->HasMultipleRealizations = hasMultipleRealizations;
 	static_cast<_resqml20__PropertySet*>(gsoapProxy2_0_1)->HasSinglePropertyKind = hasSinglePropertyKind;
 	static_cast<_resqml20__PropertySet*>(gsoapProxy2_0_1)->TimeSetKind = timeSetKind;

--- a/src/resqml2_0_1/RepresentationSetRepresentation.cpp
+++ b/src/resqml2_0_1/RepresentationSetRepresentation.cpp
@@ -31,7 +31,7 @@ RepresentationSetRepresentation::RepresentationSetRepresentation(RESQML2_NS::Abs
 	}
 
 	// proxy constructor
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORERepresentationSetRepresentation(interp->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORERepresentationSetRepresentation(interp->getGsoapContext());
 	static_cast<_resqml20__RepresentationSetRepresentation*>(gsoapProxy2_0_1)->IsHomogeneous = true;
 
 	initMandatoryMetadata();
@@ -48,7 +48,7 @@ RepresentationSetRepresentation::RepresentationSetRepresentation(COMMON_NS::Data
 	}
 
 	// proxy constructor
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORERepresentationSetRepresentation(repo->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORERepresentationSetRepresentation(repo->getGsoapContext());
 	static_cast<_resqml20__RepresentationSetRepresentation*>(gsoapProxy2_0_1)->IsHomogeneous = true;
 
 	initMandatoryMetadata();

--- a/src/resqml2_0_1/RockFluidOrganizationInterpretation.cpp
+++ b/src/resqml2_0_1/RockFluidOrganizationInterpretation.cpp
@@ -41,9 +41,9 @@ RockFluidOrganizationInterpretation::RockFluidOrganizationInterpretation(Organiz
 		throw invalid_argument("The kind of the organization feature is not a fluid organization.");
 	}
 
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORERockFluidOrganizationInterpretation(orgFeat->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORERockFluidOrganizationInterpretation(orgFeat->getGsoapContext());
 	_resqml20__RockFluidOrganizationInterpretation* rfoi = static_cast<_resqml20__RockFluidOrganizationInterpretation*>(gsoapProxy2_0_1);
-	rfoi->RockFluidUnitIndex = soap_new_resqml20__RockFluidUnitInterpretationIndex(orgFeat->getGsoapContext(), 1);
+	rfoi->RockFluidUnitIndex = soap_new_resqml20__RockFluidUnitInterpretationIndex(orgFeat->getGsoapContext());
 	// No need to initialize index since it is a bug : http://docs.energistics.org/#RESQML/RESQML_TOPICS/RESQML-500-106-0-R-sv2010.html
 	pushBackRockFluidUnitInterpretation(rockFluidUnitInterp);
 

--- a/src/resqml2_0_1/RockFluidUnitFeature.cpp
+++ b/src/resqml2_0_1/RockFluidUnitFeature.cpp
@@ -31,7 +31,7 @@ RockFluidUnitFeature::RockFluidUnitFeature(COMMON_NS::DataObjectRepository* repo
 	if (repo == nullptr)
 		throw invalid_argument("The repo cannot be null.");
 
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORERockFluidUnitFeature(repo->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORERockFluidUnitFeature(repo->getGsoapContext());
 	_resqml20__RockFluidUnitFeature* rfuf = static_cast<_resqml20__RockFluidUnitFeature*>(gsoapProxy2_0_1);
 	rfuf->Phase = phase;
 

--- a/src/resqml2_0_1/RockFluidUnitInterpretation.cpp
+++ b/src/resqml2_0_1/RockFluidUnitInterpretation.cpp
@@ -31,7 +31,7 @@ RockFluidUnitInterpretation::RockFluidUnitInterpretation(RockFluidUnitFeature * 
 		throw invalid_argument("The interpreted feature cannot be null.");
 	}
 
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORERockFluidUnitInterpretation(feature->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORERockFluidUnitInterpretation(feature->getGsoapContext());
 	//static_cast<_resqml20__RockFluidUnitInterpretation*>(gsoapProxy2_0_1)->Phase = ??;
 
 	initMandatoryMetadata();

--- a/src/resqml2_0_1/SealedSurfaceFrameworkRepresentation.cpp
+++ b/src/resqml2_0_1/SealedSurfaceFrameworkRepresentation.cpp
@@ -42,11 +42,11 @@ SealedSurfaceFrameworkRepresentation::SealedSurfaceFrameworkRepresentation(
 	}
 
     // proxy constructor
-    gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORESealedSurfaceFrameworkRepresentation(interp->getGsoapContext(), 1);
+    gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORESealedSurfaceFrameworkRepresentation(interp->getGsoapContext());
     _resqml20__SealedSurfaceFrameworkRepresentation* orgRep = static_cast<_resqml20__SealedSurfaceFrameworkRepresentation*>(gsoapProxy2_0_1);
 
 	orgRep->IsHomogeneous = true;
-    orgRep->RepresentedInterpretation = soap_new_eml20__DataObjectReference(gsoapProxy2_0_1->soap, 1);
+    orgRep->RepresentedInterpretation = soap_new_eml20__DataObjectReference(gsoapProxy2_0_1->soap);
     orgRep->RepresentedInterpretation->UUID.assign(interp->getUuid());
 
     initMandatoryMetadata();
@@ -59,7 +59,7 @@ void SealedSurfaceFrameworkRepresentation::pushBackContact(gsoap_resqml2_0_1::re
 {
     _resqml20__SealedSurfaceFrameworkRepresentation* orgRep = static_cast<_resqml20__SealedSurfaceFrameworkRepresentation*>(gsoapProxy2_0_1);
 
-    resqml20__SealedContactRepresentationPart* contactRep = soap_new_resqml20__SealedContactRepresentationPart(gsoapProxy2_0_1->soap, 1);
+    resqml20__SealedContactRepresentationPart* contactRep = soap_new_resqml20__SealedContactRepresentationPart(gsoapProxy2_0_1->soap);
     contactRep->Index = orgRep->SealedContactRepresentation.size();
     contactRep->IdentityKind = kind;
     orgRep->SealedContactRepresentation.push_back(contactRep);
@@ -90,9 +90,9 @@ void SealedSurfaceFrameworkRepresentation::pushBackContact(
 	pushBackContact(kind);
 	resqml20__SealedContactRepresentationPart* contactRep = static_cast<_resqml20__SealedSurfaceFrameworkRepresentation*>(gsoapProxy2_0_1)->SealedContactRepresentation.back();
 
-    resqml20__IntegerHdf5Array * xmlListOfIdenticalNodes = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap, 1);
+    resqml20__IntegerHdf5Array * xmlListOfIdenticalNodes = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap);
     xmlListOfIdenticalNodes->NullValue = (std::numeric_limits<int>::max)();
-    xmlListOfIdenticalNodes->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+    xmlListOfIdenticalNodes->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
     xmlListOfIdenticalNodes->Values->HdfProxy = proxy->newResqmlReference();
     ostringstream ossForHdf;
     ossForHdf << "listOfIdenticalNodes_contact" << contactRep->Index;
@@ -148,14 +148,14 @@ void SealedSurfaceFrameworkRepresentation::pushBackContactPatch(
 		throw invalid_argument("The supporting representation is not referenced by the sealed surface framework");
 	}
 
-    resqml20__ContactPatch* contactPatch = soap_new_resqml20__ContactPatch(gsoapProxy2_0_1->soap, 1);
+    resqml20__ContactPatch* contactPatch = soap_new_resqml20__ContactPatch(gsoapProxy2_0_1->soap);
     contactPatch->PatchIndex = contactRep->Contact.size();
     contactPatch->Count = nodeCount;
     contactPatch->RepresentationIndex = representationIndex;
 
-    resqml20__IntegerHdf5Array* xmlSupportingRepresentationNodes = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap, 1);
+    resqml20__IntegerHdf5Array* xmlSupportingRepresentationNodes = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap);
     xmlSupportingRepresentationNodes->NullValue = (std::numeric_limits<int>::max)();
-    xmlSupportingRepresentationNodes->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+    xmlSupportingRepresentationNodes->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
     xmlSupportingRepresentationNodes->Values->HdfProxy = proxy->newResqmlReference();
     ostringstream ossForHdf;
     ossForHdf << "SupportingRepresentationNodes_contact" << contactIndex << "_patch" << contactPatch->PatchIndex;

--- a/src/resqml2_0_1/SealedVolumeFrameworkRepresentation.cpp
+++ b/src/resqml2_0_1/SealedVolumeFrameworkRepresentation.cpp
@@ -41,7 +41,7 @@ SealedVolumeFrameworkRepresentation::SealedVolumeFrameworkRepresentation(Stratig
 	}
 
 	// proxy constructor
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORESealedVolumeFrameworkRepresentation(interp->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORESealedVolumeFrameworkRepresentation(interp->getGsoapContext());
 	_resqml20__SealedVolumeFrameworkRepresentation* orgRep = static_cast<_resqml20__SealedVolumeFrameworkRepresentation*>(gsoapProxy2_0_1);
 
 	orgRep->IsHomogeneous = true;
@@ -53,11 +53,11 @@ SealedVolumeFrameworkRepresentation::SealedVolumeFrameworkRepresentation(Stratig
 	setSealedSurfaceFramework(ssf);
 
 	// Create a dummy shell as an official workaround (see note in http://docs.energistics.org/RESQML/RESQML_TOPICS/RESQML-500-269-0-R-sv2010.html)
-	resqml20__VolumeShell* dummyShell = soap_new_resqml20__VolumeShell(gsoapProxy2_0_1->soap, 1);
+	resqml20__VolumeShell* dummyShell = soap_new_resqml20__VolumeShell(gsoapProxy2_0_1->soap);
 	dummyShell->ShellUid = "dummy uid";
 	orgRep->Shells.push_back(dummyShell);
 
-	resqml20__OrientedMacroFace* face = soap_new_resqml20__OrientedMacroFace(gsoapProxy2_0_1->soap, 1);
+	resqml20__OrientedMacroFace* face = soap_new_resqml20__OrientedMacroFace(gsoapProxy2_0_1->soap);
 	face->RepresentationIndex = (std::numeric_limits<int>::max)();
 	face->PatchIndexOfRepresentation = (std::numeric_limits<int>::max)();
 	dummyShell->MacroFaces.push_back(face);
@@ -122,12 +122,12 @@ gsoap_resqml2_0_1::resqml20__VolumeShell* SealedVolumeFrameworkRepresentation::c
 		throw invalid_argument("Cannot create a shell with has got a face count of zero.");
 	}
 
-	resqml20__VolumeShell* externalShell = soap_new_resqml20__VolumeShell(gsoapProxy2_0_1->soap, 1);
+	resqml20__VolumeShell* externalShell = soap_new_resqml20__VolumeShell(gsoapProxy2_0_1->soap);
 	externalShell->ShellUid = "dummy uid";
 
 	// Faces
 	for (unsigned int faceIdx = 0; faceIdx < shellFaceCount; ++faceIdx) {
-		resqml20__OrientedMacroFace* face = soap_new_resqml20__OrientedMacroFace(gsoapProxy2_0_1->soap, 1);
+		resqml20__OrientedMacroFace* face = soap_new_resqml20__OrientedMacroFace(gsoapProxy2_0_1->soap);
 		face->RepresentationIndex = faceRepresentationIndices[faceIdx];
 		face->PatchIndexOfRepresentation = faceRepPatchIndices[faceIdx];
 		face->SideIsPlus = faceSide[faceIdx];
@@ -142,7 +142,7 @@ void SealedVolumeFrameworkRepresentation::pushBackVolumeRegion(StratigraphicUnit
 	unsigned int * faceRepresentationIndices, unsigned int * faceRepPatchIndices, bool * faceSide)
 {
 	// Region
-	resqml20__VolumeRegion* region = soap_new_resqml20__VolumeRegion(gsoapProxy2_0_1->soap, 1);
+	resqml20__VolumeRegion* region = soap_new_resqml20__VolumeRegion(gsoapProxy2_0_1->soap);
 	region->PatchIndex = static_cast<_resqml20__SealedVolumeFrameworkRepresentation*>(gsoapProxy2_0_1)->Regions.size();
 	static_cast<_resqml20__SealedVolumeFrameworkRepresentation*>(gsoapProxy2_0_1)->Regions.push_back(region);
 	setInterpretationOfVolumeRegion(region->PatchIndex, stratiUnitInterp);

--- a/src/resqml2_0_1/SeismicLatticeFeature.cpp
+++ b/src/resqml2_0_1/SeismicLatticeFeature.cpp
@@ -32,7 +32,7 @@ SeismicLatticeFeature::SeismicLatticeFeature(COMMON_NS::DataObjectRepository* re
 	if (repo == nullptr)
 		throw invalid_argument("The repo cannot be null.");
 
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORESeismicLatticeFeature(repo->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORESeismicLatticeFeature(repo->getGsoapContext());
 	_resqml20__SeismicLatticeFeature* seismicLattice = static_cast<_resqml20__SeismicLatticeFeature*>(gsoapProxy2_0_1);
 
 	seismicLattice->InlineIndexIncrement = inlineIncrement;

--- a/src/resqml2_0_1/SeismicLineFeature.cpp
+++ b/src/resqml2_0_1/SeismicLineFeature.cpp
@@ -33,7 +33,7 @@ SeismicLineFeature::SeismicLineFeature(COMMON_NS::DataObjectRepository* repo, co
 		throw invalid_argument("The soap context cannot be null.");
 	}
 
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORESeismicLineFeature(repo->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORESeismicLineFeature(repo->getGsoapContext());
 	_resqml20__SeismicLineFeature* seismicLine = static_cast<_resqml20__SeismicLineFeature*>(gsoapProxy2_0_1);
 
 	seismicLine->TraceIndexIncrement = traceIndexIncrement;

--- a/src/resqml2_0_1/SeismicLineSetFeature.cpp
+++ b/src/resqml2_0_1/SeismicLineSetFeature.cpp
@@ -31,7 +31,7 @@ SeismicLineSetFeature::SeismicLineSetFeature(COMMON_NS::DataObjectRepository* re
 	if (repo == nullptr)
 		throw invalid_argument("The repo cannot be null.");
 
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORESeismicLineSetFeature(repo->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORESeismicLineSetFeature(repo->getGsoapContext());
 
 	initMandatoryMetadata();
 	setMetadata(guid, title, std::string(), -1, std::string(), std::string(), -1, std::string());

--- a/src/resqml2_0_1/StratigraphicColumn.cpp
+++ b/src/resqml2_0_1/StratigraphicColumn.cpp
@@ -32,7 +32,7 @@ StratigraphicColumn::StratigraphicColumn(COMMON_NS::DataObjectRepository* repo, 
 		throw invalid_argument("The repo cannot be null.");
 	}
 
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREStratigraphicColumn(repo->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREStratigraphicColumn(repo->getGsoapContext());
 
 	initMandatoryMetadata();
 	setMetadata(guid, title, std::string(), -1, std::string(), std::string(), -1, std::string());

--- a/src/resqml2_0_1/StratigraphicColumnRankInterpretation.cpp
+++ b/src/resqml2_0_1/StratigraphicColumnRankInterpretation.cpp
@@ -39,7 +39,7 @@ StratigraphicColumnRankInterpretation::StratigraphicColumnRankInterpretation(Org
 		throw invalid_argument("The kind of an organization feature linked to a stratigraphic column rank interpretation must be a stratigraphic one.");
 	}
 
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREStratigraphicColumnRankInterpretation(orgFeat->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREStratigraphicColumnRankInterpretation(orgFeat->getGsoapContext());
 	static_cast<_resqml20__StratigraphicColumnRankInterpretation*>(gsoapProxy2_0_1)->Domain = resqml20__Domain__mixed;
 	static_cast<_resqml20__StratigraphicColumnRankInterpretation*>(gsoapProxy2_0_1)->Index = rank;
 	static_cast<_resqml20__StratigraphicColumnRankInterpretation*>(gsoapProxy2_0_1)->OrderingCriteria = orderingCriteria;
@@ -55,7 +55,7 @@ void StratigraphicColumnRankInterpretation::pushBackStratiUnitInterpretation(Str
 	getRepository()->addRelationship(this, stratiUnitInterpretation);
 
     _resqml20__StratigraphicColumnRankInterpretation* stratigraphicColumnRankInterpretation = static_cast<_resqml20__StratigraphicColumnRankInterpretation*>(gsoapProxy2_0_1); 
-	resqml20__StratigraphicUnitInterpretationIndex* stratiUnitInterpRef = soap_new_resqml20__StratigraphicUnitInterpretationIndex(gsoapProxy2_0_1->soap, 1);
+	resqml20__StratigraphicUnitInterpretationIndex* stratiUnitInterpRef = soap_new_resqml20__StratigraphicUnitInterpretationIndex(gsoapProxy2_0_1->soap);
 	stratiUnitInterpRef->Index = stratigraphicColumnRankInterpretation->StratigraphicUnits.size();
 	stratiUnitInterpRef->Unit = stratiUnitInterpretation->newResqmlReference();
 	stratigraphicColumnRankInterpretation->StratigraphicUnits.push_back(stratiUnitInterpRef);

--- a/src/resqml2_0_1/StratigraphicOccurrenceInterpretation.cpp
+++ b/src/resqml2_0_1/StratigraphicOccurrenceInterpretation.cpp
@@ -38,7 +38,7 @@ StratigraphicOccurrenceInterpretation::StratigraphicOccurrenceInterpretation(Org
 		throw invalid_argument("The kind of an organization feature linked to a stratigraphic occurrence interpretation must be a stratigraphic one.");
 	}
 
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREStratigraphicOccurrenceInterpretation(orgFeat->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREStratigraphicOccurrenceInterpretation(orgFeat->getGsoapContext());
 	static_cast<_resqml20__StratigraphicOccurrenceInterpretation*>(gsoapProxy2_0_1)->Domain = resqml20__Domain__mixed;
 	static_cast<_resqml20__StratigraphicOccurrenceInterpretation*>(gsoapProxy2_0_1)->OrderingCriteria = orderingCriteria;
 

--- a/src/resqml2_0_1/StratigraphicUnitFeature.cpp
+++ b/src/resqml2_0_1/StratigraphicUnitFeature.cpp
@@ -29,7 +29,7 @@ StratigraphicUnitFeature::StratigraphicUnitFeature(COMMON_NS::DataObjectReposito
 	if (repo == nullptr)
 		throw invalid_argument("The repo cannot be null.");
 
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREStratigraphicUnitFeature(repo->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREStratigraphicUnitFeature(repo->getGsoapContext());
 
 	initMandatoryMetadata();
 	setMetadata(guid, title, std::string(), -1, std::string(), std::string(), -1, std::string());

--- a/src/resqml2_0_1/StratigraphicUnitInterpretation.cpp
+++ b/src/resqml2_0_1/StratigraphicUnitInterpretation.cpp
@@ -36,7 +36,7 @@ StratigraphicUnitInterpretation::StratigraphicUnitInterpretation(StratigraphicUn
 		throw invalid_argument("The interpreted feature cannot be null.");
 	}
 
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREStratigraphicUnitInterpretation(feature->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREStratigraphicUnitInterpretation(feature->getGsoapContext());
 	static_cast<_resqml20__StratigraphicUnitInterpretation*>(gsoapProxy2_0_1)->Domain = resqml20__Domain__mixed;
 
 	initMandatoryMetadata();

--- a/src/resqml2_0_1/StringTableLookup.cpp
+++ b/src/resqml2_0_1/StringTableLookup.cpp
@@ -33,7 +33,7 @@ StringTableLookup::StringTableLookup(COMMON_NS::DataObjectRepository* repo, cons
 	if (repo == nullptr)
 		throw invalid_argument("The repo cannot be null.");
 
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREStringTableLookup(repo->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREStringTableLookup(repo->getGsoapContext());
 
 	initMandatoryMetadata();
 	setMetadata(guid, title, std::string(), -1, std::string(), std::string(), -1, std::string());
@@ -96,7 +96,7 @@ void StringTableLookup::addValue(const string & strValue, const long & longValue
 {
 	_resqml20__StringTableLookup* stringLookup = static_cast<_resqml20__StringTableLookup*>(gsoapProxy2_0_1);
 
-	resqml20__StringLookup* xmlValue = soap_new_resqml20__StringLookup(gsoapProxy2_0_1->soap, 1);
+	resqml20__StringLookup* xmlValue = soap_new_resqml20__StringLookup(gsoapProxy2_0_1->soap);
 	xmlValue->Key = longValue;
 	xmlValue->Value = strValue;
 	stringLookup->Value.push_back(xmlValue);

--- a/src/resqml2_0_1/StructuralOrganizationInterpretation.cpp
+++ b/src/resqml2_0_1/StructuralOrganizationInterpretation.cpp
@@ -43,7 +43,7 @@ StructuralOrganizationInterpretation::StructuralOrganizationInterpretation(Organ
 		throw invalid_argument("The kind of the organization feature is not a structural organization.");
 	}
 
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREStructuralOrganizationInterpretation(orgFeat->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREStructuralOrganizationInterpretation(orgFeat->getGsoapContext());
 	
 	static_cast<_resqml20__StructuralOrganizationInterpretation*>(gsoapProxy2_0_1)->OrderingCriteria = orderingCriteria;
 	static_cast<_resqml20__StructuralOrganizationInterpretation*>(gsoapProxy2_0_1)->Domain = resqml20__Domain__mixed;
@@ -91,7 +91,7 @@ void StructuralOrganizationInterpretation::pushBackHorizonInterpretation(Horizon
 
 	_resqml20__StructuralOrganizationInterpretation* structuralOrganization = static_cast<_resqml20__StructuralOrganizationInterpretation*>(gsoapProxy2_0_1);
 
-	resqml20__HorizonInterpretationIndex* horizonInterpListElement = soap_new_resqml20__HorizonInterpretationIndex(gsoapProxy2_0_1->soap, 1);
+	resqml20__HorizonInterpretationIndex* horizonInterpListElement = soap_new_resqml20__HorizonInterpretationIndex(gsoapProxy2_0_1->soap);
 	horizonInterpListElement->StratigraphicRank = static_cast<ULONG64*>(soap_malloc(gsoapProxy2_0_1->soap, sizeof(ULONG64)));
 	*(horizonInterpListElement->StratigraphicRank) = stratigraphicRank;
 	horizonInterpListElement->Index = structuralOrganization->Horizons.size();

--- a/src/resqml2_0_1/SubRepresentation.cpp
+++ b/src/resqml2_0_1/SubRepresentation.cpp
@@ -35,7 +35,7 @@ using namespace gsoap_resqml2_0_1;
 
 void SubRepresentation::init(COMMON_NS::DataObjectRepository* repo, const string & guid, const string & title)
 {
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORESubRepresentation(repo->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORESubRepresentation(repo->getGsoapContext());
 
 	initMandatoryMetadata();
 	setMetadata(guid, title, std::string(), -1, std::string(), std::string(), -1, std::string());
@@ -77,31 +77,31 @@ void SubRepresentation::pushBackSubRepresentationPatch(const gsoap_resqml2_0_1::
 {
 	_resqml20__SubRepresentation* rep = getSpecializedGsoapProxy();
 
-	resqml20__SubRepresentationPatch* patch = soap_new_resqml20__SubRepresentationPatch(gsoapProxy2_0_1->soap, 1);
+	resqml20__SubRepresentationPatch* patch = soap_new_resqml20__SubRepresentationPatch(gsoapProxy2_0_1->soap);
 
 	// XML
 	patch->PatchIndex = rep->SubRepresentationPatch.size();
 	rep->SubRepresentationPatch.push_back(patch);
 	patch->Count = elementCountInSlowestDimension * elementCountInMiddleDimension * elementCountInFastestDimension;
-	resqml20__ElementIndices* elements = soap_new_resqml20__ElementIndices(gsoapProxy2_0_1->soap, 1);
+	resqml20__ElementIndices* elements = soap_new_resqml20__ElementIndices(gsoapProxy2_0_1->soap);
 	patch->ElementIndices.push_back(elements);
 	elements->IndexableElement = elementKind;
 
-	resqml20__IntegerLatticeArray * integerArray = soap_new_resqml20__IntegerLatticeArray(gsoapProxy2_0_1->soap, 1);
+	resqml20__IntegerLatticeArray * integerArray = soap_new_resqml20__IntegerLatticeArray(gsoapProxy2_0_1->soap);
 	elements->Indices = integerArray;
 	integerArray->StartValue = originIndex;
 
-	resqml20__IntegerConstantArray * offset = soap_new_resqml20__IntegerConstantArray(gsoapProxy2_0_1->soap, 1);
+	resqml20__IntegerConstantArray * offset = soap_new_resqml20__IntegerConstantArray(gsoapProxy2_0_1->soap);
 	offset->Count = elementCountInSlowestDimension - 1;
 	offset->Value = 1;
 	integerArray->Offset.push_back(offset);
 
-	offset = soap_new_resqml20__IntegerConstantArray(gsoapProxy2_0_1->soap, 1);
+	offset = soap_new_resqml20__IntegerConstantArray(gsoapProxy2_0_1->soap);
 	offset->Count = elementCountInMiddleDimension - 1;
 	offset->Value = 1;
 	integerArray->Offset.push_back(offset);
 
-	offset = soap_new_resqml20__IntegerConstantArray(gsoapProxy2_0_1->soap, 1);
+	offset = soap_new_resqml20__IntegerConstantArray(gsoapProxy2_0_1->soap);
 	offset->Count = elementCountInFastestDimension - 1;
 	offset->Value = 1;
 	integerArray->Offset.push_back(offset);
@@ -140,18 +140,18 @@ void SubRepresentation::pushBackRefToExistingDataset(const gsoap_resqml2_0_1::re
 	}
 	getRepository()->addRelationship(this, proxy);
 
-	resqml20__SubRepresentationPatch* patch = soap_new_resqml20__SubRepresentationPatch(gsoapProxy2_0_1->soap, 1);
+	resqml20__SubRepresentationPatch* patch = soap_new_resqml20__SubRepresentationPatch(gsoapProxy2_0_1->soap);
 
 	// XML
 	patch->PatchIndex = rep->SubRepresentationPatch.size();
 	rep->SubRepresentationPatch.push_back(patch);
 	patch->Count = elementCount;
-	resqml20__ElementIndices* elements = soap_new_resqml20__ElementIndices(gsoapProxy2_0_1->soap, 1);
+	resqml20__ElementIndices* elements = soap_new_resqml20__ElementIndices(gsoapProxy2_0_1->soap);
 	patch->ElementIndices.push_back(elements);
 	elements->IndexableElement = elementKind;
 
-	resqml20__IntegerHdf5Array * integerArray = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap, 1);
-	eml20__Hdf5Dataset * resqmlHDF5dataset = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	resqml20__IntegerHdf5Array * integerArray = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap);
+	eml20__Hdf5Dataset * resqmlHDF5dataset = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	resqmlHDF5dataset->HdfProxy = proxy->newResqmlReference();
 	if (elementDataset.empty()) {
 		ostringstream ossForHdf;
@@ -194,14 +194,14 @@ void SubRepresentation::pushBackSubRepresentationPatch(const gsoap_resqml2_0_1::
 	resqml20__SubRepresentationPatch* patch = rep->SubRepresentationPatch[rep->SubRepresentationPatch.size() - 1];
 
 	// XML
-	resqml20__ElementIndices* elements = soap_new_resqml20__ElementIndices(gsoapProxy2_0_1->soap, 1);
+	resqml20__ElementIndices* elements = soap_new_resqml20__ElementIndices(gsoapProxy2_0_1->soap);
 	patch->ElementIndices.push_back(elements);
 	elements->IndexableElement = elementKind1;
 
 	ostringstream ossForHdf;
 	ossForHdf << "subrepresentation_elementIndices1_patch" << patch->PatchIndex;
-	resqml20__IntegerHdf5Array * integerArray = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap, 1);
-	eml20__Hdf5Dataset * resqmlHDF5dataset = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	resqml20__IntegerHdf5Array * integerArray = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap);
+	eml20__Hdf5Dataset * resqmlHDF5dataset = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	resqmlHDF5dataset->HdfProxy = proxy->newResqmlReference();
 	resqmlHDF5dataset->PathInHdfFile = "/RESQML/" + rep->uuid + "/" + ossForHdf.str();
 	integerArray->Values = resqmlHDF5dataset;
@@ -411,7 +411,7 @@ gsoap_resqml2_0_1::eml20__DataObjectReference* SubRepresentation::getSupportingR
 		return getSpecializedGsoapProxy()->SupportingRepresentation;
 	}
 
-	eml20__DataObjectReference* result = soap_new_eml20__DataObjectReference(getGsoapContext(), 1);
+	eml20__DataObjectReference* result = soap_new_eml20__DataObjectReference(getGsoapContext());
 	result->ContentType = getSpecializedGsoapProxy()->SupportingRepresentation->ContentType;
 	result->Title = getSpecializedGsoapProxy()->SupportingRepresentation->Title;
 	result->UUID = getExtraMetadata("SupportingRepresentation")[index];

--- a/src/resqml2_0_1/TectonicBoundaryFeature.cpp
+++ b/src/resqml2_0_1/TectonicBoundaryFeature.cpp
@@ -30,7 +30,7 @@ TectonicBoundaryFeature::TectonicBoundaryFeature(COMMON_NS::DataObjectRepository
 		throw invalid_argument("The repo must exist");
 	}
 
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORETectonicBoundaryFeature(repo->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORETectonicBoundaryFeature(repo->getGsoapContext());
 	static_cast<gsoap_resqml2_0_1::_resqml20__TectonicBoundaryFeature*>(gsoapProxy2_0_1)->TectonicBoundaryKind = isAFracture ? gsoap_resqml2_0_1::resqml20__TectonicBoundaryKind__fracture : gsoap_resqml2_0_1::resqml20__TectonicBoundaryKind__fault;
 
 	initMandatoryMetadata();

--- a/src/resqml2_0_1/TimeSeries.cpp
+++ b/src/resqml2_0_1/TimeSeries.cpp
@@ -32,7 +32,7 @@ TimeSeries::TimeSeries(COMMON_NS::DataObjectRepository* repo, const string & gui
 		throw invalid_argument("The repo cannot be null.");
 	}
 
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORETimeSeries(repo->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORETimeSeries(repo->getGsoapContext());
 	
 	initMandatoryMetadata();
 	setMetadata(guid, title, std::string(), -1, std::string(), std::string(), -1, std::string());

--- a/src/resqml2_0_1/TriangulatedSetRepresentation.cpp
+++ b/src/resqml2_0_1/TriangulatedSetRepresentation.cpp
@@ -40,7 +40,7 @@ TriangulatedSetRepresentation::TriangulatedSetRepresentation(COMMON_NS::DataObje
 		throw invalid_argument("The repo cannot be null.");
 	}
 
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORETriangulatedSetRepresentation(repo->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORETriangulatedSetRepresentation(repo->getGsoapContext());
 
 	initMandatoryMetadata();
 	setMetadata(guid, title, std::string(), -1, std::string(), std::string(), -1, std::string());
@@ -55,7 +55,7 @@ TriangulatedSetRepresentation::TriangulatedSetRepresentation(RESQML2_NS::Abstrac
 		throw invalid_argument("The interpretation of the subrepresentation cannot be null.");
 	}
 
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORETriangulatedSetRepresentation(interp->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCORETriangulatedSetRepresentation(interp->getGsoapContext());
 
 	initMandatoryMetadata();
 	setMetadata(guid, title, std::string(), -1, std::string(), std::string(), -1, std::string());
@@ -92,7 +92,7 @@ void TriangulatedSetRepresentation::pushBackTrianglePatch(
 {
 	_resqml20__TriangulatedSetRepresentation* triRep = static_cast<_resqml20__TriangulatedSetRepresentation*>(gsoapProxy2_0_1);
 
-	resqml20__TrianglePatch* patch = soap_new_resqml20__TrianglePatch(gsoapProxy2_0_1->soap, 1);
+	resqml20__TrianglePatch* patch = soap_new_resqml20__TrianglePatch(gsoapProxy2_0_1->soap);
 	patch->PatchIndex = triRep->TrianglePatch.size();
 	triRep->TrianglePatch.push_back(patch);
 
@@ -111,10 +111,10 @@ void TriangulatedSetRepresentation::pushBackTrianglePatch(
 	getRepository()->addRelationship(this, proxy);
 
 	patch->Count = triangleCount;
-	resqml20__IntegerHdf5Array* hdfTriangles = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap, 1);
+	resqml20__IntegerHdf5Array* hdfTriangles = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap);
 	patch->Triangles = hdfTriangles;
 	hdfTriangles->NullValue = (std::numeric_limits<int>::max)();
-	hdfTriangles->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	hdfTriangles->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	hdfTriangles->Values->HdfProxy = proxy->newResqmlReference();
 	ostringstream ossForHdf;
 	ossForHdf << "triangles_patch" << patch->PatchIndex;

--- a/src/resqml2_0_1/UnstructuredGridRepresentation.cpp
+++ b/src/resqml2_0_1/UnstructuredGridRepresentation.cpp
@@ -42,7 +42,7 @@ void UnstructuredGridRepresentation::init(COMMON_NS::DataObjectRepository* repo,
 		throw invalid_argument("The repo cannot be null.");
 	}
 
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREUnstructuredGridRepresentation(repo->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREUnstructuredGridRepresentation(repo->getGsoapContext());
 	_resqml20__UnstructuredGridRepresentation* unstructuredGrid = getSpecializedGsoapProxy();
 
 	unstructuredGrid->CellCount = cellCount;
@@ -410,7 +410,7 @@ void UnstructuredGridRepresentation::setGeometryUsingExistingDatasets(const std:
 		localCrs = getRepository()->getDefaultCrs();
 	}
 
-	resqml20__UnstructuredGridGeometry* geom = soap_new_resqml20__UnstructuredGridGeometry(gsoapProxy2_0_1->soap, 1);
+	resqml20__UnstructuredGridGeometry* geom = soap_new_resqml20__UnstructuredGridGeometry(gsoapProxy2_0_1->soap);
 	getSpecializedGsoapProxy()->Geometry = geom;
 	getSpecializedGsoapProxy()->Geometry->LocalCrs = localCrs->newResqmlReference();
 
@@ -424,52 +424,52 @@ void UnstructuredGridRepresentation::setGeometryUsingExistingDatasets(const std:
 	getRepository()->addRelationship(this, proxy);
 	// Face Right handness
 	//XML
-	resqml20__BooleanHdf5Array* cellFaceIsRightHandedForHdf5 = soap_new_resqml20__BooleanHdf5Array(gsoapProxy2_0_1->soap, 1);
-	cellFaceIsRightHandedForHdf5->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	resqml20__BooleanHdf5Array* cellFaceIsRightHandedForHdf5 = soap_new_resqml20__BooleanHdf5Array(gsoapProxy2_0_1->soap);
+	cellFaceIsRightHandedForHdf5->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	cellFaceIsRightHandedForHdf5->Values->HdfProxy = proxy->newResqmlReference();
 	cellFaceIsRightHandedForHdf5->Values->PathInHdfFile = cellFaceIsRightHanded;
 	geom->CellFaceIsRightHanded = cellFaceIsRightHandedForHdf5;
 
 	// Face indices
 	//XML
-	geom->FacesPerCell = soap_new_resqml20__ResqmlJaggedArray(gsoapProxy2_0_1->soap, 1);
+	geom->FacesPerCell = soap_new_resqml20__ResqmlJaggedArray(gsoapProxy2_0_1->soap);
 	// Cumulative
-	resqml20__IntegerHdf5Array* cumulativeLength = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap, 1);
+	resqml20__IntegerHdf5Array* cumulativeLength = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap);
 	geom->FacesPerCell->CumulativeLength = cumulativeLength;
 	cumulativeLength->NullValue = -1;
-	cumulativeLength->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	cumulativeLength->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	cumulativeLength->Values->HdfProxy = proxy->newResqmlReference();
 	cumulativeLength->Values->PathInHdfFile = faceIndicesCumulativeCountPerCell;
 	// Elements
-	resqml20__IntegerHdf5Array* elements = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap, 1);
+	resqml20__IntegerHdf5Array* elements = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap);
 	geom->FacesPerCell->Elements = elements;
 	elements->NullValue = faceCount+1;
-	elements->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	elements->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	elements->Values->HdfProxy = proxy->newResqmlReference();
 	elements->Values->PathInHdfFile = faceIndicesPerCell;
 
 	// Node indices
 	//XML
-	geom->NodesPerFace = soap_new_resqml20__ResqmlJaggedArray(gsoapProxy2_0_1->soap, 1);
+	geom->NodesPerFace = soap_new_resqml20__ResqmlJaggedArray(gsoapProxy2_0_1->soap);
 	// Cumulative
-	cumulativeLength = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap, 1);
+	cumulativeLength = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap);
 	geom->NodesPerFace->CumulativeLength = cumulativeLength;
 	cumulativeLength->NullValue = -1;
-	cumulativeLength->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	cumulativeLength->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	cumulativeLength->Values->HdfProxy = proxy->newResqmlReference();
 	cumulativeLength->Values->PathInHdfFile = nodeIndicesCumulativeCountPerFace;
 	// Elements
-	elements = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap, 1);
+	elements = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap);
 	geom->NodesPerFace->Elements = elements;
 	elements->NullValue = pointCount+1;
-	elements->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	elements->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	elements->Values->HdfProxy = proxy->newResqmlReference();
 	elements->Values->PathInHdfFile = nodeIndicesPerFace;
 
 	// XML points
-	resqml20__Point3dHdf5Array* xmlPoints = soap_new_resqml20__Point3dHdf5Array(gsoapProxy2_0_1->soap, 1);
+	resqml20__Point3dHdf5Array* xmlPoints = soap_new_resqml20__Point3dHdf5Array(gsoapProxy2_0_1->soap);
 	geom->Points = xmlPoints;
-	xmlPoints->Coordinates = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	xmlPoints->Coordinates = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	xmlPoints->Coordinates->HdfProxy = proxy->newResqmlReference();
 	xmlPoints->Coordinates->PathInHdfFile = points;
 
@@ -539,7 +539,7 @@ void UnstructuredGridRepresentation::setConstantCellShapeGeometryUsingExistingDa
 		localCrs = getRepository()->getDefaultCrs();
 	}
 
-	resqml20__UnstructuredGridGeometry* geom = soap_new_resqml20__UnstructuredGridGeometry(gsoapProxy2_0_1->soap, 1);
+	resqml20__UnstructuredGridGeometry* geom = soap_new_resqml20__UnstructuredGridGeometry(gsoapProxy2_0_1->soap);
 	getSpecializedGsoapProxy()->Geometry = geom;
 	getSpecializedGsoapProxy()->Geometry->LocalCrs = localCrs->newResqmlReference();
 
@@ -561,26 +561,26 @@ void UnstructuredGridRepresentation::setConstantCellShapeGeometryUsingExistingDa
 	getRepository()->addRelationship(this, proxy);
 	// Face Right handness
 	//XML
-	resqml20__BooleanHdf5Array* cellFaceIsRightHandedForHdf5 = soap_new_resqml20__BooleanHdf5Array(gsoapProxy2_0_1->soap, 1);
-	cellFaceIsRightHandedForHdf5->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	resqml20__BooleanHdf5Array* cellFaceIsRightHandedForHdf5 = soap_new_resqml20__BooleanHdf5Array(gsoapProxy2_0_1->soap);
+	cellFaceIsRightHandedForHdf5->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	cellFaceIsRightHandedForHdf5->Values->HdfProxy = proxy->newResqmlReference();
 	cellFaceIsRightHandedForHdf5->Values->PathInHdfFile = cellFaceIsRightHanded;
 	geom->CellFaceIsRightHanded = cellFaceIsRightHandedForHdf5;
 
 	// Face indices
 	//XML
-	geom->FacesPerCell = soap_new_resqml20__ResqmlJaggedArray(gsoapProxy2_0_1->soap, 1);
+	geom->FacesPerCell = soap_new_resqml20__ResqmlJaggedArray(gsoapProxy2_0_1->soap);
 	// Cumulative
 	if (cellCount == 1)
 	{
-		resqml20__IntegerConstantArray* cumulativeLength = soap_new_resqml20__IntegerConstantArray(gsoapProxy2_0_1->soap, 1);
+		resqml20__IntegerConstantArray* cumulativeLength = soap_new_resqml20__IntegerConstantArray(gsoapProxy2_0_1->soap);
 		geom->FacesPerCell->CumulativeLength = cumulativeLength;
 		cumulativeLength->Count = cellCount;
 		cumulativeLength->Value = faceCountPerCell;
 	}
 	else
 	{
-		resqml20__IntegerLatticeArray* cumulativeLength = soap_new_resqml20__IntegerLatticeArray(gsoapProxy2_0_1->soap, 1);
+		resqml20__IntegerLatticeArray* cumulativeLength = soap_new_resqml20__IntegerLatticeArray(gsoapProxy2_0_1->soap);
 		geom->FacesPerCell->CumulativeLength = cumulativeLength;
 		cumulativeLength->StartValue = faceCountPerCell;
 		cumulativeLength->Offset.push_back(soap_new_resqml20__IntegerConstantArray(gsoapProxy2_0_1->soap, 1));
@@ -588,35 +588,35 @@ void UnstructuredGridRepresentation::setConstantCellShapeGeometryUsingExistingDa
 		cumulativeLength->Offset[0]->Value = faceCountPerCell;
 	}
 	// Elements
-	resqml20__IntegerHdf5Array* elements = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap, 1);
+	resqml20__IntegerHdf5Array* elements = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap);
 	geom->FacesPerCell->Elements = elements;
 	elements->NullValue = faceCount+1;
-	elements->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	elements->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	elements->Values->HdfProxy = proxy->newResqmlReference();
 	elements->Values->PathInHdfFile = faceIndicesPerCell;
 
 	// Node indices
 	//XML
-	geom->NodesPerFace = soap_new_resqml20__ResqmlJaggedArray(gsoapProxy2_0_1->soap, 1);
+	geom->NodesPerFace = soap_new_resqml20__ResqmlJaggedArray(gsoapProxy2_0_1->soap);
 	// Cumulative
-	resqml20__IntegerLatticeArray* cumulativeLength = soap_new_resqml20__IntegerLatticeArray(gsoapProxy2_0_1->soap, 1);
+	resqml20__IntegerLatticeArray* cumulativeLength = soap_new_resqml20__IntegerLatticeArray(gsoapProxy2_0_1->soap);
 	geom->NodesPerFace->CumulativeLength = cumulativeLength;
 	cumulativeLength->StartValue = nodeCountPerFace;
 	cumulativeLength->Offset.push_back(soap_new_resqml20__IntegerConstantArray(gsoapProxy2_0_1->soap, 1));
 	cumulativeLength->Offset[0]->Count = geom->FaceCount - 1;
 	cumulativeLength->Offset[0]->Value = nodeCountPerFace;
 	// Elements
-	elements = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap, 1);
+	elements = soap_new_resqml20__IntegerHdf5Array(gsoapProxy2_0_1->soap);
 	geom->NodesPerFace->Elements = elements;
 	elements->NullValue = pointCount+1;
-	elements->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	elements->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	elements->Values->HdfProxy = proxy->newResqmlReference();
 	elements->Values->PathInHdfFile = nodeIndicesPerFace;
 
 	// XML points
-	resqml20__Point3dHdf5Array* xmlPoints = soap_new_resqml20__Point3dHdf5Array(gsoapProxy2_0_1->soap, 1);
+	resqml20__Point3dHdf5Array* xmlPoints = soap_new_resqml20__Point3dHdf5Array(gsoapProxy2_0_1->soap);
 	geom->Points = xmlPoints;
-	xmlPoints->Coordinates = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	xmlPoints->Coordinates = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	xmlPoints->Coordinates->HdfProxy = proxy->newResqmlReference();
 	xmlPoints->Coordinates->PathInHdfFile = points;
 

--- a/src/resqml2_0_1/WellboreFeature.cpp
+++ b/src/resqml2_0_1/WellboreFeature.cpp
@@ -35,7 +35,7 @@ WellboreFeature::WellboreFeature(COMMON_NS::DataObjectRepository* repo, const st
 		throw invalid_argument("The repo cannot be null.");
 	}
 
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREWellboreFeature(repo->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREWellboreFeature(repo->getGsoapContext());
 
 	initMandatoryMetadata();
 	setMetadata(guid, title, std::string(), -1, std::string(), std::string(), -1, std::string());
@@ -48,7 +48,7 @@ void WellboreFeature::setWitsmlWellbore(WITSML2_0_NS::Wellbore * wellbore)
 	getRepository()->addRelationship(this, wellbore);
 
 	resqml20__obj_USCOREWellboreFeature* resqmlWellbore = static_cast<resqml20__obj_USCOREWellboreFeature*>(gsoapProxy2_0_1);
-	resqmlWellbore->WitsmlWellbore = soap_new_resqml20__WitsmlWellboreReference(gsoapProxy2_0_1->soap, 1);
+	resqmlWellbore->WitsmlWellbore = soap_new_resqml20__WitsmlWellboreReference(gsoapProxy2_0_1->soap);
 	resqmlWellbore->WitsmlWellbore->WitsmlWellbore = wellbore->newResqmlReference();
 	resqmlWellbore->WitsmlWellbore->WitsmlWell = wellbore->getWell()->newResqmlReference();
 }

--- a/src/resqml2_0_1/WellboreFrameRepresentation.cpp
+++ b/src/resqml2_0_1/WellboreFrameRepresentation.cpp
@@ -35,7 +35,7 @@ const char* WellboreFrameRepresentation::XML_TAG = "WellboreFrameRepresentation"
 
 WellboreFrameRepresentation::WellboreFrameRepresentation(WellboreInterpretation * interp, const string & guid, const std::string & title, WellboreTrajectoryRepresentation * traj)
 {
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREWellboreFrameRepresentation(interp->getGsoapContext(), 1);	
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREWellboreFrameRepresentation(interp->getGsoapContext());	
 	_resqml20__WellboreFrameRepresentation* frame = static_cast<_resqml20__WellboreFrameRepresentation*>(gsoapProxy2_0_1);
 
 	initMandatoryMetadata();
@@ -73,8 +73,8 @@ void WellboreFrameRepresentation::setMdValues(double * mdValues, unsigned int md
 	_resqml20__WellboreFrameRepresentation* frame = static_cast<_resqml20__WellboreFrameRepresentation*>(gsoapProxy2_0_1);
 
 	// XML
-	resqml20__DoubleHdf5Array* xmlMdValues = soap_new_resqml20__DoubleHdf5Array(gsoapProxy2_0_1->soap, 1);
-	xmlMdValues->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	resqml20__DoubleHdf5Array* xmlMdValues = soap_new_resqml20__DoubleHdf5Array(gsoapProxy2_0_1->soap);
+	xmlMdValues->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	xmlMdValues->Values->HdfProxy = proxy->newResqmlReference();
 	xmlMdValues->Values->PathInHdfFile = "/RESQML/" + frame->uuid + "/mdValues";
 
@@ -96,7 +96,7 @@ void WellboreFrameRepresentation::setMdValues(const double & firstMdValue, const
 	_resqml20__WellboreFrameRepresentation* frame = static_cast<_resqml20__WellboreFrameRepresentation*>(gsoapProxy2_0_1);
 
 	// XML
-	resqml20__DoubleLatticeArray* xmlMdValues = soap_new_resqml20__DoubleLatticeArray(gsoapProxy2_0_1->soap, 1);
+	resqml20__DoubleLatticeArray* xmlMdValues = soap_new_resqml20__DoubleLatticeArray(gsoapProxy2_0_1->soap);
 	xmlMdValues->StartValue = firstMdValue;
 	xmlMdValues->Offset.push_back(soap_new_resqml20__DoubleConstantArray(gsoapProxy2_0_1->soap, 1));
 	xmlMdValues->Offset[0]->Count = mdValueCount - 1;

--- a/src/resqml2_0_1/WellboreInterpretation.cpp
+++ b/src/resqml2_0_1/WellboreInterpretation.cpp
@@ -29,7 +29,7 @@ const char* WellboreInterpretation::XML_TAG = "WellboreInterpretation";
 
 WellboreInterpretation::WellboreInterpretation(WellboreFeature * WellboreFeature, const string & guid, const string & title, bool isDrilled)
 {
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREWellboreInterpretation(WellboreFeature->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREWellboreInterpretation(WellboreFeature->getGsoapContext());
 	_resqml20__WellboreInterpretation* wbInterp = static_cast<_resqml20__WellboreInterpretation*>(gsoapProxy2_0_1);
 	wbInterp->Domain = resqml20__Domain__mixed;
 

--- a/src/resqml2_0_1/WellboreMarker.cpp
+++ b/src/resqml2_0_1/WellboreMarker.cpp
@@ -31,7 +31,7 @@ const char* WellboreMarker::XML_TAG = "WellboreMarker";
 
 WellboreMarker::WellboreMarker(WellboreMarkerFrameRepresentation* wellboreMarkerFrame, const std::string & guid, const std::string & title)
 {
-	gsoapProxy2_0_1 = soap_new_resqml20__WellboreMarker(wellboreMarkerFrame->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__WellboreMarker(wellboreMarkerFrame->getGsoapContext());
 
 	initMandatoryMetadata();
 	setMetadata(guid, title, "", -1, "", "", -1, "");
@@ -41,7 +41,7 @@ WellboreMarker::WellboreMarker(WellboreMarkerFrameRepresentation* wellboreMarker
 
 WellboreMarker::WellboreMarker(WellboreMarkerFrameRepresentation* wellboreMarkerFrame, const std::string & guid, const std::string & title, gsoap_resqml2_0_1::resqml20__GeologicBoundaryKind geologicBoundaryKind)
 {
-	gsoapProxy2_0_1 = soap_new_resqml20__WellboreMarker(wellboreMarkerFrame->getGsoapContext(), 1);	
+	gsoapProxy2_0_1 = soap_new_resqml20__WellboreMarker(wellboreMarkerFrame->getGsoapContext());	
 	resqml20__WellboreMarker* marker = static_cast<resqml20__WellboreMarker*>(gsoapProxy2_0_1);
 
 	marker->GeologicBoundaryKind = (resqml20__GeologicBoundaryKind*)soap_malloc(gsoapProxy2_0_1->soap, sizeof(resqml20__GeologicBoundaryKind));

--- a/src/resqml2_0_1/WellboreMarkerFrameRepresentation.cpp
+++ b/src/resqml2_0_1/WellboreMarkerFrameRepresentation.cpp
@@ -44,7 +44,7 @@ const char* WellboreMarkerFrameRepresentation::XML_TAG = "WellboreMarkerFrameRep
 
 WellboreMarkerFrameRepresentation::WellboreMarkerFrameRepresentation(WellboreInterpretation * interp, const std::string & guid, const std::string & title, WellboreTrajectoryRepresentation * traj)
 {
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREWellboreMarkerFrameRepresentation(interp->getGsoapContext(), 1);	
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREWellboreMarkerFrameRepresentation(interp->getGsoapContext());	
 	_resqml20__WellboreMarkerFrameRepresentation* frame = static_cast<_resqml20__WellboreMarkerFrameRepresentation*>(gsoapProxy2_0_1);
 
 	initMandatoryMetadata();
@@ -89,7 +89,7 @@ void WellboreMarkerFrameRepresentation::setStratigraphicOccurrenceInterpretation
 	getRepository()->addRelationship(this, stratiOccurenceInterp);
 
 	_resqml20__WellboreMarkerFrameRepresentation* frame = static_cast<_resqml20__WellboreMarkerFrameRepresentation*>(gsoapProxy2_0_1);
-	frame->IntervalStratigraphiUnits = soap_new_resqml20__IntervalStratigraphicUnits(frame->soap, 1);
+	frame->IntervalStratigraphiUnits = soap_new_resqml20__IntervalStratigraphicUnits(frame->soap);
 	frame->IntervalStratigraphiUnits->StratigraphicOrganization = stratiOccurenceInterp->newResqmlReference();
 }
 
@@ -104,9 +104,9 @@ void WellboreMarkerFrameRepresentation::setIntervalStratigraphicUnits(unsigned i
 
 	_resqml20__WellboreMarkerFrameRepresentation* frame = static_cast<_resqml20__WellboreMarkerFrameRepresentation*>(gsoapProxy2_0_1);
 
-	resqml20__IntegerHdf5Array* xmlDataset = soap_new_resqml20__IntegerHdf5Array(frame->soap, 1);
+	resqml20__IntegerHdf5Array* xmlDataset = soap_new_resqml20__IntegerHdf5Array(frame->soap);
 	xmlDataset->NullValue = nullValue;
-	xmlDataset->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	xmlDataset->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	xmlDataset->Values->HdfProxy = proxy->newResqmlReference();
 	xmlDataset->Values->PathInHdfFile = "/RESQML/" + frame->uuid + "/IntervalStratigraphicUnits";
 	frame->IntervalStratigraphiUnits->UnitIndices = xmlDataset;

--- a/src/resqml2_0_1/WellboreTrajectoryRepresentation.cpp
+++ b/src/resqml2_0_1/WellboreTrajectoryRepresentation.cpp
@@ -37,7 +37,7 @@ const char* WellboreTrajectoryRepresentation::XML_TAG = "WellboreTrajectoryRepre
 
 WellboreTrajectoryRepresentation::WellboreTrajectoryRepresentation(WellboreInterpretation * interp, const string & guid, const std::string & title, RESQML2_NS::MdDatum * mdInfo)
 {
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREWellboreTrajectoryRepresentation(interp->getGsoapContext(), 1);	
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREWellboreTrajectoryRepresentation(interp->getGsoapContext());	
 	_resqml20__WellboreTrajectoryRepresentation* rep = static_cast<_resqml20__WellboreTrajectoryRepresentation*>(gsoapProxy2_0_1);
 
 	initMandatoryMetadata();
@@ -53,7 +53,7 @@ WellboreTrajectoryRepresentation::WellboreTrajectoryRepresentation(WellboreInter
 
 WellboreTrajectoryRepresentation::WellboreTrajectoryRepresentation(WellboreInterpretation * interp, const string & guid, const std::string & title, DeviationSurveyRepresentation * deviationSurvey)
 {
-	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREWellboreTrajectoryRepresentation(interp->getGsoapContext(), 1);
+	gsoapProxy2_0_1 = soap_new_resqml20__obj_USCOREWellboreTrajectoryRepresentation(interp->getGsoapContext());
 	_resqml20__WellboreTrajectoryRepresentation* rep = static_cast<_resqml20__WellboreTrajectoryRepresentation*>(gsoapProxy2_0_1);
 
 	RESQML2_NS::MdDatum * mdInfo = deviationSurvey->getMdDatum();
@@ -89,8 +89,8 @@ void WellboreTrajectoryRepresentation::setGeometry(double * controlPoints, doubl
 		localCrs = getRepository()->getDefaultCrs();
 	}
 
-	rep->Geometry = soap_new_resqml20__ParametricLineGeometry(gsoapProxy2_0_1->soap, 1);
-	resqml20__ParametricLineGeometry* paramLine = soap_new_resqml20__ParametricLineGeometry(gsoapProxy2_0_1->soap, 1);
+	rep->Geometry = soap_new_resqml20__ParametricLineGeometry(gsoapProxy2_0_1->soap);
+	resqml20__ParametricLineGeometry* paramLine = soap_new_resqml20__ParametricLineGeometry(gsoapProxy2_0_1->soap);
 	paramLine->LocalCrs = localCrs->newResqmlReference();
 	rep->StartMd = startMd;
 	rep->FinishMd = endMd;
@@ -105,8 +105,8 @@ void WellboreTrajectoryRepresentation::setGeometry(double * controlPoints, doubl
 	getRepository()->addRelationship(this, proxy);
 
 	// XML control points
-	resqml20__Point3dHdf5Array* xmlControlPoints = soap_new_resqml20__Point3dHdf5Array(gsoapProxy2_0_1->soap, 1);
-	xmlControlPoints->Coordinates = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	resqml20__Point3dHdf5Array* xmlControlPoints = soap_new_resqml20__Point3dHdf5Array(gsoapProxy2_0_1->soap);
+	xmlControlPoints->Coordinates = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	xmlControlPoints->Coordinates->HdfProxy = proxy->newResqmlReference();
 	xmlControlPoints->Coordinates->PathInHdfFile = "/RESQML/" + rep->uuid + "/controlPoints";
 	paramLine->ControlPoints = xmlControlPoints;
@@ -129,8 +129,8 @@ void WellboreTrajectoryRepresentation::setGeometry(double * controlPoints, doubl
 	resqml20__ParametricLineGeometry* paramLine = static_cast<resqml20__ParametricLineGeometry*>(rep->Geometry);
 
 	// XML control point parameters
-	resqml20__DoubleHdf5Array* xmlControlPointParameters = soap_new_resqml20__DoubleHdf5Array(gsoapProxy2_0_1->soap, 1);
-	xmlControlPointParameters->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	resqml20__DoubleHdf5Array* xmlControlPointParameters = soap_new_resqml20__DoubleHdf5Array(gsoapProxy2_0_1->soap);
+	xmlControlPointParameters->Values = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	xmlControlPointParameters->Values->HdfProxy = proxy->newResqmlReference();
 	xmlControlPointParameters->Values->PathInHdfFile = "/RESQML/" + rep->uuid + "/controlPointParameters";
 	paramLine->ControlPointParameters = xmlControlPointParameters;
@@ -151,8 +151,8 @@ void WellboreTrajectoryRepresentation::setGeometry(double * controlPoints,
 	paramLine->LineKindIndex = 5;
 
 	// XML tangent vectors
-	resqml20__Point3dHdf5Array* xmlTangentVectors = soap_new_resqml20__Point3dHdf5Array(gsoapProxy2_0_1->soap, 1);
-	xmlTangentVectors->Coordinates = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap, 1);
+	resqml20__Point3dHdf5Array* xmlTangentVectors = soap_new_resqml20__Point3dHdf5Array(gsoapProxy2_0_1->soap);
+	xmlTangentVectors->Coordinates = soap_new_eml20__Hdf5Dataset(gsoapProxy2_0_1->soap);
 	xmlTangentVectors->Coordinates->HdfProxy = proxy->newResqmlReference();
 	xmlTangentVectors->Coordinates->PathInHdfFile = "/RESQML/" + rep->uuid + "/tangentVectors";
 	paramLine->TangentVectors = xmlTangentVectors;
@@ -187,7 +187,7 @@ void WellboreTrajectoryRepresentation::addParentTrajectory(double kickoffMd, dou
 	getRepository()->addRelationship(this, parentTrajRep);
 
 	_resqml20__WellboreTrajectoryRepresentation* rep = static_cast<_resqml20__WellboreTrajectoryRepresentation*>(gsoapProxy2_0_1);
-	rep->ParentIntersection = soap_new_resqml20__WellboreTrajectoryParentIntersection(rep->soap, 1);
+	rep->ParentIntersection = soap_new_resqml20__WellboreTrajectoryParentIntersection(rep->soap);
 	rep->ParentIntersection->KickoffMd = kickoffMd;
 	rep->ParentIntersection->ParentMd = parentMd;
 	rep->ParentIntersection->ParentTrajectory = parentTrajRep->newResqmlReference();

--- a/src/witsml2_0/Trajectory.cpp
+++ b/src/witsml2_0/Trajectory.cpp
@@ -39,7 +39,7 @@ Trajectory::Trajectory(Wellbore* witsmlWellbore,
 {
 	if (witsmlWellbore == nullptr) throw invalid_argument("A wellbore must be associated to a wellbore trajectory.");
 
-	gsoapProxy2_1 = soap_new_witsml20__Trajectory(witsmlWellbore->getGsoapContext(), 1);
+	gsoapProxy2_1 = soap_new_witsml20__Trajectory(witsmlWellbore->getGsoapContext());
 
 	initMandatoryMetadata();
 	setMetadata(guid, title, std::string(), -1, std::string(), std::string(), -1, std::string());

--- a/src/witsml2_0/Well.cpp
+++ b/src/witsml2_0/Well.cpp
@@ -43,7 +43,7 @@ Well::Well(COMMON_NS::DataObjectRepository * repo,
 		throw invalid_argument("A repo must exist.");
 	}
 
-	gsoapProxy2_1 = soap_new_witsml20__Well(repo->getGsoapContext(), 1);
+	gsoapProxy2_1 = soap_new_witsml20__Well(repo->getGsoapContext());
 
 	initMandatoryMetadata();
 	setMetadata(guid, title, "", -1, "", "", -1, "");
@@ -63,7 +63,7 @@ Well::Well(COMMON_NS::DataObjectRepository * repo,
 		throw invalid_argument("A repo must exist.");
 	}
 
-	gsoapProxy2_1 = soap_new_witsml20__Well(repo->getGsoapContext(), 1);
+	gsoapProxy2_1 = soap_new_witsml20__Well(repo->getGsoapContext());
 
 	initMandatoryMetadata();
 	setMetadata(guid, title, "", -1, "", "", -1, "");
@@ -116,7 +116,7 @@ void Well::setTimeZone(bool direction, unsigned short hours, unsigned short minu
 	if (hours > 23) { throw invalid_argument("You cannot set a time zone superior to 23 hours"); }
 	if (minutes > 59) { throw invalid_argument("You cannot set a time zone superior to 59 minutes"); }
 	witsml20__Well* well = static_cast<witsml20__Well*>(gsoapProxy2_1);
-	if (well->TimeZone == nullptr) { well->TimeZone = soap_new_eml21__TimeZone(gsoapProxy2_1->soap, 1); }
+	if (well->TimeZone == nullptr) { well->TimeZone = soap_new_eml21__TimeZone(gsoapProxy2_1->soap); }
 
 	if (hours == 00 && minutes == 0) {
 		well->TimeZone->assign("Z");
@@ -205,7 +205,7 @@ void Well::pushBackLocation(
 {
 	witsml20__Well* well = static_cast<witsml20__Well*>(gsoapProxy2_1);
 
-	witsml20__ProjectedWellLocation* location = soap_new_witsml20__ProjectedWellLocation(gsoapProxy2_1->soap, 1);
+	witsml20__ProjectedWellLocation* location = soap_new_witsml20__ProjectedWellLocation(gsoapProxy2_1->soap);
 	if (guid.size() == 0) {
 		ostringstream oss;
 		oss << well->WellLocation.size();
@@ -216,7 +216,7 @@ void Well::pushBackLocation(
 	}
 	location->Coordinate1 = projectedX;
 	location->Coordinate2 = projectedY;
-	location->Crs = soap_new_eml21__ProjectedEpsgCrs(gsoapProxy2_1->soap, 1);
+	location->Crs = soap_new_eml21__ProjectedEpsgCrs(gsoapProxy2_1->soap);
 	static_cast<eml21__ProjectedEpsgCrs*>(location->Crs)->EpsgCode = projectedCrsEpsgCode;
 
 	well->WellLocation.push_back(location);
@@ -237,7 +237,7 @@ void Well::pushBackDatum(
 {
 	witsml20__Well* well = static_cast<witsml20__Well*>(gsoapProxy2_1);
 
-	witsml20__WellDatum* wellDatum = soap_new_witsml20__WellDatum(gsoapProxy2_1->soap, 1);
+	witsml20__WellDatum* wellDatum = soap_new_witsml20__WellDatum(gsoapProxy2_1->soap);
 	if (guid.empty()) {
 		ostringstream oss;
 		oss << well->WellDatum.size();
@@ -251,10 +251,10 @@ void Well::pushBackDatum(
 	wellDatum->Code = (eml21__WellboreDatumReference *)soap_malloc(gsoapProxy2_1->soap, sizeof(eml21__WellboreDatumReference));
 	*wellDatum->Code = code;
 
-	wellDatum->Crs = soap_new_eml21__VerticalEpsgCrs(gsoapProxy2_1->soap, 1);
+	wellDatum->Crs = soap_new_eml21__VerticalEpsgCrs(gsoapProxy2_1->soap);
 	static_cast<eml21__VerticalEpsgCrs*>(wellDatum->Crs)->EpsgCode = verticalCrsEpsgCode;
 
-	wellDatum->Elevation = soap_new_witsml20__WellElevationCoord(gsoapProxy2_1->soap, 1);
+	wellDatum->Elevation = soap_new_witsml20__WellElevationCoord(gsoapProxy2_1->soap);
 	wellDatum->Elevation->datum = datum;
 	wellDatum->Elevation->uom = elevationUnit;
 	wellDatum->Elevation->__item = elevation;

--- a/src/witsml2_0/WellCompletion.cpp
+++ b/src/witsml2_0/WellCompletion.cpp
@@ -35,7 +35,7 @@ WellCompletion::WellCompletion(Well* witsmlWell,
 {
 	if (witsmlWell == nullptr) throw invalid_argument("A well must be associated to a well completion.");
 
-	gsoapProxy2_1 = soap_new_witsml20__WellCompletion(witsmlWell->getGsoapContext(), 1);
+	gsoapProxy2_1 = soap_new_witsml20__WellCompletion(witsmlWell->getGsoapContext());
 
 	initMandatoryMetadata();
 	setMetadata(guid, title, "", -1, "", "", -1, "");

--- a/src/witsml2_0/Wellbore.cpp
+++ b/src/witsml2_0/Wellbore.cpp
@@ -36,7 +36,7 @@ Wellbore::Wellbore( Well* witsmlWell, const std::string & guid, const std::strin
 {
 	if (witsmlWell == nullptr) throw invalid_argument("A wellbore must be associated to a well.");
 
-	gsoapProxy2_1 = soap_new_witsml20__Wellbore(witsmlWell->getGsoapContext(), 1);
+	gsoapProxy2_1 = soap_new_witsml20__Wellbore(witsmlWell->getGsoapContext());
 
 	initMandatoryMetadata();
 	setMetadata(guid, title, "", -1, "", "", -1, "");
@@ -55,7 +55,7 @@ Wellbore::Wellbore(
 {
 	if (witsmlWell == nullptr) throw invalid_argument("A wellbore must be associated to a well.");
 
-	gsoapProxy2_1 = soap_new_witsml20__Wellbore(witsmlWell->getGsoapContext(), 1);
+	gsoapProxy2_1 = soap_new_witsml20__Wellbore(witsmlWell->getGsoapContext());
 
 	initMandatoryMetadata();
 	setMetadata(guid, title, "", -1, "", "", -1, "");

--- a/src/witsml2_0/WellboreCompletion.cpp
+++ b/src/witsml2_0/WellboreCompletion.cpp
@@ -38,7 +38,7 @@ WellboreCompletion::WellboreCompletion(Wellbore* witsmlWellbore,
 	if (witsmlWellbore == nullptr) throw invalid_argument("A wellbore must be associated to a wellbore completion.");
 	if (wellCompletion == nullptr) throw invalid_argument("A well completion must be associated to a wellbore completion");
 
-	gsoapProxy2_1 = soap_new_witsml20__WellboreCompletion(witsmlWellbore->getGsoapContext(), 1);
+	gsoapProxy2_1 = soap_new_witsml20__WellboreCompletion(witsmlWellbore->getGsoapContext());
 
 	initMandatoryMetadata();
 	setMetadata(guid, title, std::string(), -1, std::string(), std::string(), -1, std::string());
@@ -106,10 +106,10 @@ void WellboreCompletion::pushBackPerforation(const string & datum,
 
 	if (wellboreCompletion->ContactIntervalSet == nullptr)
 	{
-		wellboreCompletion->ContactIntervalSet = soap_new_witsml20__ContactIntervalSet(gsoapProxy2_1->soap, 1);
+		wellboreCompletion->ContactIntervalSet = soap_new_witsml20__ContactIntervalSet(gsoapProxy2_1->soap);
 	}
 
-	witsml20__PerforationSetInterval* perforationSetInterval = soap_new_witsml20__PerforationSetInterval(gsoapProxy2_1->soap, 1);
+	witsml20__PerforationSetInterval* perforationSetInterval = soap_new_witsml20__PerforationSetInterval(gsoapProxy2_1->soap);
 
 	if (guid.size() == 0) {
 		ostringstream oss;
@@ -120,12 +120,12 @@ void WellboreCompletion::pushBackPerforation(const string & datum,
 		perforationSetInterval->uid = guid;
 	}
 
-	perforationSetInterval->PerforationSetMdInterval = soap_new_eml21__MdInterval(gsoapProxy2_1->soap, 1);
+	perforationSetInterval->PerforationSetMdInterval = soap_new_eml21__MdInterval(gsoapProxy2_1->soap);
 	perforationSetInterval->PerforationSetMdInterval->datum = datum;
-	perforationSetInterval->PerforationSetMdInterval->MdTop = soap_new_eml21__LengthMeasure(gsoapProxy2_1->soap, 1);
+	perforationSetInterval->PerforationSetMdInterval->MdTop = soap_new_eml21__LengthMeasure(gsoapProxy2_1->soap);
 	perforationSetInterval->PerforationSetMdInterval->MdTop->uom = MdUnit;
 	perforationSetInterval->PerforationSetMdInterval->MdTop->__item = TopMd;
-	perforationSetInterval->PerforationSetMdInterval->MdBase = soap_new_eml21__LengthMeasure(gsoapProxy2_1->soap, 1);
+	perforationSetInterval->PerforationSetMdInterval->MdBase = soap_new_eml21__LengthMeasure(gsoapProxy2_1->soap);
 	perforationSetInterval->PerforationSetMdInterval->MdBase->uom = MdUnit;
 	perforationSetInterval->PerforationSetMdInterval->MdBase->__item = BaseMd;
 
@@ -137,7 +137,7 @@ void WellboreCompletion::pushBackPerforationHistory(unsigned int index,
 {
 	witsml20__PerforationSetInterval * perforationSetInterval = getPerforation(index);
 
-	witsml20__PerforationStatusHistory* perforationStatusHistory = soap_new_witsml20__PerforationStatusHistory(gsoapProxy2_1->soap, 1);
+	witsml20__PerforationStatusHistory* perforationStatusHistory = soap_new_witsml20__PerforationStatusHistory(gsoapProxy2_1->soap);
 
 	if (guid.size() == 0) {
 		ostringstream oss;
@@ -158,7 +158,7 @@ void WellboreCompletion::pushBackPerforationHistory(unsigned int index,
 {
 	witsml20__PerforationSetInterval * perforationSetInterval = getPerforation(index);
 
-	witsml20__PerforationStatusHistory* perforationStatusHistory = soap_new_witsml20__PerforationStatusHistory(gsoapProxy2_1->soap, 1);
+	witsml20__PerforationStatusHistory* perforationStatusHistory = soap_new_witsml20__PerforationStatusHistory(gsoapProxy2_1->soap);
 
 	if (guid.size() == 0) {
 		ostringstream oss;
@@ -169,12 +169,12 @@ void WellboreCompletion::pushBackPerforationHistory(unsigned int index,
 		perforationStatusHistory->uid = guid;
 	}
 
-	perforationStatusHistory->PerforationStatus = soap_new_witsml20__PerforationStatus(gsoapProxy2_1->soap, 1);
+	perforationStatusHistory->PerforationStatus = soap_new_witsml20__PerforationStatus(gsoapProxy2_1->soap);
 	*perforationStatusHistory->PerforationStatus = perforationStatus;
 
 	if (startDate != -1)
 	{
-		perforationStatusHistory->StartDate = soap_new_std__string(gsoapProxy2_1->soap, 1);
+		perforationStatusHistory->StartDate = soap_new_std__string(gsoapProxy2_1->soap);
 		perforationStatusHistory->StartDate->assign(timeTools::convertUnixTimestampToIso(startDate));
 	}
 
@@ -325,7 +325,7 @@ void WellboreCompletion::setPerforationHistoryStatus(unsigned int historyIndex,
 
 	if (perforationStatusHistory->PerforationStatus == nullptr)
 	{
-		perforationStatusHistory->PerforationStatus = soap_new_witsml20__PerforationStatus(gsoapProxy2_1->soap, 1);
+		perforationStatusHistory->PerforationStatus = soap_new_witsml20__PerforationStatus(gsoapProxy2_1->soap);
 	}
 
 	*perforationStatusHistory->PerforationStatus = perforationStatus;
@@ -357,7 +357,7 @@ void WellboreCompletion::setPerforationHistoryStartDate(unsigned int historyInde
 
 	if (perforationStatusHistory->StartDate == nullptr)
 	{
-		perforationStatusHistory->StartDate = soap_new_std__string(gsoapProxy2_1->soap, 1);
+		perforationStatusHistory->StartDate = soap_new_std__string(gsoapProxy2_1->soap);
 	}
 
 	perforationStatusHistory->StartDate->assign(timeTools::convertUnixTimestampToIso(startDate));
@@ -389,7 +389,7 @@ void WellboreCompletion::setPerforationHistoryEndDate(unsigned int historyIndex,
 
 	if (perforationStatusHistory->EndDate == nullptr)
 	{
-		perforationStatusHistory->EndDate = soap_new_std__string(gsoapProxy2_1->soap, 1);
+		perforationStatusHistory->EndDate = soap_new_std__string(gsoapProxy2_1->soap);
 	}
 
 	perforationStatusHistory->EndDate->assign(timeTools::convertUnixTimestampToIso(endDate));
@@ -482,11 +482,11 @@ void WellboreCompletion::setPerforationHistoryTopMd(unsigned int historyIndex,
 	witsml20__PerforationStatusHistory* perforationStatusHistory = getPerforationHistoryEntry(historyIndex, perforationIndex);
 
 	if (perforationStatusHistory->PerforationMdInterval == nullptr) {
-		perforationStatusHistory->PerforationMdInterval = soap_new_eml21__MdInterval(gsoapProxy2_1->soap, 1);	
+		perforationStatusHistory->PerforationMdInterval = soap_new_eml21__MdInterval(gsoapProxy2_1->soap);	
 	}
 
 	perforationStatusHistory->PerforationMdInterval->datum = datum;
-	perforationStatusHistory->PerforationMdInterval->MdTop = soap_new_eml21__LengthMeasure(gsoapProxy2_1->soap, 1);
+	perforationStatusHistory->PerforationMdInterval->MdTop = soap_new_eml21__LengthMeasure(gsoapProxy2_1->soap);
 	perforationStatusHistory->PerforationMdInterval->MdTop->uom = MdUnit;
 	perforationStatusHistory->PerforationMdInterval->MdTop->__item = TopMd;
 }
@@ -528,11 +528,11 @@ void WellboreCompletion::setPerforationHistoryBaseMd(unsigned int historyIndex,
 	witsml20__PerforationStatusHistory* perforationStatusHistory = getPerforationHistoryEntry(historyIndex, perforationIndex);
 
 	if (perforationStatusHistory->PerforationMdInterval == nullptr) {
-		perforationStatusHistory->PerforationMdInterval = soap_new_eml21__MdInterval(gsoapProxy2_1->soap, 1);
+		perforationStatusHistory->PerforationMdInterval = soap_new_eml21__MdInterval(gsoapProxy2_1->soap);
 	}
 
 	perforationStatusHistory->PerforationMdInterval->datum = datum;
-	perforationStatusHistory->PerforationMdInterval->MdBase = soap_new_eml21__LengthMeasure(gsoapProxy2_1->soap, 1);
+	perforationStatusHistory->PerforationMdInterval->MdBase = soap_new_eml21__LengthMeasure(gsoapProxy2_1->soap);
 	perforationStatusHistory->PerforationMdInterval->MdBase->uom = MdUnit;
 	perforationStatusHistory->PerforationMdInterval->MdBase->__item = BaseMd;
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
gSoap instances are for now created by means of an array of a single value instead of only a single value. This PR fixes that?

Does this close any currently open issues?
------------------------------------------
Fix #182 

Where has this been tested?
---------------------------
**Operating System:** Win 64 10

**Platform:** VS 2015 64
