### PR TITLE
Can get the WITSML perforation uid

### DIFF
--- a/cmake/swigModule.i
+++ b/cmake/swigModule.i
@@ -702,6 +702,10 @@ namespace COMMON_NS
 
 		//*************** WITSML *************
 
+		WITSML2_0_NS::Well* createPartialWell(
+			const std::string & guid,
+			const std::string & title);
+
 		WITSML2_0_NS::Well* createWell(const std::string & guid,
 			const std::string & title);
 

--- a/cmake/swigModule_experimental.i
+++ b/cmake/swigModule_experimental.i
@@ -755,6 +755,10 @@ namespace COMMON_NS
 
 		//*************** WITSML *************
 
+		WITSML2_0_NS::Well* createPartialWell(
+			const std::string & guid,
+			const std::string & title);
+
 		WITSML2_0_NS::Well* createWell(const std::string & guid,
 			const std::string & title);
 

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -238,7 +238,7 @@ void serializePerforations(COMMON_NS::DataObjectRepository * pck)
 	// WELLBORE COMPLETION
 	WITSML2_0_NS::WellboreCompletion* wellboreCompletion = pck->createWellboreCompletion(witsmlWellbore, wellCompletion, "7bda8ecf-2037-4dc7-8c59-db6ca09f2008", "WellboreCompletion1", "wellCompletionName");
 
-	wellboreCompletion->pushBackPerforation("Mean Sea Level", gsoap_eml2_1::eml21__LengthUom__m, 1970, 1980);
+	wellboreCompletion->pushBackPerforation("Mean Sea Level", gsoap_eml2_1::eml21__LengthUom__m, 1970, 1980, "myId");
 	wellboreCompletion->pushBackPerforation("Mean Sea Level", gsoap_eml2_1::eml21__LengthUom__m, 1990, 2000);
 	wellboreCompletion->pushBackPerforationHistory(0);
 	wellboreCompletion->setPerforationHistoryStatus(0, 0, gsoap_eml2_1::witsml20__PerforationStatus__open);
@@ -3275,7 +3275,7 @@ void deserializePerforations(COMMON_NS::DataObjectRepository & pck)
 
 	for (unsigned int perforationIndex = 0; perforationIndex < wellboreCompletion->getPerforationCount(); ++perforationIndex)
 	{
-		cout << std::endl << "perforation " << perforationIndex << ":" << std::endl;
+		cout << std::endl << "perforation " << perforationIndex << " with uid \"" << wellboreCompletion->getPerforationUid(perforationIndex) << "\":" << std::endl;
 		if (wellboreCompletion->hasPerforationMdDatum(perforationIndex))
 		{
 			cout << "datum: " << wellboreCompletion->getPerforationMdDatum(perforationIndex) << std::endl;

--- a/src/common/DataObjectRepository.cpp
+++ b/src/common/DataObjectRepository.cpp
@@ -1344,6 +1344,13 @@ RESQML2_NS::Activity* DataObjectRepository::createActivity(RESQML2_NS::ActivityT
 //*************** WITSML *************
 //************************************
 
+WITSML2_0_NS::Well* DataObjectRepository::createPartialWell(
+	const std::string & guid,
+	const std::string & title)
+{
+	return createPartial<WITSML2_0_NS::Well>(guid, title);
+}
+
 WITSML2_0_NS::Well* DataObjectRepository::createWell(const std::string & guid,
 	const std::string & title)
 {

--- a/src/common/DataObjectRepository.h
+++ b/src/common/DataObjectRepository.h
@@ -1221,6 +1221,10 @@ namespace COMMON_NS
 
 		//*************** WITSML *************
 
+		DLL_IMPORT_OR_EXPORT WITSML2_0_NS::Well* createPartialWell(
+			const std::string & guid,
+			const std::string & title);
+
 		DLL_IMPORT_OR_EXPORT WITSML2_0_NS::Well* createWell(const std::string & guid,
 			const std::string & title);
 

--- a/src/common/HdfProxy.cpp
+++ b/src/common/HdfProxy.cpp
@@ -43,6 +43,9 @@ void HdfProxy::open()
 	if (openingMode == COMMON_NS::DataObjectRepository::READ_ONLY) {
 		if (H5Fis_hdf5((packageDirectoryAbsolutePath + relativeFilePath).c_str()) > 0) {
 			hdfFile = H5Fopen((packageDirectoryAbsolutePath + relativeFilePath).c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
+			if (hdfFile < 0) {
+				throw invalid_argument("Can not open HDF5 file (in read only mode) : " + packageDirectoryAbsolutePath + relativeFilePath);
+			}
 
 			// Check the uuid
 			string hdfUuid = readStringAttribute(".", "uuid");
@@ -67,6 +70,9 @@ void HdfProxy::open()
 		if (hdfFile < 0) {
 			if (H5Fis_hdf5((packageDirectoryAbsolutePath + relativeFilePath).c_str()) > 0) {
 				hdfFile = H5Fopen((packageDirectoryAbsolutePath + relativeFilePath).c_str(), H5F_ACC_RDWR, access_props);
+				if (hdfFile < 0) {
+					throw invalid_argument("Can not open HDF5 file (in read and write mode): " + packageDirectoryAbsolutePath + relativeFilePath);
+				}
 
 				string hdfUuid = readStringAttribute(".", "uuid");
 				if (getUuid() != hdfUuid) {
@@ -112,6 +118,9 @@ void HdfProxy::open()
 #endif
 
 		hdfFile = H5Fcreate((packageDirectoryAbsolutePath + relativeFilePath).c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, access_props);
+		if (hdfFile < 0) {
+			throw invalid_argument("Can not create HDF5 file : " + packageDirectoryAbsolutePath + relativeFilePath);
+		}
 
 		// create an attribute at the file level to store the uuid of the corresponding resqml hdf proxy.
 		hid_t aid = H5Screate(H5S_SCALAR);
@@ -139,10 +148,6 @@ void HdfProxy::open()
 	}
 	else {
 		throw invalid_argument("The HDF5 permission access is unknown.");
-	}
-
-	if (hdfFile < 0) {
-		throw invalid_argument("The HDF5 file " + packageDirectoryAbsolutePath + relativeFilePath + " could not have been created or opened.");
 	}
 }
 

--- a/src/witsml2_0/WellboreCompletion.cpp
+++ b/src/witsml2_0/WellboreCompletion.cpp
@@ -35,8 +35,12 @@ WellboreCompletion::WellboreCompletion(Wellbore* witsmlWellbore,
 	const string & title,
 	const string & wellCompletionName)
 {
-	if (witsmlWellbore == nullptr) throw invalid_argument("A wellbore must be associated to a wellbore completion.");
-	if (wellCompletion == nullptr) throw invalid_argument("A well completion must be associated to a wellbore completion");
+	if (witsmlWellbore == nullptr) {
+		throw invalid_argument("A wellbore must be associated to a wellbore completion.");
+	}
+	if (wellCompletion == nullptr) {
+		throw invalid_argument("A well completion must be associated to a wellbore completion");
+	}
 
 	gsoapProxy2_1 = soap_new_witsml20__WellboreCompletion(witsmlWellbore->getGsoapContext());
 
@@ -97,15 +101,14 @@ void WellboreCompletion::setWellCompletion(WellCompletion* wellCompletion)
 
 void WellboreCompletion::pushBackPerforation(const string & datum,
 	eml21__LengthUom MdUnit,
-	const double & TopMd,
-	const double & BaseMd,
+	double TopMd,
+	double BaseMd,
 	const string & guid
 )
 {
 	witsml20__WellboreCompletion* wellboreCompletion = static_cast<witsml20__WellboreCompletion*>(gsoapProxy2_1);
 
-	if (wellboreCompletion->ContactIntervalSet == nullptr)
-	{
+	if (wellboreCompletion->ContactIntervalSet == nullptr) {
 		wellboreCompletion->ContactIntervalSet = soap_new_witsml20__ContactIntervalSet(gsoapProxy2_1->soap);
 	}
 
@@ -153,7 +156,7 @@ void WellboreCompletion::pushBackPerforationHistory(unsigned int index,
 
 void WellboreCompletion::pushBackPerforationHistory(unsigned int index,
 	gsoap_eml2_1::witsml20__PerforationStatus perforationStatus,
-	const time_t & startDate,
+	time_t startDate,
 	const std::string & guid)
 {
 	witsml20__PerforationSetInterval * perforationSetInterval = getPerforation(index);
@@ -172,8 +175,7 @@ void WellboreCompletion::pushBackPerforationHistory(unsigned int index,
 	perforationStatusHistory->PerforationStatus = soap_new_witsml20__PerforationStatus(gsoapProxy2_1->soap);
 	*perforationStatusHistory->PerforationStatus = perforationStatus;
 
-	if (startDate != -1)
-	{
+	if (startDate != -1) {
 		perforationStatusHistory->StartDate = soap_new_std__string(gsoapProxy2_1->soap);
 		perforationStatusHistory->StartDate->assign(timeTools::convertUnixTimestampToIso(startDate));
 	}
@@ -185,23 +187,26 @@ unsigned int WellboreCompletion::getPerforationCount() const
 {
 	witsml20__WellboreCompletion* wellboreCompletion = static_cast<witsml20__WellboreCompletion*>(gsoapProxy2_1);
 
-	if (wellboreCompletion->ContactIntervalSet == nullptr)
-	{
+	if (wellboreCompletion->ContactIntervalSet == nullptr) {
 		throw invalid_argument("No contact interval exists.");
 	}
 
 	return wellboreCompletion->ContactIntervalSet->PerforationSetInterval.size();
 }
 
+std::string WellboreCompletion::getPerforationUid(unsigned int index) const
+{
+	return getPerforation(index)->uid;
+}
+
 bool WellboreCompletion::hasPerforationMdDatum(unsigned int index) const
 {
-	return (getPerforation(index)->PerforationSetMdInterval != nullptr);
+	return getPerforation(index)->PerforationSetMdInterval != nullptr;
 }
 
 string WellboreCompletion::getPerforationMdDatum(unsigned int index) const
 {
-	if (!hasPerforationMdDatum(index))
-	{
+	if (!hasPerforationMdDatum(index)) {
 		throw invalid_argument("No perforation md datum is defined.");
 	}
 
@@ -210,34 +215,24 @@ string WellboreCompletion::getPerforationMdDatum(unsigned int index) const
 
 bool WellboreCompletion::hasPerforationMdUnit(unsigned int index) const
 {
-	witsml20__PerforationSetInterval * perforationSetInterval = getPerforation(index);
+	witsml20__PerforationSetInterval const * const perforationSetInterval = getPerforation(index);
 
-	if (perforationSetInterval->PerforationSetMdInterval == nullptr)
-	{
-		return false;
-	}
-
-	return perforationSetInterval->PerforationSetMdInterval->MdBase != nullptr ||
-		perforationSetInterval->PerforationSetMdInterval->MdTop != nullptr;
+	return perforationSetInterval->PerforationSetMdInterval == nullptr
+		? false
+		: perforationSetInterval->PerforationSetMdInterval->MdBase != nullptr || perforationSetInterval->PerforationSetMdInterval->MdTop != nullptr;
 }
 
 eml21__LengthUom WellboreCompletion::getPerforationMdUnit(unsigned int index) const
 {
-	if (!hasPerforationMdUnit(index))
-	{
+	if (!hasPerforationMdUnit(index)) {
 		throw invalid_argument("No perforation md unit is defined.");
 	}
 
-	witsml20__PerforationSetInterval * perforationSetInterval = getPerforation(index);
+	witsml20__PerforationSetInterval const * const perforationSetInterval = getPerforation(index);
 
-	if (perforationSetInterval->PerforationSetMdInterval->MdBase != nullptr)
-	{
-		return perforationSetInterval->PerforationSetMdInterval->MdBase->uom;
-	}
-	else
-	{
-		return perforationSetInterval->PerforationSetMdInterval->MdTop->uom;
-	}
+	return perforationSetInterval->PerforationSetMdInterval->MdBase != nullptr
+		? perforationSetInterval->PerforationSetMdInterval->MdBase->uom
+		: perforationSetInterval->PerforationSetMdInterval->MdTop->uom;
 }
 
 string WellboreCompletion::getPerforationMdUnitAsString(unsigned int index) const
@@ -247,20 +242,16 @@ string WellboreCompletion::getPerforationMdUnitAsString(unsigned int index) cons
 
 bool WellboreCompletion::hasPerforationTopMd(unsigned int index) const
 {
-	witsml20__PerforationSetInterval * perforationSetInterval = getPerforation(index);
+	witsml20__PerforationSetInterval const * const perforationSetInterval = getPerforation(index);
 
-	if (perforationSetInterval->PerforationSetMdInterval == nullptr)
-	{
-		return false;
-	}
-
-	return (perforationSetInterval->PerforationSetMdInterval->MdTop != nullptr);
+	return perforationSetInterval->PerforationSetMdInterval == nullptr
+		? false
+		: perforationSetInterval->PerforationSetMdInterval->MdTop != nullptr;
 }
 
 double WellboreCompletion::getPerforationTopMd(unsigned int index) const
 {
-	if (!hasPerforationTopMd(index))
-	{
+	if (!hasPerforationTopMd(index)) {
 		throw invalid_argument("No perforation top md is defined.");
 	}
 
@@ -269,20 +260,16 @@ double WellboreCompletion::getPerforationTopMd(unsigned int index) const
 
 bool WellboreCompletion::hasPerforationBaseMd(unsigned int index) const
 {
-	witsml20__PerforationSetInterval * perforationSetInterval = getPerforation(index);
+	witsml20__PerforationSetInterval const * const perforationSetInterval = getPerforation(index);
 
-	if (perforationSetInterval->PerforationSetMdInterval == nullptr)
-	{
-		return false;
-	}
-
-	return (perforationSetInterval->PerforationSetMdInterval->MdBase != nullptr);
+	return perforationSetInterval->PerforationSetMdInterval == nullptr
+		? false
+		: perforationSetInterval->PerforationSetMdInterval->MdBase != nullptr;
 }
 
 double WellboreCompletion::getPerforationBaseMd(unsigned int index) const
 {
-	if (!hasPerforationBaseMd(index))
-	{
+	if (!hasPerforationBaseMd(index)) {
 		throw invalid_argument("No perforation base md is defined.");
 	}
 
@@ -303,8 +290,7 @@ bool WellboreCompletion::hasPerforationHistoryStatus(unsigned int historyIndex,
 witsml20__PerforationStatus WellboreCompletion::getPerforationHistoryStatus(unsigned int historyIndex,
 	unsigned int perforationIndex) const
 {
-	if (!hasPerforationHistoryStatus(historyIndex, perforationIndex))
-	{
+	if (!hasPerforationHistoryStatus(historyIndex, perforationIndex)) {
 		throw invalid_argument("No perforation history entry is defined.");
 	}
 
@@ -323,8 +309,7 @@ void WellboreCompletion::setPerforationHistoryStatus(unsigned int historyIndex,
 {
 	witsml20__PerforationStatusHistory* perforationStatusHistory = getPerforationHistoryEntry(historyIndex, perforationIndex);
 
-	if (perforationStatusHistory->PerforationStatus == nullptr)
-	{
+	if (perforationStatusHistory->PerforationStatus == nullptr) {
 		perforationStatusHistory->PerforationStatus = soap_new_witsml20__PerforationStatus(gsoapProxy2_1->soap);
 	}
 
@@ -340,23 +325,19 @@ bool WellboreCompletion::hasPerforationHistoryStartDate(unsigned int historyInde
 time_t WellboreCompletion::getPerforationHistoryStartDate(unsigned int historyIndex,
 	unsigned int perforationIndex) const
 {
-	if (!hasPerforationHistoryStartDate(historyIndex, perforationIndex))
-	{
+	if (!hasPerforationHistoryStartDate(historyIndex, perforationIndex)) {
 		throw invalid_argument("No perforation history entry start date is defined.");
 	}
 
-	string startDate = *getPerforationHistoryEntry(historyIndex, perforationIndex)->StartDate;
-
-	return timeTools::convertIsoToUnixTimestamp(startDate);
+	return timeTools::convertIsoToUnixTimestamp(*getPerforationHistoryEntry(historyIndex, perforationIndex)->StartDate);
 }
 
 void WellboreCompletion::setPerforationHistoryStartDate(unsigned int historyIndex,
-	unsigned int perforationIndex, const time_t & startDate) const
+	unsigned int perforationIndex, time_t startDate) const
 {
 	witsml20__PerforationStatusHistory* perforationStatusHistory = getPerforationHistoryEntry(historyIndex, perforationIndex);
 
-	if (perforationStatusHistory->StartDate == nullptr)
-	{
+	if (perforationStatusHistory->StartDate == nullptr) {
 		perforationStatusHistory->StartDate = soap_new_std__string(gsoapProxy2_1->soap);
 	}
 
@@ -372,23 +353,19 @@ bool WellboreCompletion::hasPerforationHistoryEndDate(unsigned int historyIndex,
 time_t WellboreCompletion::getPerforationHistoryEndDate(unsigned int historyIndex,
 	unsigned int perforationIndex) const
 {
-	if (!hasPerforationHistoryEndDate(historyIndex, perforationIndex))
-	{
+	if (!hasPerforationHistoryEndDate(historyIndex, perforationIndex)) {
 		throw invalid_argument("No perforation history entry end date is defined.");
 	}
 
-	string endDate = *getPerforationHistoryEntry(historyIndex, perforationIndex)->EndDate;
-
-	return timeTools::convertIsoToUnixTimestamp(endDate);
+	return timeTools::convertIsoToUnixTimestamp(*getPerforationHistoryEntry(historyIndex, perforationIndex)->EndDate);
 }
 
 void WellboreCompletion::setPerforationHistoryEndDate(unsigned int historyIndex,
-	unsigned int perforationIndex, const time_t & endDate) const
+	unsigned int perforationIndex, time_t endDate) const
 {
 	witsml20__PerforationStatusHistory* perforationStatusHistory = getPerforationHistoryEntry(historyIndex, perforationIndex);
 
-	if (perforationStatusHistory->EndDate == nullptr)
-	{
+	if (perforationStatusHistory->EndDate == nullptr) {
 		perforationStatusHistory->EndDate = soap_new_std__string(gsoapProxy2_1->soap);
 	}
 
@@ -404,8 +381,7 @@ bool WellboreCompletion::hasPerforationHistoryMdDatum(unsigned int historyIndex,
 string WellboreCompletion::getPerforationHistoryMdDatum(unsigned int historyIndex,
 	unsigned int perforationIndex) const
 {
-	if (!hasPerforationHistoryMdDatum(historyIndex, perforationIndex))
-	{
+	if (!hasPerforationHistoryMdDatum(historyIndex, perforationIndex)) {
 		throw invalid_argument("No perforation history entry md datum is defined.");
 	}
 
@@ -415,28 +391,25 @@ string WellboreCompletion::getPerforationHistoryMdDatum(unsigned int historyInde
 bool WellboreCompletion::hasPerforationHistoryMdUnit(unsigned int historyIndex,
 	unsigned int perforationIndex) const
 {
-	witsml20__PerforationStatusHistory* perforationStatusHistory = getPerforationHistoryEntry(historyIndex, perforationIndex);
+	witsml20__PerforationStatusHistory const * const perforationStatusHistory = getPerforationHistoryEntry(historyIndex, perforationIndex);
 
-	if (perforationStatusHistory->PerforationMdInterval == nullptr)
-	{
-		return false;
-	}
-
-	return perforationStatusHistory->PerforationMdInterval->MdBase != nullptr ||
-		perforationStatusHistory->PerforationMdInterval->MdTop != nullptr;
+	return perforationStatusHistory->PerforationMdInterval == nullptr
+		? false
+		: perforationStatusHistory->PerforationMdInterval->MdBase != nullptr ||perforationStatusHistory->PerforationMdInterval->MdTop != nullptr;
 }
 
 eml21__LengthUom WellboreCompletion::getPerforationHistoryMdUnit(unsigned int historyIndex,
 	unsigned int perforationIndex) const
 {
-	if (!hasPerforationHistoryMdUnit(historyIndex, perforationIndex))
-	{
+	if (!hasPerforationHistoryMdUnit(historyIndex, perforationIndex)) {
 		throw invalid_argument("No perforation history entry md unit is defined.");
 	}
 
-	witsml20__PerforationStatusHistory* perforationStatusHistory = getPerforationHistoryEntry(historyIndex, perforationIndex);
+	witsml20__PerforationStatusHistory const * const perforationStatusHistory = getPerforationHistoryEntry(historyIndex, perforationIndex);
 
-	return perforationStatusHistory->PerforationMdInterval->MdBase != nullptr ? perforationStatusHistory->PerforationMdInterval->MdBase->uom : perforationStatusHistory->PerforationMdInterval->MdTop->uom;
+	return perforationStatusHistory->PerforationMdInterval->MdBase != nullptr 
+		? perforationStatusHistory->PerforationMdInterval->MdBase->uom
+		: perforationStatusHistory->PerforationMdInterval->MdTop->uom;
 }
 
 string WellboreCompletion::getPerforationHistoryMdUnitAsString(unsigned int historyIndex,
@@ -448,14 +421,12 @@ string WellboreCompletion::getPerforationHistoryMdUnitAsString(unsigned int hist
 bool WellboreCompletion::hasPerforationHistoryTopMd(unsigned int historyIndex,
 	unsigned int perforationIndex) const
 {
-	witsml20__PerforationStatusHistory* perforationStatusHistory = getPerforationHistoryEntry(historyIndex, perforationIndex);
-	if (perforationStatusHistory == nullptr)
-	{
+	witsml20__PerforationStatusHistory const * const perforationStatusHistory = getPerforationHistoryEntry(historyIndex, perforationIndex);
+	if (perforationStatusHistory == nullptr) {
 		return false;
 	}
 
-	if (perforationStatusHistory->PerforationMdInterval == nullptr)
-	{
+	if (perforationStatusHistory->PerforationMdInterval == nullptr) {
 		return false;
 	}
 
@@ -465,8 +436,7 @@ bool WellboreCompletion::hasPerforationHistoryTopMd(unsigned int historyIndex,
 double WellboreCompletion::getPerforationHistoryTopMd(unsigned int historyIndex,
 	unsigned int perforationIndex) const
 {
-	if (!hasPerforationHistoryTopMd(historyIndex, perforationIndex))
-	{
+	if (!hasPerforationHistoryTopMd(historyIndex, perforationIndex)) {
 		throw invalid_argument("No perforation history entry top md is defined.");
 	}
 
@@ -477,7 +447,7 @@ void WellboreCompletion::setPerforationHistoryTopMd(unsigned int historyIndex,
 	unsigned int perforationIndex,
 	const std::string & datum,
 	gsoap_eml2_1::eml21__LengthUom MdUnit,
-	const double & TopMd)
+	double TopMd)
 {
 	witsml20__PerforationStatusHistory* perforationStatusHistory = getPerforationHistoryEntry(historyIndex, perforationIndex);
 
@@ -494,14 +464,12 @@ void WellboreCompletion::setPerforationHistoryTopMd(unsigned int historyIndex,
 bool WellboreCompletion::hasPerforationHistoryBaseMd(unsigned int historyIndex,
 	unsigned int perforationIndex) const
 {
-	witsml20__PerforationStatusHistory* perforationStatusHistory = getPerforationHistoryEntry(historyIndex, perforationIndex);
-	if (perforationStatusHistory == nullptr)
-	{
+	witsml20__PerforationStatusHistory const * const perforationStatusHistory = getPerforationHistoryEntry(historyIndex, perforationIndex);
+	if (perforationStatusHistory == nullptr) {
 		return false;
 	}
 
-	if (perforationStatusHistory->PerforationMdInterval == nullptr)
-	{
+	if (perforationStatusHistory->PerforationMdInterval == nullptr) {
 		return false;
 	}
 
@@ -523,7 +491,7 @@ void WellboreCompletion::setPerforationHistoryBaseMd(unsigned int historyIndex,
 	unsigned int perforationIndex,
 	const std::string & datum,
 	gsoap_eml2_1::eml21__LengthUom MdUnit,
-	const double & BaseMd)
+	double BaseMd)
 {
 	witsml20__PerforationStatusHistory* perforationStatusHistory = getPerforationHistoryEntry(historyIndex, perforationIndex);
 
@@ -546,15 +514,13 @@ void WellboreCompletion::loadTargetRelationships()
 
 gsoap_eml2_1::witsml20__PerforationSetInterval* WellboreCompletion::getPerforation(unsigned int index) const
 {
-	witsml20__WellboreCompletion* wellboreCompletion = static_cast<witsml20__WellboreCompletion*>(gsoapProxy2_1);
+	witsml20__WellboreCompletion const * const wellboreCompletion = static_cast<witsml20__WellboreCompletion*>(gsoapProxy2_1);
 
-	if (wellboreCompletion->ContactIntervalSet == nullptr)
-	{
+	if (wellboreCompletion->ContactIntervalSet == nullptr) {
 		throw invalid_argument("No contact interval exists.");
 	}
 
-	if (index >= wellboreCompletion->ContactIntervalSet->PerforationSetInterval.size())
-	{
+	if (index >= wellboreCompletion->ContactIntervalSet->PerforationSetInterval.size()) {
 		throw invalid_argument("Perforation index out of range.");
 	}
 
@@ -564,10 +530,9 @@ gsoap_eml2_1::witsml20__PerforationSetInterval* WellboreCompletion::getPerforati
 gsoap_eml2_1::witsml20__PerforationStatusHistory* WellboreCompletion::getPerforationHistoryEntry(unsigned int index,
 	unsigned int perforationIndex) const
 {
-	witsml20__PerforationSetInterval* perforationSetInterval = getPerforation(perforationIndex);
+	witsml20__PerforationSetInterval const * const perforationSetInterval = getPerforation(perforationIndex);
 
-	if (index >= perforationSetInterval->PerforationStatusHistory.size())
-	{
+	if (index >= perforationSetInterval->PerforationStatusHistory.size()) {
 		throw invalid_argument("History index out of range.");
 	}
 

--- a/src/witsml2_0/WellboreCompletion.cpp
+++ b/src/witsml2_0/WellboreCompletion.cpp
@@ -505,6 +505,40 @@ void WellboreCompletion::setPerforationHistoryBaseMd(unsigned int historyIndex,
 	perforationStatusHistory->PerforationMdInterval->MdBase->__item = BaseMd;
 }
 
+bool WellboreCompletion::hasPerforationHistoryComment(unsigned int historyIndex,
+	unsigned int perforationIndex) const
+{
+	witsml20__PerforationStatusHistory const* const perforationStatusHistory = getPerforationHistoryEntry(historyIndex, perforationIndex);
+	if (perforationStatusHistory == nullptr) {
+		return false;
+	}
+
+	return perforationStatusHistory->Comment != nullptr;
+}
+
+std::string WellboreCompletion::getPerforationHistoryComment(unsigned int historyIndex,
+	unsigned int perforationIndex) const
+{
+	if (!hasPerforationHistoryComment(historyIndex, perforationIndex))
+	{
+		throw invalid_argument("No perforation history comment is defined.");
+	}
+
+	return *getPerforationHistoryEntry(historyIndex, perforationIndex)->Comment;
+}
+
+void WellboreCompletion::setPerforationHistoryComment(unsigned int historyIndex,
+	unsigned int perforationIndex,
+	const std::string & comment)
+{
+	witsml20__PerforationStatusHistory* perforationStatusHistory = getPerforationHistoryEntry(historyIndex, perforationIndex);
+
+	if (perforationStatusHistory->Comment == nullptr) {
+		perforationStatusHistory->Comment = soap_new_std__string(gsoapProxy2_1->soap, 1);
+	}
+	perforationStatusHistory->Comment->assign(comment);
+}
+
 void WellboreCompletion::loadTargetRelationships()
 {
 	WellboreObject::loadTargetRelationships();

--- a/src/witsml2_0/WellboreCompletion.h
+++ b/src/witsml2_0/WellboreCompletion.h
@@ -179,6 +179,16 @@ namespace WITSML2_0_NS
 			const std::string & datum,
 			gsoap_eml2_1::eml21__LengthUom MdUnit,
 			double BaseMd);
+			
+		DLL_IMPORT_OR_EXPORT bool hasPerforationHistoryComment(unsigned int historyIndex,
+			unsigned int perforationIndex) const;
+
+		DLL_IMPORT_OR_EXPORT std::string getPerforationHistoryComment(unsigned int historyIndex,
+			unsigned int perforationIndex) const;
+
+		DLL_IMPORT_OR_EXPORT void setPerforationHistoryComment(unsigned int historyIndex,
+			unsigned int perforationIndex,
+			const std::string & comment);				
 
 		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
 		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const { return XML_TAG; }

--- a/src/witsml2_0/WellboreCompletion.h
+++ b/src/witsml2_0/WellboreCompletion.h
@@ -22,6 +22,9 @@ under the License.
 
 namespace WITSML2_0_NS
 {
+	/**
+	* The location/interval of the perforation set and its history.
+	*/
 	class WellboreCompletion : public WITSML2_0_NS::WellboreObject
 	{
 	public:
@@ -53,8 +56,8 @@ namespace WITSML2_0_NS
 
 		DLL_IMPORT_OR_EXPORT void pushBackPerforation(const std::string & datum,
 			gsoap_eml2_1::eml21__LengthUom MdUnit,
-			const double & TopMd,
-			const double & BaseMd, 
+			double TopMd,
+			double BaseMd, 
 			const std::string & guid = "");
 
 		DLL_IMPORT_OR_EXPORT void pushBackPerforationHistory(unsigned int index,
@@ -62,10 +65,12 @@ namespace WITSML2_0_NS
 
 		DLL_IMPORT_OR_EXPORT void pushBackPerforationHistory(unsigned int index,
 			gsoap_eml2_1::witsml20__PerforationStatus perforationStatus,
-			const time_t & startDate,
+			time_t startDate,
 			const std::string & guid = "");
 
 		DLL_IMPORT_OR_EXPORT unsigned int getPerforationCount() const;
+
+		DLL_IMPORT_OR_EXPORT std::string getPerforationUid(unsigned int index) const;
 
 		DLL_IMPORT_OR_EXPORT bool hasPerforationMdDatum(unsigned int index) const;
 	
@@ -113,7 +118,7 @@ namespace WITSML2_0_NS
 			unsigned int perforationIndex) const;
 
 		DLL_IMPORT_OR_EXPORT void setPerforationHistoryStartDate(unsigned int historyIndex,
-			unsigned int perforationIndex, const time_t & startDate) const;
+			unsigned int perforationIndex, time_t startDate) const;
 
 		DLL_IMPORT_OR_EXPORT bool hasPerforationHistoryEndDate(unsigned int historyIndex,
 			unsigned int perforationIndex) const;
@@ -122,7 +127,7 @@ namespace WITSML2_0_NS
 			unsigned int perforationIndex) const;
 
 		DLL_IMPORT_OR_EXPORT void setPerforationHistoryEndDate(unsigned int historyIndex,
-			unsigned int perforationIndex, const time_t & endDate) const;
+			unsigned int perforationIndex, time_t endDate) const;
 		
 		DLL_IMPORT_OR_EXPORT bool hasPerforationHistoryMdDatum(unsigned int historyIndex,
 			unsigned int perforationIndex) const;
@@ -158,7 +163,7 @@ namespace WITSML2_0_NS
 			unsigned int perforationIndex,
 			const std::string & datum,
 			gsoap_eml2_1::eml21__LengthUom MdUnit,
-			const double & TopMd);
+			double TopMd);
 		
 		DLL_IMPORT_OR_EXPORT bool hasPerforationHistoryBaseMd(unsigned int historyIndex,
 			unsigned int perforationIndex) const;
@@ -173,7 +178,7 @@ namespace WITSML2_0_NS
 			unsigned int perforationIndex,
 			const std::string & datum,
 			gsoap_eml2_1::eml21__LengthUom MdUnit,
-			const double & BaseMd);
+			double BaseMd);
 
 		DLL_IMPORT_OR_EXPORT static const char* XML_TAG;
 		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const { return XML_TAG; }

--- a/swig/swigWitsml2_0Include.i
+++ b/swig/swigWitsml2_0Include.i
@@ -506,6 +506,16 @@ namespace WITSML2_0_NS
 			const std::string & datum,
 			gsoap_eml2_1::eml21__LengthUom MdUnit,
 			double BaseMd);
+			
+		bool hasPerforationHistoryComment(unsigned int historyIndex,
+			unsigned int perforationIndex) const;
+
+		std::string getPerforationHistoryComment(unsigned int historyIndex,
+			unsigned int perforationIndex) const;
+
+		void setPerforationHistoryComment(unsigned int historyIndex,
+			unsigned int perforationIndex,
+			const std::string & comment);
 	};
 	
 	class Trajectory : public WellboreObject

--- a/swig/swigWitsml2_0Include.i
+++ b/swig/swigWitsml2_0Include.i
@@ -401,8 +401,8 @@ namespace WITSML2_0_NS
 
 		void pushBackPerforation(const std::string & datum,
 			gsoap_eml2_1::eml21__LengthUom MdUnit,
-			const double & TopMd,
-			const double & BaseMd, 
+			double TopMd,
+			double BaseMd, 
 			const std::string & guid = "");
 
 		void pushBackPerforationHistory(unsigned int index,
@@ -410,10 +410,12 @@ namespace WITSML2_0_NS
 			
 		void pushBackPerforationHistory(unsigned int index,
 			gsoap_eml2_1::witsml20__PerforationStatus perforationStatus,
-			const time_t & startDate,
+			time_t startDate,
 			const std::string & guid = "");	
 
 		unsigned int getPerforationCount() const;
+		
+		std::string getPerforationUid(unsigned int index) const;
 
 		bool hasPerforationMdDatum(unsigned int index) const;
 	
@@ -455,7 +457,7 @@ namespace WITSML2_0_NS
 			unsigned int perforationIndex) const;
 
 		void setPerforationHistoryStartDate(unsigned int historyIndex,
-			unsigned int perforationIndex, const time_t & startDate) const;
+			unsigned int perforationIndex, time_t startDate) const;
 
 		bool hasPerforationHistoryEndDate(unsigned int historyIndex,
 			unsigned int perforationIndex) const;
@@ -464,7 +466,7 @@ namespace WITSML2_0_NS
 			unsigned int perforationIndex) const;
 
 		void setPerforationHistoryEndDate(unsigned int historyIndex,
-			unsigned int perforationIndex, const time_t & endDate) const;
+			unsigned int perforationIndex, time_t endDate) const;
 		
 		bool hasPerforationHistoryMdDatum(unsigned int historyIndex,
 			unsigned int perforationIndex) const;
@@ -491,7 +493,7 @@ namespace WITSML2_0_NS
 			unsigned int perforationIndex,
 			const std::string & datum,
 			gsoap_eml2_1::eml21__LengthUom MdUnit,
-			const double & TopMd);
+			double TopMd);
 		
 		bool hasPerforationHistoryBaseMd(unsigned int historyIndex,
 			unsigned int perforationIndex) const;
@@ -503,7 +505,7 @@ namespace WITSML2_0_NS
 			unsigned int perforationIndex,
 			const std::string & datum,
 			gsoap_eml2_1::eml21__LengthUom MdUnit,
-			const double & BaseMd);
+			double BaseMd);
 	};
 	
 	class Trajectory : public WellboreObject

--- a/test/unitTest.cpp
+++ b/test/unitTest.cpp
@@ -53,6 +53,7 @@ under the License.
 #include "resqml2_0_1test/MultirealPropertyTest.h"
 #include "witsml2_0test/WellTest.h"
 #include "witsml2_0test/Trajectory.h"
+#include "witsml2_0test/Perforation.h"
 
 #ifdef WITH_EXPERIMENTAL
 #include "GraphicalInformationSetTest.h"
@@ -153,7 +154,8 @@ FESAPI_TEST("Export and import a seismic lattice feature", "[seismic]", SeismicL
 FESAPI_TEST("Export and import a seismic horizon grid 2d rep", "[seismic]", Grid2dRepresentationTest)
 FESAPI_TEST("Export and import an horizon on a seismic line", "[seismic]", HorizonOnSeismicLine)
 
-FESAPI_TEST("Export and import a Witsml well", "[well]", WellTest)
-FESAPI_TEST("Export and import a Witsml trajectory", "[well]", Trajectory)
+FESAPI_TEST("Export and import a WITSML well", "[well]", WellTest)
+FESAPI_TEST("Export and import a WITSML trajectory", "[well]", Trajectory)
+FESAPI_TEST("Export and import a WITSML perforation", "[well]", Perforation)
 
 FESAPI_TEST("Export and import some multi realization properties", "[property]", MultirealPropertyTest)

--- a/test/witsml2_0test/Perforation.cpp
+++ b/test/witsml2_0test/Perforation.cpp
@@ -1,0 +1,91 @@
+/*-----------------------------------------------------------------------
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"; you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-----------------------------------------------------------------------*/
+#include "Perforation.h"
+#include "../catch.hpp"
+#include "witsml2_0/Well.h"
+#include "witsml2_0/Wellbore.h"
+#include "witsml2_0/WellCompletion.h"
+#include "witsml2_0/WellboreCompletion.h"
+#include <stdexcept>
+
+using namespace std;
+using namespace witsml2_0test;
+using namespace COMMON_NS;
+
+const char* Perforation::defaultUuid = "d5a528c8-73e7-4bf3-9441-118f8111d56a";
+const char* Perforation::defaultTitle = "WITSML Perforation Test";
+
+Perforation::Perforation(const string & epcDocPath)
+	: AbstractObjectTest(epcDocPath) {
+}
+
+Perforation::Perforation(DataObjectRepository* repo, bool init)
+	: AbstractObjectTest(repo) {
+	if (init)
+		initRepo();
+	else
+		readRepo();
+}
+
+void Perforation::initRepoHandler() {
+	WITSML2_0_NS::Well* well = repo->createPartialWell("", "");
+	WITSML2_0_NS::Wellbore* wellbore = repo->createPartialWellbore("", "");
+	WITSML2_0_NS::WellCompletion* wellCompletion = repo->createWellCompletion(well, "6593d580-2f44-4b18-97ce-8a9cf42a0414", "WellCompletion1");
+	WITSML2_0_NS::WellboreCompletion* wellboreCompletion = repo->createWellboreCompletion(wellbore, wellCompletion, "7bda8ecf-2037-4dc7-8c59-db6ca09f2008", "WellboreCompletion1", "wellCompletionName");
+
+	wellboreCompletion->pushBackPerforation("Mean Sea Level", gsoap_eml2_1::eml21__LengthUom__m, 1970, 1980, "myId");
+	wellboreCompletion->pushBackPerforation("Mean Sea Level", gsoap_eml2_1::eml21__LengthUom__m, 1990, 2000);
+	wellboreCompletion->pushBackPerforationHistory(0);
+	wellboreCompletion->setPerforationHistoryStatus(0, 0, gsoap_eml2_1::witsml20__PerforationStatus__open);
+	wellboreCompletion->setPerforationHistoryTopMd(0, 0, "Mean Sea Level", gsoap_eml2_1::eml21__LengthUom__m, 1970);
+	wellboreCompletion->setPerforationHistoryBaseMd(0, 0, "Mean Sea Level", gsoap_eml2_1::eml21__LengthUom__m, 1980);
+	wellboreCompletion->setPerforationHistoryStartDate(0, 0, 407568645);
+	wellboreCompletion->setPerforationHistoryEndDate(0, 0, 1514764800);
+}
+
+void Perforation::readRepoHandler() {
+	WITSML2_0_NS::WellboreCompletion* wellboreCompletion = repo->getDataObjectByUuid<WITSML2_0_NS::WellboreCompletion>("7bda8ecf-2037-4dc7-8c59-db6ca09f2008");
+	REQUIRE (wellboreCompletion != nullptr);
+
+	REQUIRE(wellboreCompletion->getPerforationCount() == 2);
+	REQUIRE(wellboreCompletion->getPerforationUid(0) == "myId");
+	REQUIRE(wellboreCompletion->hasPerforationMdDatum(0));
+	REQUIRE(wellboreCompletion->getPerforationMdDatum(0) == "Mean Sea Level");
+	REQUIRE(wellboreCompletion->hasPerforationMdUnit(0));
+	REQUIRE(wellboreCompletion->getPerforationMdUnit(0) == gsoap_eml2_1::eml21__LengthUom__m);
+	REQUIRE(wellboreCompletion->hasPerforationTopMd(0));
+	REQUIRE(wellboreCompletion->getPerforationTopMd(0) == 1970);
+	REQUIRE(wellboreCompletion->hasPerforationBaseMd(0));
+	REQUIRE(wellboreCompletion->getPerforationBaseMd(0) == 1980);
+	REQUIRE(wellboreCompletion->getPerforationHistoryCount(0) == 1);
+	REQUIRE(wellboreCompletion->hasPerforationHistoryStatus(0, 0));
+	REQUIRE(wellboreCompletion->getPerforationHistoryStatus(0, 0) == gsoap_eml2_1::witsml20__PerforationStatus__open);
+	REQUIRE(wellboreCompletion->hasPerforationHistoryStartDate(0, 0));
+	REQUIRE(wellboreCompletion->getPerforationHistoryStartDate(0, 0) == 407568645);
+	REQUIRE(wellboreCompletion->hasPerforationHistoryEndDate(0, 0));
+	REQUIRE(wellboreCompletion->getPerforationHistoryEndDate(0, 0) == 1514764800);
+	REQUIRE(wellboreCompletion->hasPerforationHistoryMdDatum(0, 0));
+	REQUIRE(wellboreCompletion->getPerforationHistoryMdDatum(0, 0) == "Mean Sea Level");
+	REQUIRE(wellboreCompletion->hasPerforationHistoryMdUnit(0, 0));
+	REQUIRE(wellboreCompletion->getPerforationHistoryMdUnit(0, 0) == gsoap_eml2_1::eml21__LengthUom__m);
+	REQUIRE(wellboreCompletion->hasPerforationHistoryTopMd(0, 0));
+	REQUIRE(wellboreCompletion->getPerforationHistoryTopMd(0, 0) == 1970);
+	REQUIRE(wellboreCompletion->hasPerforationHistoryBaseMd(0, 0));
+	REQUIRE(wellboreCompletion->getPerforationHistoryBaseMd(0, 0) == 1980);
+}

--- a/test/witsml2_0test/Perforation.cpp
+++ b/test/witsml2_0test/Perforation.cpp
@@ -57,6 +57,7 @@ void Perforation::initRepoHandler() {
 	wellboreCompletion->setPerforationHistoryBaseMd(0, 0, "Mean Sea Level", gsoap_eml2_1::eml21__LengthUom__m, 1980);
 	wellboreCompletion->setPerforationHistoryStartDate(0, 0, 407568645);
 	wellboreCompletion->setPerforationHistoryEndDate(0, 0, 1514764800);
+	wellboreCompletion->setPerforationHistoryComment(0, 0, "Comment");
 }
 
 void Perforation::readRepoHandler() {
@@ -88,4 +89,5 @@ void Perforation::readRepoHandler() {
 	REQUIRE(wellboreCompletion->getPerforationHistoryTopMd(0, 0) == 1970);
 	REQUIRE(wellboreCompletion->hasPerforationHistoryBaseMd(0, 0));
 	REQUIRE(wellboreCompletion->getPerforationHistoryBaseMd(0, 0) == 1980);
+	REQUIRE(wellboreCompletion->getPerforationHistoryComment(0, 0) == "Comment");
 }

--- a/test/witsml2_0test/Perforation.h
+++ b/test/witsml2_0test/Perforation.h
@@ -1,0 +1,53 @@
+/*-----------------------------------------------------------------------
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"; you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-----------------------------------------------------------------------*/
+#pragma once
+
+#include "../AbstractObjectTest.h"
+#include <string>
+
+namespace COMMON_NS {
+	class DataObjectRepository;
+}
+
+namespace witsml2_0test {
+	class Perforation : public commontest::AbstractObjectTest {
+	public:
+		static const char* defaultUuid;
+		static const char* defaultTitle;
+
+		/**
+		* Creation of a testing object from an EPC document path. At serialize() call,
+		* exising .epc file will be erased.
+		* @param epcDocPath the path of the .epc file (including .epc extension)
+		*/
+		Perforation(const std::string & epcDocPath);
+
+		/**
+		* Creation of a testing object from an existing EPC document.
+		* @param repo an existing EPC document
+		* @param init true if this object is created for initialization purpose else false if it is
+		* created for reading purpose. According to init value a iniEpcDoc() or readRepo() is called.
+		*/
+		Perforation(COMMON_NS::DataObjectRepository* repo, bool init);
+	protected:
+		void initRepoHandler();
+		void readRepoHandler();
+	};
+}
+


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Can create partial WITSML well.
Throw exception when the HDF5 file cannot be opened or created.
Add an unit test for perforation

Does this close any currently open issues?
------------------------------------------
No

Where has this been tested?
---------------------------
**Operating System:** Win 64 10

**Platform:** VS 2015 64
