### PR TITLE
Allow a wellbore trajectory without a geometry

### DIFF
--- a/src/common/AbstractHdfProxy.h
+++ b/src/common/AbstractHdfProxy.h
@@ -37,19 +37,19 @@ namespace COMMON_NS
 		/**
 		* @param soapContext	The soap context where the underlying gsoap proxy is going to be created.
 		*/
-		AbstractHdfProxy(const std::string & packageDirAbsolutePath, const std::string & externalFilePath, DataObjectRepository::openingMode hdfPermissionAccess = DataObjectRepository::READ_ONLY);
+		DLL_IMPORT_OR_EXPORT AbstractHdfProxy(const std::string & packageDirAbsolutePath, const std::string & externalFilePath, DataObjectRepository::openingMode hdfPermissionAccess = DataObjectRepository::READ_ONLY);
 
-		AbstractHdfProxy(gsoap_resqml2_0_1::_eml20__EpcExternalPartReference* fromGsoap) :
+		DLL_IMPORT_OR_EXPORT AbstractHdfProxy(gsoap_resqml2_0_1::_eml20__EpcExternalPartReference* fromGsoap) :
 			EpcExternalPartReference(fromGsoap), openingMode(DataObjectRepository::READ_ONLY) {}
 
-		AbstractHdfProxy(gsoap_eml2_1::_eml21__EpcExternalPartReference* fromGsoap) :
+		DLL_IMPORT_OR_EXPORT AbstractHdfProxy(gsoap_eml2_1::_eml21__EpcExternalPartReference* fromGsoap) :
 			EpcExternalPartReference(fromGsoap), openingMode(DataObjectRepository::READ_ONLY) {}
 
 		/**
 		* Instantiate and initialize the gsoap proxy v2.0.1.
 		* This method is defined in order to be used in derived class without having to link to generated gsoap files.
 		*/
-		void initGsoapProxy(COMMON_NS::DataObjectRepository * repo, const std::string & guid, const std::string & title, EmlVersion emlVersion);
+		DLL_IMPORT_OR_EXPORT void initGsoapProxy(COMMON_NS::DataObjectRepository * repo, const std::string & guid, const std::string & title, EmlVersion emlVersion);
 
 	public:  
 		virtual ~AbstractHdfProxy() {}

--- a/src/resqml2_0_1/StratigraphicColumn.cpp
+++ b/src/resqml2_0_1/StratigraphicColumn.cpp
@@ -49,7 +49,7 @@ void StratigraphicColumn::pushBackStratiColumnRank(StratigraphicColumnRankInterp
 
 std::vector<class StratigraphicColumnRankInterpretation *> StratigraphicColumn::getStratigraphicColumnRankInterpretationSet() const
 {
-	return getRepository()->getSourceObjects<StratigraphicColumnRankInterpretation>(this);
+	return getRepository()->getTargetObjects<StratigraphicColumnRankInterpretation>(this);
 }
 
 void StratigraphicColumn::loadTargetRelationships()

--- a/src/resqml2_0_1/WellboreTrajectoryRepresentation.cpp
+++ b/src/resqml2_0_1/WellboreTrajectoryRepresentation.cpp
@@ -19,6 +19,7 @@ under the License.
 #include "resqml2_0_1/WellboreTrajectoryRepresentation.h"
 
 #include <stdexcept>
+#include <limits>
 
 #include "H5public.h"
 
@@ -46,6 +47,8 @@ WellboreTrajectoryRepresentation::WellboreTrajectoryRepresentation(WellboreInter
 	if (dynamic_cast<RESQML2_NS::AbstractLocal3dCrs*>(mdInfo->getLocalCrs()) != nullptr) {
 		rep->MdUom = static_cast<RESQML2_NS::AbstractLocal3dCrs*>(mdInfo->getLocalCrs())->getVerticalCrsUnit();
 	}
+	rep->StartMd = std::numeric_limits<double>::quiet_NaN();
+	rep->FinishMd = std::numeric_limits<double>::quiet_NaN();
 
 	setMdDatum(mdInfo);
 	setInterpretation(interp);
@@ -74,6 +77,15 @@ WellboreTrajectoryRepresentation::WellboreTrajectoryRepresentation(WellboreInter
 	if (dynamic_cast<RESQML2_NS::AbstractLocal3dCrs*>(mdInfo->getLocalCrs()) != nullptr) {
 		rep->MdUom = static_cast<RESQML2_NS::AbstractLocal3dCrs*>(mdInfo->getLocalCrs())->getVerticalCrsUnit();
 	}
+	rep->StartMd = std::numeric_limits<double>::quiet_NaN();
+	rep->FinishMd = std::numeric_limits<double>::quiet_NaN();
+}
+
+void WellboreTrajectoryRepresentation::setMinimalGeometry(double startMd, double endMd)
+{
+	_resqml20__WellboreTrajectoryRepresentation* rep = static_cast<_resqml20__WellboreTrajectoryRepresentation*>(gsoapProxy2_0_1);
+	rep->StartMd = startMd;
+	rep->FinishMd = endMd;
 }
 
 void WellboreTrajectoryRepresentation::setGeometry(double * controlPoints, double startMd, double endMd, unsigned int controlPointCount, int lineKind, COMMON_NS::AbstractHdfProxy * proxy, RESQML2_NS::AbstractLocal3dCrs* localCrs)
@@ -85,7 +97,9 @@ void WellboreTrajectoryRepresentation::setGeometry(double * controlPoints, doubl
 		throw invalid_argument("The control point count cannot be 0.");
 	}
 
-	_resqml20__WellboreTrajectoryRepresentation* rep = static_cast<_resqml20__WellboreTrajectoryRepresentation*>(gsoapProxy2_0_1);
+	setMinimalGeometry(startMd, endMd);
+
+	_resqml20__WellboreTrajectoryRepresentation* const rep = static_cast<_resqml20__WellboreTrajectoryRepresentation*>(gsoapProxy2_0_1);
 
 	if (localCrs == nullptr) {
 		localCrs = getRepository()->getDefaultCrs();
@@ -94,8 +108,6 @@ void WellboreTrajectoryRepresentation::setGeometry(double * controlPoints, doubl
 	rep->Geometry = soap_new_resqml20__ParametricLineGeometry(gsoapProxy2_0_1->soap);
 	resqml20__ParametricLineGeometry* paramLine = soap_new_resqml20__ParametricLineGeometry(gsoapProxy2_0_1->soap);
 	paramLine->LocalCrs = localCrs->newResqmlReference();
-	rep->StartMd = startMd;
-	rep->FinishMd = endMd;
 	rep->Geometry = paramLine;
 
 	paramLine->KnotCount = controlPointCount;

--- a/src/resqml2_0_1/WellboreTrajectoryRepresentation.h
+++ b/src/resqml2_0_1/WellboreTrajectoryRepresentation.h
@@ -45,7 +45,7 @@ namespace RESQML2_0_1_NS
 		* @param interp					The WellboreFeature interpretation the instance represents.
 		* @param guid					The guid to set to the new instance. If empty then a new guid will be generated.
 		* @param title					A title for the instance to create.
-		* @param mdInfo					The MD information of the trajectory, mainly the well reference point.
+		* @param mdInfo					The MD information of the trajectory, mainly the well reference point. The uom used for the mdInfo coordinates must also be used for the start and end MD of the trajectory.
 		*/
 		WellboreTrajectoryRepresentation(class WellboreInterpretation * interp, const std::string & guid, const std::string & title, RESQML2_NS::MdDatum * mdInfo);
 
@@ -65,8 +65,19 @@ namespace RESQML2_0_1_NS
 		DLL_IMPORT_OR_EXPORT virtual std::string getXmlTag() const {return XML_TAG;}
 
 		/*
-		*  Set the geometry of the representation by means of a parametric line without MD information.
+		* Set the geometry of the representation by means of a parametric line without MD information.
+		* @param startMd						The start MD of the trajectory. Uom is the same as the one for the assocaited MdDatum coordinates.
+		* @param endMd							The end MD of the trajectory. Uom is the same as the one for the assocaited MdDatum coordinates.
+		* @localCrs								The local CRS where the control points are given.
+		*										If null, then the default Local CRS of the DataObject repository will be arbitrarily selected.
+		*/
+		DLL_IMPORT_OR_EXPORT void setMinimalGeometry(double startMd, double endMd);
+
+		/*
+		* Set the geometry of the representation by means of a parametric line without MD information (only start and end MD).
 		* @param controlPoints					All the control points of all the cubic parametric lines. They are ordered by parametric line first.
+		* @param startMd						The start MD of the trajectory.
+		* @param endMd							The end MD of the trajectory.
 		* @param controlPointCount				The count of control points and control point parameters per cubic parametric line.
 		* @param lineKind						Integer indicating the parametric line kind: 0 for vertical, 1 for linear spline, 2 for natural cubic spline, 3 for cubic spline, 4 for z linear cubic spline, 5 for minimum-curvature spline, (-1) for null: no line
 		* @param proxy							The HDF proxy which indicates in which HDF5 file the control points and its parameters will be stored.
@@ -78,7 +89,7 @@ namespace RESQML2_0_1_NS
 		DLL_IMPORT_OR_EXPORT void setGeometry(double * controlPoints, double startMd, double endMd, unsigned int controlPointCount, int lineKind, COMMON_NS::AbstractHdfProxy* proxy = nullptr, RESQML2_NS::AbstractLocal3dCrs* localCrs = nullptr);
 
 		/*
-		*  Set the geometry of the representation by means of one natural cubic parametric line.
+		* Set the geometry of the representation by means of a parametric line with MD information.
 		* @param controlPoints					All the control points of all the cubic parametric lines. They are ordered by parametric line first.
 		* @param controlPointParameters			The arrays of control point parameters (ordered regarding the control points). It corresponds to the MD values in a WellboreFeature context.
 		* @param controlPointCount				The count of control points and control point parameters per cubic parametric line.
@@ -93,7 +104,7 @@ namespace RESQML2_0_1_NS
 			COMMON_NS::AbstractHdfProxy* proxy = nullptr, RESQML2_NS::AbstractLocal3dCrs* localCrs = nullptr);
 
 		/*
-		*  Set the geometry of the representation by means of one cubic parametric line.
+		* Set the geometry of the representation by means of a parametric line with MD and tangent vector information.
 		* @param controlPoints					All the control points of all the cubic parametric lines. They are ordered by parametric line first.
 		* @param tangentVectors					All the tangent vectors of all the control points of all the cubic parametric lines. They are ordered according to the control points.
 		* @param controlPointParameters			The arrays of control point parameters (ordered regarding the control points). It corresponds to the MD values in a WellboreFeature context.

--- a/swig/swigResqml2_0_1Include.i
+++ b/swig/swigResqml2_0_1Include.i
@@ -2772,6 +2772,8 @@ namespace RESQML2_0_1_NS
 		std::string getMdDatumUuid() const;
 		RESQML2_NS::MdDatum * getMdDatum() const;
 		
+		void setMinimalGeometry(double startMd, double endMd);
+		
 		void setGeometry(double * controlPoints, double startMd, double endMd, unsigned int controlPointCount, int lineKind, COMMON_NS::AbstractHdfProxy* proxy = nullptr, RESQML2_NS::AbstractLocal3dCrs* localCrs = nullptr);
 
 		void setGeometry(double * controlPoints, double* controlPointParameters, unsigned int controlPointCount, int lineKind,


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
* Allow to derive from AbstractHdfProxy when using fesapi as a DLL
* Bug fix : cannot get StratigraphicColumnRankInterpretationSet from StratigraphicColumn

Does this close any currently open issues?
------------------------------------------
No

Where has this been tested?
---------------------------
**Operating System:** Win 64 10

**Platform:** Vs 2015 64
