### PR TITLE
pillarGeometryIsDefined must override pillarKind information

### DIFF
--- a/example/example.cpp
+++ b/example/example.cpp
@@ -4167,6 +4167,12 @@ void deserialize(const string & inputFile)
 							cout << "Pillar index " << pillarIndex << " with kind " << pillarKind[pillarIndex] << endl;
 						}
 						delete[] pillarKind;
+						bool* pillarIsDefined = new bool[paramIjkGrid->getPillarCount()];
+						paramIjkGrid->getPillarGeometryIsDefined(pillarIsDefined);
+						for (size_t pillarIndex = 0; pillarIndex < paramIjkGrid->getPillarCount() && pillarIndex < 10; ++pillarIndex) {
+							cout << "Pillar index " << pillarIndex << " is defined : " << pillarIsDefined[pillarIndex] << endl;
+						}
+						delete[] pillarIsDefined;
 					}
 
 					unsigned int patchCount = ijkGrid->getPatchCount();

--- a/swig/swigResqml2Include.i
+++ b/swig/swigResqml2Include.i
@@ -518,6 +518,7 @@ namespace RESQML2_NS
 		void setTimeStep(const unsigned int & timeStep);
 		TimeSeries* getTimeSeries() const;
 		time_t getTimestamp() const;
+		unsigned int getTimeIndex() const;
 	};
 	
 	class AbstractValuesProperty : public RESQML2_NS::AbstractProperty


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
pillarGeometryIsDefined must override pillarKind information
Also port getTimeIndex() method in swig

Does this close any currently open issues?
------------------------------------------
Fix #199 

Where has this been tested?
---------------------------
**Operating System:**win 64 10

**Platform:** VS 2015 64
