### PR TITLE
Support for HdfProxyFactory

### DIFF
--- a/src/common/AbstractHdfProxy.h
+++ b/src/common/AbstractHdfProxy.h
@@ -29,6 +29,10 @@ namespace COMMON_NS
 	class AbstractHdfProxy : public EpcExternalPartReference
 	{
 	protected:
+		/**
+		* Only to be used in partial transfer context
+		*/
+		AbstractHdfProxy(gsoap_resqml2_0_1::eml20__DataObjectReference* partialObject) : COMMON_NS::EpcExternalPartReference(partialObject) {}
 
 		std::string packageDirectoryAbsolutePath;												/// The directory where the EPC document is stored.
 		std::string relativeFilePath;															/// Must be relative to the location of the package

--- a/src/common/DataObjectRepository.h
+++ b/src/common/DataObjectRepository.h
@@ -161,6 +161,7 @@ namespace COMMON_NS
 {
 	class AbstractObject;
 	class AbstractHdfProxy;
+	class HdfProxyFactory;
 	class PropertyKind;
 	class GraphicalInformationSet;
 
@@ -191,6 +192,8 @@ namespace COMMON_NS
 
 		COMMON_NS::AbstractHdfProxy* defaultHdfProxy;
 		RESQML2_NS::AbstractLocal3dCrs* defaultCrs;
+
+		COMMON_NS::HdfProxyFactory* hdfProxyFactory;
 
 		/**
 		* Set the stream of the curent gsoap context.
@@ -260,6 +263,11 @@ namespace COMMON_NS
 		DLL_IMPORT_OR_EXPORT void addRelationship(COMMON_NS::AbstractObject * source, COMMON_NS::AbstractObject * target);
 
 		/**
+		* Set the factory used to create Hdf Proxy
+		*/
+		DLL_IMPORT_OR_EXPORT void setHdfProxyFactory(COMMON_NS::HdfProxyFactory * factory);
+
+		/**
 		* Get the target objects of a particular data objects.
 		* Throw an exception if the target objects have not been defined yet.
 		*/
@@ -296,37 +304,6 @@ namespace COMMON_NS
 		* @param proxy	The dataobject to add or replace.
 		*/
 		DLL_IMPORT_OR_EXPORT void addOrReplaceDataObject(COMMON_NS::AbstractObject* proxy);
-
-		/**
-		* This method allows to use a different behaviour for gettting numerical data from where they are persisted.
-		* NumericalValueBase must be a child of COMMON_NS::EpcExternalPartReference
-		*/
-		template <class NumericalValueBase>
-		NumericalValueBase* addOrReplaceEpcExternalPartReference2_0(const std::string & xml)
-		{
-			std::istringstream iss(xml);
-			setGsoapStream(&iss);
-			gsoap_resqml2_0_1::_eml20__EpcExternalPartReference* read = gsoap_resqml2_0_1::soap_new_eml20__obj_USCOREEpcExternalPartReference(gsoapContext);
-			soap_read_eml20__obj_USCOREEpcExternalPartReference(gsoapContext, read);
-
-			if (gsoapContext->error != SOAP_OK) {
-				std::ostringstream oss;
-				soap_stream_fault(gsoapContext, oss);
-				return nullptr;
-			}
-			else {
-				NumericalValueBase* obj = getDataObjectByUuid<NumericalValueBase>(read->uuid);
-				if (obj == nullptr) {
-					NumericalValueBase* wrapper = new NumericalValueBase(read);
-					addOrReplaceDataObject(wrapper);
-					return wrapper;
-				}
-				else { // replacement
-					obj->setGsoapProxy(read);
-					return obj;
-				}
-			}
-		}
 
 		/**
 		* Add a dataobject to the repository based on its Energistics XML definition.

--- a/src/common/EpcDocument.h
+++ b/src/common/EpcDocument.h
@@ -29,9 +29,6 @@ under the License.
 
 namespace COMMON_NS
 {
-	class AbstractObject;
-	class AbstractHdfProxy;
-
 	/**
 	* This class allows an access to a memory package representing an EPC document.
 	*/

--- a/src/common/EpcExternalPartReference.h
+++ b/src/common/EpcExternalPartReference.h
@@ -24,6 +24,12 @@ namespace COMMON_NS
 {
 	class EpcExternalPartReference : public COMMON_NS::AbstractObject
 	{
+	protected:
+		/**
+		* Only to be used in partial transfer context
+		*/
+		EpcExternalPartReference(gsoap_resqml2_0_1::eml20__DataObjectReference* partialObject) : COMMON_NS::AbstractObject(partialObject) {}
+
 	public:
 		/**
 		* @param packageDirAbsolutePath		The directory where the EPC document is stored. Must end with a slash or back-slash

--- a/src/common/HdfProxy.h
+++ b/src/common/HdfProxy.h
@@ -133,6 +133,11 @@ namespace COMMON_NS
 	public:
 
 		/**
+		* Only to be used in partial transfer context
+		*/
+		HdfProxy(gsoap_resqml2_0_1::eml20__DataObjectReference* partialObject) : AbstractHdfProxy(partialObject), hdfFile(-1), compressionLevel(0) {}
+
+		/**
 		* Destructor.
 		* Close the hdf file.
 		*/

--- a/src/common/HdfProxyFactory.h
+++ b/src/common/HdfProxyFactory.h
@@ -1,0 +1,53 @@
+/*-----------------------------------------------------------------------
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"; you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-----------------------------------------------------------------------*/
+#pragma once
+
+#include "../resqml2_0_1/HdfProxy.h"
+
+namespace COMMON_NS
+{
+	class HdfProxyFactory
+	{
+	public:
+
+		DLL_IMPORT_OR_EXPORT virtual ~HdfProxyFactory() {}
+
+		/**
+		* Only to be used in partial transfer context
+		*/
+		DLL_IMPORT_OR_EXPORT virtual AbstractHdfProxy* make(gsoap_resqml2_0_1::eml20__DataObjectReference* partialObject) {
+			return new RESQML2_0_1_NS::HdfProxy(partialObject);
+		}
+
+		/**
+		* Creates an instance of this class by wrapping a gsoap instance.
+		*/
+		DLL_IMPORT_OR_EXPORT virtual AbstractHdfProxy* make(gsoap_resqml2_0_1::_eml20__EpcExternalPartReference* fromGsoap) {
+			return new RESQML2_0_1_NS::HdfProxy(fromGsoap);
+		}
+		
+		/**
+		* Creates an instance of this class for serialization purpose.
+		*/
+		DLL_IMPORT_OR_EXPORT virtual AbstractHdfProxy* make(COMMON_NS::DataObjectRepository * repo, const std::string & guid, const std::string & title, const std::string & packageDirAbsolutePath, const std::string & externalFilePath, COMMON_NS::DataObjectRepository::openingMode hdfPermissionAccess = COMMON_NS::DataObjectRepository::READ_ONLY) {
+			return new RESQML2_0_1_NS::HdfProxy(repo, guid, title, packageDirAbsolutePath, externalFilePath, hdfPermissionAccess);
+		}
+
+	};
+}

--- a/src/common/HdfProxyROS3Factory.h
+++ b/src/common/HdfProxyROS3Factory.h
@@ -1,0 +1,52 @@
+/*-----------------------------------------------------------------------
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"; you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-----------------------------------------------------------------------*/
+#pragma once
+
+#include "HdfProxyFactory.h"
+
+#include "../resqml2_0_1/HdfProxyROS3.h"
+
+namespace COMMON_NS
+{
+	class HdfProxyROS3Factory : public HdfProxyFactory
+	{
+	public:
+
+		std::string secret_id;
+		std::string secret_key;
+
+		HdfProxyROS3Factory() {}
+
+		 ~HdfProxyROS3Factory() {}
+
+		 /**
+		 * Only to be used in partial transfer context
+		 */
+		 virtual AbstractHdfProxy* make(gsoap_resqml2_0_1::eml20__DataObjectReference* partialObject) {
+			 return new RESQML2_0_1_NS::HdfProxyROS3(partialObject, secret_id, secret_key);
+		 }
+
+		/**
+		* Creates an instance of this class by wrapping a gsoap instance.
+		*/
+		virtual AbstractHdfProxy* make(gsoap_resqml2_0_1::_eml20__EpcExternalPartReference* fromGsoap) {
+			return new RESQML2_0_1_NS::HdfProxyROS3(fromGsoap, secret_id, secret_key);
+		}
+	};
+}

--- a/src/epc/CoreProperty.cpp
+++ b/src/epc/CoreProperty.cpp
@@ -28,18 +28,18 @@ CoreProperty::CoreProperty() :
 {
 }
 
-CoreProperty::CoreProperty(const TypeProperty & pType):
+CoreProperty::CoreProperty(TypeProperty pType):
 	type(pType), value()
 {
 }
 
-CoreProperty::CoreProperty(const TypeProperty & pType, const string & pValue):
+CoreProperty::CoreProperty(TypeProperty pType, const string & pValue):
 	type(pType), value()
 {
 	value.push_back(pValue);
 }
 
-CoreProperty::CoreProperty(const TypeProperty & pType, const std::vector<std::string> & pValue):
+CoreProperty::CoreProperty(TypeProperty pType, const std::vector<std::string> & pValue):
 	type(pType), value(pValue)
 {
 }
@@ -54,17 +54,17 @@ CoreProperty::TypeProperty CoreProperty::getTypeProperty() const
 	return type;
 }
 
-void CoreProperty::setTypeProperty(const TypeProperty & corePropertyType)
+void CoreProperty::setTypeProperty(TypeProperty corePropertyType)
 {
 	type = corePropertyType;
 }
 
-vector<string> CoreProperty::getAllValue() const
+const vector<string>& CoreProperty::getAllValue() const
 {
 	return value;
 }
 
-string CoreProperty::getValue(const int & index) const
+string CoreProperty::getValue(size_t index) const
 {
 	return value[index];
 }
@@ -87,14 +87,12 @@ string CoreProperty::toString() const
 		return "<dc:identifier>" + getValue() + "</dc:identifier>";
 	case keywords:
 		{
-			vector<string> wk_Vector = getAllValue();
-			unsigned int wk_SizeVector = wk_Vector.size();
+			const vector<string> wk_Vector = getAllValue();
 
 			ostringstream oss;
 			oss << "<keywords xml:lang=\"" << wk_Vector[0].substr(0,5) << "\"> " << wk_Vector[0].substr(5,wk_Vector[0].size()) << endl;
 		
-			for (unsigned int i = 1; i < wk_SizeVector; i++)
-			{
+			for (size_t i = 1; i < wk_Vector.size(); ++i) {
 				oss << "<value xml:lang=\"" << wk_Vector[i].substr(0,5) << "\">" << wk_Vector[i].substr(5,wk_Vector[i].size()) << "</value>" << endl; 
 			}
 
@@ -234,18 +232,3 @@ void CoreProperty::setVersion(std::string pValue)
 	value.erase(value.begin(), value.end());
 	value.push_back(pValue);
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/epc/CoreProperty.h
+++ b/src/epc/CoreProperty.h
@@ -51,9 +51,9 @@ namespace epc
 		};
 
 		CoreProperty();
-		CoreProperty(const TypeProperty & pType);
-		CoreProperty(const TypeProperty & pType, const std::string & pValue);
-		CoreProperty(const TypeProperty & pType, const std::vector<std::string> & pValue);
+		CoreProperty(TypeProperty pType);
+		CoreProperty(TypeProperty pType, const std::string & pValue);
+		CoreProperty(TypeProperty pType, const std::vector<std::string> & pValue);
 		~CoreProperty() {}
 
 		/**
@@ -69,18 +69,18 @@ namespace epc
 		/**
 		* Set the type of the core property
 		*/
-		void setTypeProperty(const TypeProperty & corePropertyType);
+		void setTypeProperty(TypeProperty corePropertyType);
 
 		/**
 		* Get all the string values. Relevant only for some core properties which can have several string values (such as keywords)
 		*/
-		std::vector<std::string> getAllValue() const;
+		const std::vector<std::string>& getAllValue() const;
 
 		/**
 		* Get the first string value of the core property.
 		* Usually this method is the common one for retrieving string value of a core property since most of timeonly one string value is necessary for one core property.
 		*/
-		std::string getValue(const int & index = 0) const;
+		std::string getValue(size_t index = 0) const;
 
 		/**
 		* Serialize the core property into an XML element embeded into a string.

--- a/src/epc/FilePart.cpp
+++ b/src/epc/FilePart.cpp
@@ -56,7 +56,7 @@ const FileRelationship & FilePart::getFileRelationship() const
 	return fileRelationship;
 }
 
-Relationship FilePart::getIndexRelationship(const int & index) const
+Relationship FilePart::getIndexRelationship(int index) const
 {
 	return fileRelationship.getIndexRelationship(index);
 }
@@ -80,7 +80,7 @@ void FilePart::setFinalPathName(const string & finalPath)
 	fileRelationship.setPathName(wkRelsPathname);
 }
 
-void FilePart::createRelationship(const std::string & rsTarget, const std::string & rsType,const std::string & rsId, const bool & internalTarget)
+void FilePart::createRelationship(const std::string & rsTarget, const std::string & rsType,const std::string & rsId, bool internalTarget)
 {
 	Relationship rel(rsTarget, rsType, rsId, internalTarget);
 	fileRelationship.addRelationship(rel);

--- a/src/epc/FilePart.h
+++ b/src/epc/FilePart.h
@@ -46,7 +46,7 @@ namespace epc
 		// ACCESSORS
 		const std::string & getFinalPathName() const;
 		const FileRelationship & getFileRelationship() const;
-		Relationship getIndexRelationship(const int & index) const;
+		Relationship getIndexRelationship(int index) const;
 
 		void setFinalPathName(const std::string & finalPath);
 
@@ -58,7 +58,7 @@ namespace epc
 		/**
 		* Creates a new relationship into the relationship set of the part according to the supplied parameters
 		*/
-		void createRelationship(const std::string & rsTarget, const std::string & rsType,const std::string & rsId, const bool & internalTarget = true);
+		void createRelationship(const std::string & rsTarget, const std::string & rsType,const std::string & rsId, bool internalTarget = true);
 	};
 }
 

--- a/src/epc/FileRelationship.cpp
+++ b/src/epc/FileRelationship.cpp
@@ -24,10 +24,6 @@ under the License.
 using namespace std; // in order not to prefix by "std::" for each class in the "std" namespace. Never use "using namespace" in *.h file but only in *.cpp file!!!
 using namespace epc; // in order not to prefix by "epc::" for each class in the "epc" namespace. Never use "using namespace" in *.h file but only in *.cpp file!!!
 
-FileRelationship::FileRelationship()
-{
-}
-
 FileRelationship::FileRelationship(const Relationship & frRelationship) : pathName("_rels\\.rels"), relationship()
 {
 	relationship.push_back(frRelationship);
@@ -42,17 +38,7 @@ bool FileRelationship::isEmpty() const
 	return relationship.empty();
 }
 
-string FileRelationship::getPathName() const
-{
-	return pathName;
-}
-
-vector<Relationship> FileRelationship::getAllRelationship() const
-{
-	return relationship;
-}
-
-Relationship FileRelationship::getIndexRelationship(const int & index) const
+Relationship FileRelationship::getIndexRelationship(size_t index) const
 {
 	return relationship[index];
 }
@@ -66,8 +52,7 @@ string FileRelationship::toString() const
 		oss << "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" << endl << "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">" << endl;
 
 		// parcourir le vector...
-		for (size_t i = 0; i < relationship.size(); ++i)
-		{
+		for (size_t i = 0; i < relationship.size(); ++i) {
 			oss << "\t" << relationship[i].toString() << endl;
 		}
 
@@ -75,11 +60,6 @@ string FileRelationship::toString() const
 		oss << "</Relationships>" << endl;
 	}
 	return oss.str();
-}
-
-void FileRelationship::setPathName(const std::string & frPathName)
-{
-	pathName = frPathName;
 }
 
 void FileRelationship::addRelationship(const Relationship & frRelationship)
@@ -158,19 +138,3 @@ void FileRelationship::readFromString(const string & textInput)
 			pos = textInput.find("Relationship>", end + 1);
 	}
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/epc/FileRelationship.h
+++ b/src/epc/FileRelationship.h
@@ -36,19 +36,19 @@ namespace epc
 
 	public:
 		// CONSTRUCTORS
-		FileRelationship();
+		FileRelationship() {}
 		FileRelationship(const Relationship & frRelationship);
 		FileRelationship(const std::vector<Relationship> & frRelationship);
 		~FileRelationship() {}
 
 		// ACCESSORS
 		bool isEmpty() const;
-		std::string getPathName() const;
-		std::vector<Relationship> getAllRelationship() const;
-		Relationship getIndexRelationship(const int & index) const;
+		const std::string& getPathName() const { return pathName; }
+		const std::vector<Relationship>& getAllRelationship() const { return relationship; }
+		Relationship getIndexRelationship(size_t index) const;
 		std::string toString() const;
 
-		void setPathName(const std::string & frPathName);
+		void setPathName(const std::string & frPathName) { pathName = frPathName; }
 		void addRelationship(const Relationship & frRelationship);
 
 		/**

--- a/src/resqml2_0_1/AbstractStratigraphicOrganizationInterpretation.cpp
+++ b/src/resqml2_0_1/AbstractStratigraphicOrganizationInterpretation.cpp
@@ -35,10 +35,10 @@ unsigned int AbstractStratigraphicOrganizationInterpretation::getGridRepresentat
 	const size_t count = getGridRepresentations().size();
 
 	if (count > (std::numeric_limits<unsigned int>::max)()) {
-		throw out_of_range("Too moch associated grids");
+		throw out_of_range("Too much associated grids");
 	}
 
-	return count;
+	return static_cast<unsigned int>(count);
 }
 
 RESQML2_NS::AbstractGridRepresentation * AbstractStratigraphicOrganizationInterpretation::getGridRepresentation(unsigned int index) const

--- a/src/resqml2_0_1/BlockedWellboreRepresentation.cpp
+++ b/src/resqml2_0_1/BlockedWellboreRepresentation.cpp
@@ -141,7 +141,7 @@ ULONG64 BlockedWellboreRepresentation::getCellCount() const
 	return static_cast<_resqml20__BlockedWellboreRepresentation*>(gsoapProxy2_0_1)->CellCount;
 }
 
-unsigned int BlockedWellboreRepresentation::getGridIndices(unsigned int * gridIndices) const
+LONG64 BlockedWellboreRepresentation::getGridIndices(unsigned int * gridIndices) const
 {
 	_resqml20__BlockedWellboreRepresentation* rep = static_cast<_resqml20__BlockedWellboreRepresentation*>(gsoapProxy2_0_1);
 
@@ -161,7 +161,7 @@ unsigned int BlockedWellboreRepresentation::getGridIndices(unsigned int * gridIn
 		throw std::logic_error("Not implemented yet");
 	}
 
-	return (numeric_limits<unsigned int>::max)();
+	return (numeric_limits<LONG64>::max)();
 }
 
 void BlockedWellboreRepresentation::pushBackSupportingGridRepresentation(RESQML2_NS::AbstractGridRepresentation * supportingGridRep)

--- a/src/resqml2_0_1/BlockedWellboreRepresentation.h
+++ b/src/resqml2_0_1/BlockedWellboreRepresentation.h
@@ -80,7 +80,7 @@ namespace RESQML2_0_1_NS
 		* Size of array = IntervalCount on the wellbore frame rep. The grids (and there indices) are defined using pushBackSupportingGridRepresentation method.
 		* @return nullValue
 		*/
-		DLL_IMPORT_OR_EXPORT unsigned int getGridIndices(unsigned int * gridIndices) const;
+		DLL_IMPORT_OR_EXPORT LONG64 getGridIndices(unsigned int * gridIndices) const;
 
 		/**
 		 * Pushes back a grid representation which is one of the support of this representation.

--- a/src/resqml2_0_1/HdfProxy.h
+++ b/src/resqml2_0_1/HdfProxy.h
@@ -25,6 +25,12 @@ namespace RESQML2_0_1_NS
 	class HdfProxy : public COMMON_NS::HdfProxy
 	{
 	public:
+
+		/**
+		* Only to be used in partial transfer context
+		*/
+		DLL_IMPORT_OR_EXPORT HdfProxy(gsoap_resqml2_0_1::eml20__DataObjectReference* partialObject) : COMMON_NS::HdfProxy(partialObject) {}
+
 		/**
 		* Creates an instance of this class in a gsoap context.
 		* @param repo				The repo where the underlying gsoap proxy is going to be created.
@@ -33,17 +39,17 @@ namespace RESQML2_0_1_NS
 		* @packageDirAbsolutePath	The directory where the EPC document is stored. Must end with a slash or back-slash
 		* @relativeFilePath			The relative file path of the associated HDF file. It is relative to the location of the package
 		*/
-		HdfProxy(COMMON_NS::DataObjectRepository * repo, const std::string & guid, const std::string & title, const std::string & packageDirAbsolutePath, const std::string & externalFilePath, COMMON_NS::DataObjectRepository::openingMode hdfPermissionAccess = COMMON_NS::DataObjectRepository::READ_ONLY);
+		DLL_IMPORT_OR_EXPORT HdfProxy(COMMON_NS::DataObjectRepository * repo, const std::string & guid, const std::string & title, const std::string & packageDirAbsolutePath, const std::string & externalFilePath, COMMON_NS::DataObjectRepository::openingMode hdfPermissionAccess = COMMON_NS::DataObjectRepository::READ_ONLY);
 
-		HdfProxy(gsoap_resqml2_0_1::_eml20__EpcExternalPartReference* fromGsoap) :
+		DLL_IMPORT_OR_EXPORT HdfProxy(gsoap_resqml2_0_1::_eml20__EpcExternalPartReference* fromGsoap) :
 			COMMON_NS::HdfProxy(fromGsoap) {}
 
-		~HdfProxy() {}
+		DLL_IMPORT_OR_EXPORT ~HdfProxy() {}
 
 		/**
 		* Get the XML namespace for the tags for the XML serialization of this instance
 		*/
-		std::string getXmlNamespace() const;
+		DLL_IMPORT_OR_EXPORT std::string getXmlNamespace() const;
 
 	private:
 		static const char * RESQML_ROOT_GROUP;

--- a/src/resqml2_0_1/HdfProxyROS3.cpp
+++ b/src/resqml2_0_1/HdfProxyROS3.cpp
@@ -1,0 +1,69 @@
+/*-----------------------------------------------------------------------
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"; you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-----------------------------------------------------------------------*/
+#include "HdfProxyROS3.h"
+
+#include <stdexcept>
+
+#include <hdf5.h>
+
+using namespace std;
+using namespace RESQML2_0_1_NS;
+
+void HdfProxyROS3::open()
+{
+#if H5_VERSION_GE(1, 10, 6)
+	if (hdfFile != -1) {
+		close();
+	}
+
+	if (openingMode == COMMON_NS::DataObjectRepository::READ_ONLY) {
+		H5FD_ros3_fapl_t fa = { 1, 0, "", "", "" }; // Only non authenticate mode is supported buy fesapi so far.
+		if (!secret_id.empty() && !secret_key.empty()) {
+			strcpy(fa.aws_region, packageDirectoryAbsolutePath.c_str());
+			strcpy(fa.secret_id, secret_id.c_str());
+			strcpy(fa.secret_key, secret_key.c_str());
+		}
+
+		/* create and set fapl entry */
+		hid_t fapl_id = H5Pcreate(H5P_FILE_ACCESS);
+		if (fapl_id < 0) {
+			throw invalid_argument("Cannot create the file property.");
+		}
+		if (H5Pset_fapl_ros3(fapl_id, &fa) < 0) {
+			throw invalid_argument("Cannot set the ROS3 information to the file property.");
+		}
+
+		hdfFile = H5Fopen(relativeFilePath.c_str(), H5F_ACC_RDONLY, fapl_id);
+		if (hdfFile < 0) {
+			throw invalid_argument("Can not open HDF5 file (in read only mode on AWS S3) on region \"" + packageDirectoryAbsolutePath + "\" and URL \"" + relativeFilePath + "\"");
+		}
+
+		// Check the uuid
+		string hdfUuid = readStringAttribute(".", "uuid");
+		if (getUuid() != hdfUuid) {
+			getRepository()->addWarning("The uuid \"" + hdfUuid + "\" attribute of the HDF5 file is not the same as the uuid \"" + getUuid() + "\" of the xml EpcExternalPart.");
+		}
+	}
+	else {
+		throw invalid_argument("HDF5 file on an AWS bucket can only be open in read only mode for now.");
+	}
+#else
+	throw logic_error("ROS3 VFD is only supported starting from HDF 1.10.6 release.");
+#endif
+}

--- a/src/resqml2_0_1/HdfProxyROS3.h
+++ b/src/resqml2_0_1/HdfProxyROS3.h
@@ -1,0 +1,51 @@
+/*-----------------------------------------------------------------------
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"; you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-----------------------------------------------------------------------*/
+#pragma once
+
+#include "HdfProxy.h"
+
+namespace RESQML2_0_1_NS
+{
+	/**
+	* This class allows to open an HDF5 file for reading only which is located on an AWS S3 bucket.
+	*/
+	class HdfProxyROS3 : public RESQML2_0_1_NS::HdfProxy
+	{
+		// aws_region is assumed to be managed by means of inherited setRootPath method
+		std::string secret_id;
+		std::string secret_key;
+
+	public:
+
+		/**
+		* Only to be used in partial transfer context
+		*/
+		HdfProxyROS3(gsoap_resqml2_0_1::eml20__DataObjectReference* partialObject, const std::string & secret_id = "", const std::string & secret_key = "") : RESQML2_0_1_NS::HdfProxy(partialObject) {}
+
+		HdfProxyROS3(gsoap_resqml2_0_1::_eml20__EpcExternalPartReference* fromGsoap, const std::string & secret_id = "", const std::string & secret_key = "") :
+			RESQML2_0_1_NS::HdfProxy(fromGsoap) {}
+
+		~HdfProxyROS3() {}
+
+		/**
+		* Open the file for reading.
+		*/
+		void open();
+	};
+}


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
* Simplify the way to create its own implementation of an HDFProxy
* Also add suport for ROS3 HDF virtual file driver (HDF file on S3)

Does this close any currently open issues?
------------------------------------------
It may simplify a workaround for #201 

Where has this been tested?
---------------------------
**Operating System:** WIN64 10

**Platform:** VS 2015 64
