### PR TITLE
String validation, property CRS and "d"-suffixed debug DLLs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required (VERSION 3.12)
 
 project (Fesapi)
 
+set(CMAKE_DEBUG_POSTFIX "d" CACHE STRING "DEBUG_POSTFIX property is initialized when the target is created to the value of this variable except for executable targets")
+
 set (FESAPI_ROOT_DIR ${CMAKE_SOURCE_DIR})
 set (FESAPI_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -49,6 +49,10 @@ IF (WIN32)
 	SET_TARGET_PROPERTIES (example PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${FESAPI_BINARY_DIR})
 ENDIF (WIN32)
 
+# The value of DEBUG_POSTFIX property is initialized when the target is created to the value of the variable CMAKE_<CONFIG>_POSTFIX
+# except for executable targets because earlier CMake versions which did not use this variable for executables.
+set_target_properties(example PROPERTIES DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX})
+
 INSTALL (
 	TARGETS example
 	DESTINATION ${CMAKE_INSTALL_PREFIX}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,9 +11,16 @@ configure_file(${FESAPI_ROOT_DIR}/cmake/version_config.h.in ${FESAPI_ROOT_DIR}/s
 if (HDF5_1_10)
 	set (COMMENT_HDF5_1_8 "//")
 	set (COMMENT_HDF5_1_10 "")
+	set (HDF5_ROS3_ENABLED OFF CACHE BOOL "Is your HDF5 library built with ROS3 ?")
+	if (HDF5_ROS3_ENABLED)
+		target_compile_definitions(${CPP_LIBRARY_NAME} PRIVATE "HDF5_ROS3_ENABLED")
+	endif(HDF5_ROS3_ENABLED)
 else ()
 	set (COMMENT_HDF5_1_8 "")
 	set (COMMENT_HDF5_1_10 "//")
+	if (DEFINED HDF5_ROS3_ENABLED)
+		unset(HDF5_ROS3_ENABLED CACHE)
+	endif ()
 endif ()
 configure_file(${FESAPI_ROOT_DIR}/cmake/HidtType.h.in ${FESAPI_ROOT_DIR}/src/common/HidtType.h)
 
@@ -54,6 +61,9 @@ endif (FESAPI_USE_BOOST_UUID)
 
 # Linker instructions
 if (WIN32)
+	if (EXISTS ${MINIZIP_LIBRARY_DEBUG} AND EXISTS ${HDF5_C_LIBRARY_DEBUG})
+		set(CMAKE_CONFIGURATION_TYPES "Release;MinSizeRel;RelWithDebInfo;Debug" CACHE STRING "" FORCE)
+	endif ()
 	if (NOT EXISTS ${MINIZIP_LIBRARY_DEBUG} OR NOT EXISTS ${HDF5_C_LIBRARY_DEBUG})
 		set(CMAKE_CONFIGURATION_TYPES "Release;MinSizeRel;RelWithDebInfo" CACHE STRING "" FORCE)
 	endif ()
@@ -109,7 +119,7 @@ if (WIN32)
 	set (IMPORT_SUFFIX ".lib")
 	if (SUFFIX_INCLUDES_VERSION)
 		set_target_properties(${CPP_LIBRARY_NAME}
-			PROPERTIES PDB_NAME ${ASSEMBLY_NAME}.${Fesapi_VERSION}
+			PROPERTIES PDB_NAME ${ASSEMBLY_NAME}${CMAKE_DEBUG_POSTFIX}.${Fesapi_VERSION}
 		)
 		set (ASSEMBLY_NAME ${ASSEMBLY_NAME}.${Fesapi_VERSION})
 		set (DLL_SUFFIX .${Fesapi_VERSION}${DLL_SUFFIX})

--- a/src/common/AbstractObject.cpp
+++ b/src/common/AbstractObject.cpp
@@ -357,8 +357,12 @@ void AbstractObject::setUuid(const std::string & uuid)
 
 void AbstractObject::setTitle(const std::string & title)
 {
-	if (partialObject != nullptr)
+	if (partialObject != nullptr) {
 		throw invalid_argument("The wrapped gsoap proxy must not be null");
+	}
+	if (title.size() > 256) {
+		throw range_error("The title cannot be more than 256 chars long.");
+	}
 
 	if (title.empty()) {
 		if (gsoapProxy2_0_1 != nullptr) gsoapProxy2_0_1->Citation->Title = "unknown";
@@ -374,8 +378,12 @@ void AbstractObject::setTitle(const std::string & title)
 
 void AbstractObject::setEditor(const std::string & editor)
 {
-	if (partialObject != nullptr)
+	if (partialObject != nullptr) {
 		throw invalid_argument("The wrapped gsoap proxy must not be null");
+	}
+	if (editor.size() > 64) {
+		throw range_error("The editor cannot be more than 64 chars long.");
+	}
 
 	if (!editor.empty()) {
 		if (gsoapProxy2_0_1 != nullptr) {
@@ -426,8 +434,12 @@ void AbstractObject::setCreation(const tm & creation)
 
 void AbstractObject::setOriginator(const std::string & originator)
 {
-	if (partialObject != nullptr)
+	if (partialObject != nullptr) {
 		throw invalid_argument("The wrapped gsoap proxy must not be null");
+	}
+	if (originator.size() > 64) {
+		throw range_error("The originator cannot be more than 64 chars long.");
+	}
 
 	if (originator.empty()) {
 #if defined(__gnu_linux__) || defined(__APPLE__)
@@ -458,22 +470,32 @@ void AbstractObject::setOriginator(const std::string & originator)
 
 void AbstractObject::setDescription(const std::string & description)
 {
-	if (partialObject != nullptr)
+	if (partialObject != nullptr) {
 		throw invalid_argument("The wrapped gsoap proxy must not be null");
+	}
 
 	if (!description.empty())
 	{
 		if (gsoapProxy2_0_1 != nullptr) {
+			if (description.size() > 4000) {
+				throw range_error("The description cannot be more than 4000 chars long.");
+			}
 			if (gsoapProxy2_0_1->Citation->Description == nullptr)
 				gsoapProxy2_0_1->Citation->Description = gsoap_resqml2_0_1::soap_new_std__string(gsoapProxy2_0_1->soap);
 			gsoapProxy2_0_1->Citation->Description->assign(description);
 		}
 		else if (gsoapProxy2_1 != nullptr) {
+			if (description.size() > 2000) {
+				throw range_error("The description cannot be more than 2000 chars long.");
+			}
 			if (gsoapProxy2_1->Citation->Description == nullptr)
 				gsoapProxy2_1->Citation->Description = gsoap_eml2_1::soap_new_std__string(gsoapProxy2_1->soap);
 			gsoapProxy2_1->Citation->Description->assign(description);
 		}
 		else if (gsoapProxy2_2 != nullptr) {
+			if (description.size() > 2000) {
+				throw range_error("The description cannot be more than 2000 chars long.");
+			}
 			if (gsoapProxy2_2->Citation->Description == nullptr)
 				gsoapProxy2_2->Citation->Description = gsoap_eml2_2::soap_new_std__string(gsoapProxy2_2->soap);
 			gsoapProxy2_2->Citation->Description->assign(description);
@@ -526,7 +548,7 @@ void AbstractObject::setFormat(const std::string & vendor, const std::string & a
 	format += applicationVersionNumber;
 	format += ']';
 	if (vendor.size() + applicationName.size() + applicationVersionNumber.size() > 256) {
-		throw range_error("The format cannot be more than 256 characters");
+		throw range_error("The format cannot be more than 256 chars long");
 	}
 
 	format.copy(citationFormat, format.size());
@@ -535,22 +557,32 @@ void AbstractObject::setFormat(const std::string & vendor, const std::string & a
 
 void AbstractObject::setDescriptiveKeywords(const std::string & descriptiveKeywords)
 {
-	if (partialObject != nullptr)
+	if (partialObject != nullptr) {
 		throw invalid_argument("The wrapped gsoap proxy must not be null");
+	}
 
 	if (!descriptiveKeywords.empty())
 	{
 		if (gsoapProxy2_0_1 != nullptr) {
+			if (descriptiveKeywords.size() > 4000) {
+				throw range_error("The descriptiveKeywords cannot be more than 4000 chars long.");
+			}
 			if (gsoapProxy2_0_1->Citation->DescriptiveKeywords == nullptr)
 				gsoapProxy2_0_1->Citation->DescriptiveKeywords = gsoap_resqml2_0_1::soap_new_std__string(gsoapProxy2_0_1->soap);
 			gsoapProxy2_0_1->Citation->DescriptiveKeywords->assign(descriptiveKeywords);
 		}
 		else if(gsoapProxy2_1 != nullptr) {
+			if (descriptiveKeywords.size() > 2000) {
+				throw range_error("The descriptiveKeywords cannot be more than 2000 chars long.");
+			}
 			if (gsoapProxy2_1->Citation->DescriptiveKeywords == nullptr)
 				gsoapProxy2_1->Citation->DescriptiveKeywords = gsoap_eml2_1::soap_new_std__string(gsoapProxy2_1->soap);
 			gsoapProxy2_1->Citation->DescriptiveKeywords->assign(descriptiveKeywords);
 		}
 		else if (gsoapProxy2_2 != nullptr) {
+			if (descriptiveKeywords.size() > 2000) {
+				throw range_error("The descriptiveKeywords cannot be more than 2000 chars long.");
+			}
 			if (gsoapProxy2_2->Citation->DescriptiveKeywords == nullptr)
 				gsoapProxy2_2->Citation->DescriptiveKeywords = gsoap_eml2_2::soap_new_std__string(gsoapProxy2_2->soap);
 			gsoapProxy2_2->Citation->DescriptiveKeywords->assign(descriptiveKeywords);
@@ -562,6 +594,9 @@ void AbstractObject::setVersion(const std::string & version)
 {
 	if (version.empty()) {
 		throw invalid_argument("Cannot set an empty version");
+	}
+	if (version.size() > 64) {
+		throw range_error("The version cannot be more than 64 chars long.");
 	}
 
 	if (gsoapProxy2_0_1 != nullptr) {
@@ -805,8 +840,15 @@ string AbstractObject::serializeIntoString()
 
 void AbstractObject::addAlias(const std::string & authority, const std::string & title)
 {
-	if (partialObject != nullptr)
+	if (partialObject != nullptr) {
 		throw invalid_argument("The wrapped gsoap proxy must not be null");
+	}
+	if (authority.size() > 64) {
+		throw range_error("The authority cannot be more than 64 chars long.");
+	}
+	if (title.size() > 64) {
+		throw range_error("The identifier cannot be more than 64 chars long.");
+	}
 
 	if (gsoapProxy2_0_1 != nullptr) {
 		gsoap_resqml2_0_1::eml20__ObjectAlias* alias = gsoap_resqml2_0_1::soap_new_eml20__ObjectAlias(gsoapProxy2_0_1->soap);

--- a/src/resqml2/AbstractProperty.h
+++ b/src/resqml2/AbstractProperty.h
@@ -109,6 +109,39 @@ namespace RESQML2_NS
 		DLL_IMPORT_OR_EXPORT unsigned int getPropertySetCount() const;
 
 		DLL_IMPORT_OR_EXPORT RESQML2_NS::PropertySet * getPropertySet(unsigned int index) const;
+		
+		//*********************************************
+		//****** CRS ***********************
+		//*********************************************
+
+		/**
+		* Set the local CRS which is associated to the current property.
+		* you sould not set any CRS if your property is not CRS related.
+		*/
+		DLL_IMPORT_OR_EXPORT void setLocalCrs(class AbstractLocal3dCrs * crs);
+
+		/**
+		* Getter for the local CRS which is associated to this property.
+		* Usually returns null except for a property which is CRS related.
+		*/
+		DLL_IMPORT_OR_EXPORT class AbstractLocal3dCrs* getLocalCrs() const;
+
+		/**
+		* @return	null pointer if no local CRS is associated to this property. Otherwise return the data object reference of the associated local CRS.
+		*/
+		gsoap_resqml2_0_1::eml20__DataObjectReference* getLocalCrsDor() const;
+
+		/*
+		* Getter for the uuid of the local CRS which is associated to this property.
+		* @return empty string if no local CRS is associated to this property
+		*/
+		DLL_IMPORT_OR_EXPORT std::string getLocalCrsUuid() const;
+
+		/*
+		* Getter for the uuid of the local CRS which is associated to this property.
+		* @return empty string if no local CRS is associated to this property
+		*/
+		DLL_IMPORT_OR_EXPORT std::string getLocalCrsTitle() const;
 
 		//*********************************************
 		//****** REALIZATION DIMENSION ****************

--- a/src/resqml2_0_1/HdfProxyROS3.cpp
+++ b/src/resqml2_0_1/HdfProxyROS3.cpp
@@ -27,13 +27,13 @@ using namespace RESQML2_0_1_NS;
 
 void HdfProxyROS3::open()
 {
-#if H5_VERSION_GE(1, 10, 6)
+#if HDF5_ROS3_ENABLED
 	if (hdfFile != -1) {
 		close();
 	}
 
 	if (openingMode == COMMON_NS::DataObjectRepository::READ_ONLY) {
-		H5FD_ros3_fapl_t fa = { 1, 0, "", "", "" }; // Only non authenticate mode is supported buy fesapi so far.
+		H5FD_ros3_fapl_t fa = { 1, 0, "", "", "" }; // Only non authenticate mode is supported by fesapi so far.
 		if (!secret_id.empty() && !secret_key.empty()) {
 			strcpy(fa.aws_region, packageDirectoryAbsolutePath.c_str());
 			strcpy(fa.secret_id, secret_id.c_str());
@@ -64,6 +64,6 @@ void HdfProxyROS3::open()
 		throw invalid_argument("HDF5 file on an AWS bucket can only be open in read only mode for now.");
 	}
 #else
-	throw logic_error("ROS3 VFD is only supported starting from HDF 1.10.6 release.");
+	throw logic_error("Please enable ROS3 VFD support using CMAKE HDF5_ROS3_ENABLED variable if you want to use it.");
 #endif
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
 Citation String max length validation
Fix #209 : Support for LocalCrs on AbstractProperty
Fix #205 : generate "d"-suffixed debug DLLs 

Does this close any currently open issues?
------------------------------------------
Fix #209, Fix #205 

Where has this been tested?
---------------------------
**Operating System:** win10 64

**Platform:** VS 2017 64
