### PR TITLE
Can open only existing HDF5 file in RW

### DIFF
--- a/cmake/swigModule.i
+++ b/cmake/swigModule.i
@@ -240,7 +240,12 @@ namespace COMMON_NS
 	{
 	public:
 	
-		enum openingMode { READ_ONLY = 0, READ_WRITE = 1, OVERWRITE = 2 };
+		enum class openingMode : std::int8_t {
+			READ_ONLY = 0,
+			READ_WRITE = 1,
+			READ_WRITE_DO_NOT_CREATE = 2,
+			OVERWRITE = 3
+		};
 		
 		DataObjectRepository();
 		DataObjectRepository(const std::string & propertyKindMappingFilesDirectory);
@@ -889,7 +894,7 @@ namespace COMMON_NS
 		void setFilePath(const std::string & fp);
 
 		virtual void serializeFrom(const DataObjectRepository & repo, bool useZip64 = false);
-		virtual std::string deserializeInto(DataObjectRepository & repo, DataObjectRepository::openingMode hdfPermissionAccess = DataObjectRepository::READ_ONLY);
+		virtual std::string deserializeInto(DataObjectRepository & repo, DataObjectRepository::openingMode hdfPermissionAccess = DataObjectRepository::openingMode::READ_ONLY);
 		void close();
 		std::string getStorageDirectory() const;
 		std::string getName() const;

--- a/cmake/swigModule_experimental.i
+++ b/cmake/swigModule_experimental.i
@@ -293,7 +293,12 @@ namespace COMMON_NS
 	{
 	public:
 	
-		enum openingMode { READ_ONLY = 0, READ_WRITE = 1, OVERWRITE = 2 };
+		enum class openingMode : std::int8_t {
+			READ_ONLY = 0,
+			READ_WRITE = 1,
+			READ_WRITE_DO_NOT_CREATE = 2,
+			OVERWRITE = 3
+		};
 		
 		DataObjectRepository();
 		DataObjectRepository(const std::string & propertyKindMappingFilesDirectory);		
@@ -967,7 +972,7 @@ namespace COMMON_NS
 		void setFilePath(const std::string & fp);
 
 		virtual void serializeFrom(const DataObjectRepository & repo, bool useZip64 = false);
-		virtual std::string deserializeInto(DataObjectRepository & repo, DataObjectRepository::openingMode hdfPermissionAccess = DataObjectRepository::READ_ONLY);
+		virtual std::string deserializeInto(DataObjectRepository & repo, DataObjectRepository::openingMode hdfPermissionAccess = DataObjectRepository::openingMode::READ_ONLY);
 		void close();
 		std::string getStorageDirectory() const;
 		std::string getName() const;

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -965,14 +965,14 @@ void serializeGrid(COMMON_NS::DataObjectRepository * pck, COMMON_NS::AbstractHdf
 	ijkgrid->setIntervalAssociationWithStratigraphicOrganizationInterpretation(&stratiUnitIndice, 1000, stratiColumnRank0);
 
 	// Partial transfer
-	UnstructuredGridRepresentation* partialGrid = pck->createPartial<UnstructuredGridRepresentation>("", "Partial Grid");
+	UnstructuredGridRepresentation* partialGrid = pck->createPartial<UnstructuredGridRepresentation>("5cc3ee47-4bd5-4d82-ae3e-ed64e6d8d1eb", "Partial Grid");
 	ContinuousProperty* continuousProp1 = pck->createContinuousProperty(partialGrid, "cd627946-0f89-48fa-b99c-bdb35d8ac4aa", "Testing partial property", 1,
 		gsoap_resqml2_0_1::resqml20__IndexableElements__cells, gsoap_resqml2_0_1::resqml20__ResqmlUom__m, gsoap_resqml2_0_1::resqml20__ResqmlPropertyKind__length);
 	double continuousProp1Values[6] = { 0, 1, 2, 3, 4, 5 };
 	continuousProp1->pushBackDoubleHdf5Array1dOfValues(continuousProp1Values, 6, hdfProxy);
 
 	// sub rep of a partial unstructured grid
-	RESQML2_NS::SubRepresentation * subRepOfUnstructuredGrid = pck->createSubRepresentation("", "Subrep On Partial grid");
+	RESQML2_NS::SubRepresentation * subRepOfUnstructuredGrid = pck->createSubRepresentation("6b48c8d0-d60e-42b5-994c-2d4d4f3d0765", "Subrep On Partial grid");
 	subRepOfUnstructuredGrid->pushBackSupportingRepresentation(partialGrid);
 	ULONG64 nodeIndex[2] = { 0, 1 };
 	subRepOfUnstructuredGrid->pushBackSubRepresentationPatch(gsoap_resqml2_0_1::resqml20__IndexableElements__nodes, 2, nodeIndex, hdfProxy);
@@ -1962,7 +1962,7 @@ bool serialize(const string & filePath)
 
 	COMMON_NS::AbstractObject::setFormat("F2I-CONSULTING", "Fesapi Example", FESAPI_VERSION);
 
-	COMMON_NS::AbstractHdfProxy* hdfProxy = repo.createHdfProxy("", "Hdf Proxy", pck.getStorageDirectory(), pck.getName() + ".h5", COMMON_NS::DataObjectRepository::OVERWRITE);
+	COMMON_NS::AbstractHdfProxy* hdfProxy = repo.createHdfProxy("", "Hdf Proxy", pck.getStorageDirectory(), pck.getName() + ".h5", COMMON_NS::DataObjectRepository::openingMode::OVERWRITE);
 	repo.setDefaultHdfProxy(hdfProxy);
 
 	//CRS

--- a/src/common/AbstractHdfProxy.h
+++ b/src/common/AbstractHdfProxy.h
@@ -41,13 +41,13 @@ namespace COMMON_NS
 		/**
 		* @param soapContext	The soap context where the underlying gsoap proxy is going to be created.
 		*/
-		DLL_IMPORT_OR_EXPORT AbstractHdfProxy(const std::string & packageDirAbsolutePath, const std::string & externalFilePath, DataObjectRepository::openingMode hdfPermissionAccess = DataObjectRepository::READ_ONLY);
+		DLL_IMPORT_OR_EXPORT AbstractHdfProxy(const std::string & packageDirAbsolutePath, const std::string & externalFilePath, DataObjectRepository::openingMode hdfPermissionAccess = DataObjectRepository::openingMode::READ_ONLY);
 
 		DLL_IMPORT_OR_EXPORT AbstractHdfProxy(gsoap_resqml2_0_1::_eml20__EpcExternalPartReference* fromGsoap) :
-			EpcExternalPartReference(fromGsoap), openingMode(DataObjectRepository::READ_ONLY) {}
+			EpcExternalPartReference(fromGsoap), openingMode(DataObjectRepository::openingMode::READ_ONLY) {}
 
 		DLL_IMPORT_OR_EXPORT AbstractHdfProxy(gsoap_eml2_1::_eml21__EpcExternalPartReference* fromGsoap) :
-			EpcExternalPartReference(fromGsoap), openingMode(DataObjectRepository::READ_ONLY) {}
+			EpcExternalPartReference(fromGsoap), openingMode(DataObjectRepository::openingMode::READ_ONLY) {}
 
 		/**
 		* Instantiate and initialize the gsoap proxy v2.0.1.

--- a/src/common/DataObjectRepository.cpp
+++ b/src/common/DataObjectRepository.cpp
@@ -313,13 +313,13 @@ void DataObjectRepository::addRelationship(COMMON_NS::AbstractObject * source, C
 		throw invalid_argument("Cannot set a relationship with a null pointer");
 	}
 
-	if (forwardRels.find(source) == forwardRels.end()) {
+	auto sourceIt = forwardRels.find(source);
+	if (sourceIt == forwardRels.end()) {
 		forwardRels[source].push_back(target);
 	}
 	else {
-		const std::vector< COMMON_NS::AbstractObject * >& targets = forwardRels.at(source);
-		if (std::find(targets.begin(), targets.end(), target) == targets.end()) {
-			forwardRels[source].push_back(target);
+		if (std::find(sourceIt->second.begin(), sourceIt->second.end(), target) == sourceIt->second.end()) {
+			sourceIt->second.push_back(target);
 		}
 		else {
 			return;
@@ -332,6 +332,26 @@ void DataObjectRepository::addRelationship(COMMON_NS::AbstractObject * source, C
 		RESQML2_NS::AbstractRepresentation const * rep = dynamic_cast<RESQML2_NS::AbstractRepresentation const *>(source);
 		if (rep != nullptr && rep->getInterpretation() != nullptr) {
 			rep->getInterpretation()->initDomain(gsoap_resqml2_0_1::resqml20__Domain__mixed);
+		}
+	}
+}
+
+void DataObjectRepository::deleteRelationship(COMMON_NS::AbstractObject * source, COMMON_NS::AbstractObject * target)
+{
+	if (source == nullptr || target == nullptr) {
+		throw invalid_argument("Cannot set a relationship with a null pointer");
+	}
+
+	auto sourceIt = forwardRels.find(source);
+	if (sourceIt != forwardRels.end()) {
+		auto targetIt = std::find(sourceIt->second.begin(), sourceIt->second.end(), target);
+		if (targetIt != sourceIt->second.end()) {
+			// Erase in Forward Rels
+			sourceIt->second.erase(targetIt);
+			
+			// Erase in Backward rels
+			auto& sources = backwardRels[target];
+			sources.erase(std::find(sources.begin(), sources.end(), source));
 		}
 	}
 }

--- a/src/common/DataObjectRepository.h
+++ b/src/common/DataObjectRepository.h
@@ -244,7 +244,12 @@ namespace COMMON_NS
 		DLL_IMPORT_OR_EXPORT DataObjectRepository();
 		DLL_IMPORT_OR_EXPORT DataObjectRepository(const std::string & propertyKindMappingFilesDirectory);
 
-		enum openingMode { READ_ONLY = 0, READ_WRITE = 1, OVERWRITE = 2 };
+		enum class openingMode : std::int8_t {
+			READ_ONLY = 0, // It is meant to open an existing file in read only mode. It throws an exception if the file does not exist.
+			READ_WRITE = 1, // It is meant to open a file in read and write mode. It creates the file if the file does not exist.
+			READ_WRITE_DO_NOT_CREATE = 2, // It is meant to open an existing file in read and write mode. It throws an exception if the file does not exist.
+			OVERWRITE = 3 // It is meant to open an existing file in read and write mode. It deletes the content of the file if the later does already exist.
+		};
 
 		DLL_IMPORT_OR_EXPORT virtual ~DataObjectRepository();
 

--- a/src/common/DataObjectRepository.h
+++ b/src/common/DataObjectRepository.h
@@ -268,6 +268,13 @@ namespace COMMON_NS
 		DLL_IMPORT_OR_EXPORT void addRelationship(COMMON_NS::AbstractObject * source, COMMON_NS::AbstractObject * target);
 
 		/**
+		* Delete a relationship between two objects
+		* Source and target are defined by Energistics data model. Usually, the simplest is to look at Energistics UML diagrams. Another way is to rely on XSD/XML : explicit relationships are contained by the source objects and point to target objects.
+		* @param source	The source object of the relationship
+		*/
+		DLL_IMPORT_OR_EXPORT void deleteRelationship(COMMON_NS::AbstractObject * source, COMMON_NS::AbstractObject * target);
+
+		/**
 		* Set the factory used to create Hdf Proxy
 		*/
 		DLL_IMPORT_OR_EXPORT void setHdfProxyFactory(COMMON_NS::HdfProxyFactory * factory);

--- a/src/common/EpcDocument.h
+++ b/src/common/EpcDocument.h
@@ -71,7 +71,7 @@ namespace COMMON_NS
 		* Unzip the package (dataobjects + relationships) into a data repository
 		* @return			An empty string if everything's ok otherwise the error string.
 		*/
-		DLL_IMPORT_OR_EXPORT virtual std::string deserializeInto(DataObjectRepository & repo, DataObjectRepository::openingMode hdfPermissionAccess = DataObjectRepository::READ_ONLY);
+		DLL_IMPORT_OR_EXPORT virtual std::string deserializeInto(DataObjectRepository & repo, DataObjectRepository::openingMode hdfPermissionAccess = DataObjectRepository::openingMode::READ_ONLY);
 
 		/**
 		* Get the absolute path of the directory where the epc document is stored.

--- a/src/common/HdfProxy.cpp
+++ b/src/common/HdfProxy.cpp
@@ -34,17 +34,54 @@ using namespace COMMON_NS;
 HdfProxy::HdfProxy(const std::string & packageDirAbsolutePath, const std::string & externalFilePath, DataObjectRepository::openingMode hdfPermissionAccess) :
 	AbstractHdfProxy(packageDirAbsolutePath, externalFilePath, hdfPermissionAccess), hdfFile(-1), compressionLevel(0), openedGroups() {}
 
+// create an attribute at the file level to store the uuid of the corresponding COMMON hdf proxy.
+void HdfProxy::writeUuidAttribute()
+{
+	const hid_t aid = H5Screate(H5S_SCALAR);
+	if (aid < 0) {
+		throw invalid_argument("The HDF5 uuid file attribute dataspace could not have been created.");
+	}
+	const hid_t atype = H5Tcopy(H5T_C_S1);
+	if (atype < 0) {
+		throw invalid_argument("The HDF5 uuid file attribute datatype could not have been created by copy.");
+	}
+	if (H5Tset_size(atype, getUuid().size()) < 0) {
+		throw invalid_argument("Cannot set the size of the HDF5 uuid file attribute.");
+	}
+	const hid_t attribute_id = H5Acreate2(hdfFile, "uuid", atype, aid, H5P_DEFAULT, H5P_DEFAULT);
+	if (attribute_id < 0) {
+		throw invalid_argument("The HDF5 uuid file attribute could not have been created.");
+	}
+	if (H5Awrite(attribute_id, atype, getUuid().c_str()) < 0) {
+		throw invalid_argument("The uuid file attribute could not have been written.");
+	}
+
+	// Close the attribute.
+	if (H5Sclose(aid) < 0) {
+		throw invalid_argument("The HDF5 uuid file attribute dataspace could not have been closed.");
+	}
+	if (H5Tclose(atype) < 0) {
+		throw invalid_argument("The HDF5 uuid file attribute datatype could not have been closed.");
+	}
+	if (H5Aclose(attribute_id) < 0) {
+		throw invalid_argument("The HDF5 uuid file attribute could not have been closed.");
+	}
+}
+
 void HdfProxy::open()
 {
-	if (hdfFile != -1) {
+	if (hdfFile > -1) {
 		close();
 	}
 
-	if (openingMode == COMMON_NS::DataObjectRepository::READ_ONLY) {
-		if (H5Fis_hdf5((packageDirectoryAbsolutePath + relativeFilePath).c_str()) > 0) {
-			hdfFile = H5Fopen((packageDirectoryAbsolutePath + relativeFilePath).c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
+	const std::string fullName = packageDirectoryAbsolutePath + relativeFilePath;
+	if (openingMode == COMMON_NS::DataObjectRepository::openingMode::READ_ONLY || openingMode == COMMON_NS::DataObjectRepository::openingMode::READ_WRITE_DO_NOT_CREATE) {
+		if (H5Fis_hdf5(fullName.c_str()) > 0) {
+			hdfFile = H5Fopen(fullName.c_str(),
+				openingMode == COMMON_NS::DataObjectRepository::openingMode::READ_ONLY ? H5F_ACC_RDONLY : H5F_ACC_RDWR,
+				H5P_DEFAULT);
 			if (hdfFile < 0) {
-				throw invalid_argument("Can not open HDF5 file (in read only mode) : " + packageDirectoryAbsolutePath + relativeFilePath);
+				throw invalid_argument("Can not open HDF5 file (in read only mode) : " + fullName);
 			}
 
 			// Check the uuid
@@ -54,97 +91,38 @@ void HdfProxy::open()
 			}
 		}
 		else {
-			throw invalid_argument("The HDF5 file " + packageDirectoryAbsolutePath + relativeFilePath + " does not exist or is not a valid HDF5 file.");
+			throw invalid_argument("The HDF5 file " + fullName + " does not exist or is not a valid HDF5 file.");
 		}
 	}
-	else if (openingMode == COMMON_NS::DataObjectRepository::READ_WRITE) {
-
-	        hid_t access_props = H5Pcreate (H5P_FILE_ACCESS);
+	else if (openingMode == COMMON_NS::DataObjectRepository::openingMode::READ_WRITE) {
+		hid_t access_props = H5Pcreate (H5P_FILE_ACCESS);
 #ifdef H5F_LIBVER_V18
-		H5Pset_libver_bounds (access_props,
-				      H5F_LIBVER_V18, H5F_LIBVER_V18);
+		H5Pset_libver_bounds (access_props, H5F_LIBVER_V18, H5F_LIBVER_V18);
 #endif
 
-		hdfFile = H5Fcreate((packageDirectoryAbsolutePath + relativeFilePath).c_str(), H5F_ACC_EXCL, H5P_DEFAULT, access_props);
+		hdfFile = H5Fcreate(fullName.c_str(), H5F_ACC_EXCL, H5P_DEFAULT, access_props);
 
 		if (hdfFile < 0) {
-			if (H5Fis_hdf5((packageDirectoryAbsolutePath + relativeFilePath).c_str()) > 0) {
-				hdfFile = H5Fopen((packageDirectoryAbsolutePath + relativeFilePath).c_str(), H5F_ACC_RDWR, access_props);
-				if (hdfFile < 0) {
-					throw invalid_argument("Can not open HDF5 file (in read and write mode): " + packageDirectoryAbsolutePath + relativeFilePath);
-				}
-
-				string hdfUuid = readStringAttribute(".", "uuid");
-				if (getUuid() != hdfUuid) {
-					getRepository()->addWarning("The uuid \"" + hdfUuid + "\" attribute of the HDF5 file is not the same as the uuid \"" + getUuid() + "\" of the xml EpcExternalPart.");
-				}
-			}
-			else {
-				throw invalid_argument("The HDF5 file " + packageDirectoryAbsolutePath + relativeFilePath + " is not a valid HDF5 file.");
-			}
+			openingMode == COMMON_NS::DataObjectRepository::openingMode::READ_WRITE_DO_NOT_CREATE;
+			open();
+			openingMode == COMMON_NS::DataObjectRepository::openingMode::READ_WRITE;
 		}
 		else {
-			// create an attribute at the file level to store the uuid of the corresponding resqml hdf proxy.
-			hid_t aid = H5Screate(H5S_SCALAR);
-			hid_t atype = H5Tcopy(H5T_C_S1);
-			H5Tset_size(atype, getUuid().size());
-			hid_t attribute_id = H5Acreate2(hdfFile, "uuid", atype, aid, H5P_DEFAULT, H5P_DEFAULT);
-			int status = H5Awrite(attribute_id, atype, getUuid().c_str());
-			if (status < 0) {
-				throw invalid_argument("The uuid file attribute could not have been written.");
-			}
-
-			// Close the attribute.
-			status = H5Sclose(aid);
-			if (status < 0) {
-				throw invalid_argument("The uuid file attribute dataspace could not have been closed.");
-			}
-			status = H5Tclose(atype);
-			if (status < 0) {
-				throw invalid_argument("The uuid file attribute datatype could not have been closed.");
-			}
-			status = H5Aclose(attribute_id);
-			if (status < 0) {
-				throw invalid_argument("The uuid file attribute could not have been closed.");
-			}
+			writeUuidAttribute();
 		}
 	}
-	else if (openingMode == COMMON_NS::DataObjectRepository::OVERWRITE) {
-
-	        hid_t access_props = H5Pcreate (H5P_FILE_ACCESS);
+	else if (openingMode == COMMON_NS::DataObjectRepository::openingMode::OVERWRITE) {
+		hid_t access_props = H5Pcreate (H5P_FILE_ACCESS);
 #ifdef H5F_LIBVER_V18
-		H5Pset_libver_bounds (access_props,
-				      H5F_LIBVER_V18, H5F_LIBVER_V18);
+		H5Pset_libver_bounds (access_props, H5F_LIBVER_V18, H5F_LIBVER_V18);
 #endif
 
-		hdfFile = H5Fcreate((packageDirectoryAbsolutePath + relativeFilePath).c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, access_props);
+		hdfFile = H5Fcreate(fullName.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, access_props);
 		if (hdfFile < 0) {
-			throw invalid_argument("Can not create HDF5 file : " + packageDirectoryAbsolutePath + relativeFilePath);
+			throw invalid_argument("Can not create HDF5 file : " + fullName);
 		}
 
-		// create an attribute at the file level to store the uuid of the corresponding resqml hdf proxy.
-		hid_t aid = H5Screate(H5S_SCALAR);
-		hid_t atype = H5Tcopy(H5T_C_S1);
-		H5Tset_size(atype, getUuid().size());
-		hid_t attribute_id = H5Acreate2(hdfFile, "uuid", atype, aid, H5P_DEFAULT, H5P_DEFAULT);
-		int status = H5Awrite(attribute_id, atype, getUuid().c_str());
-		if (status < 0) {
-			throw invalid_argument("The uuid file attribute could not have been written.");
-		}
-
-		// Close the attribute.
-		status = H5Sclose(aid);
-		if (status < 0) {
-			throw invalid_argument("The uuid file attribute dataspace could not have been closed.");
-		}
-		status = H5Tclose(atype);
-		if (status < 0) {
-			throw invalid_argument("The uuid file attribute datatype could not have been closed.");
-		}
-		status = H5Aclose(attribute_id);
-		if (status < 0) {
-			throw invalid_argument("The uuid file attribute could not have been closed.");
-		}
+		writeUuidAttribute();
 	}
 	else {
 		throw invalid_argument("The HDF5 permission access is unknown.");
@@ -160,7 +138,7 @@ void HdfProxy::close()
 	}
 	openedGroups.clear();
 
-	if (hdfFile != -1) {
+	if (hdfFile > -1) {
 		H5Fclose(hdfFile);
 		hdfFile = -1;
 	}

--- a/src/common/HdfProxy.h
+++ b/src/common/HdfProxy.h
@@ -39,7 +39,7 @@ namespace COMMON_NS
 		* @packageDirAbsolutePath	The directory where the EPC document is stored. Must end with a slash or back-slash
 		* @relativeFilePath			The relative file path of the associated HDF file. It is relative to the location of the package
 		*/
-		HdfProxy(const std::string & packageDirAbsolutePath, const std::string & externalFilePath, DataObjectRepository::openingMode hdfPermissionAccess = DataObjectRepository::READ_ONLY);
+		HdfProxy(const std::string & packageDirAbsolutePath, const std::string & externalFilePath, DataObjectRepository::openingMode hdfPermissionAccess = DataObjectRepository::openingMode::READ_ONLY);
 
 		/**
 		* Read an array Nd of float values stored in a specific dataset.
@@ -130,6 +130,11 @@ namespace COMMON_NS
 			unsigned long long slabSize, 
 			hdf5_hid_t datatype);
 
+		/**
+		* Write the uuid of the XML EpcExternalPartReference as a string attribute of the HDF5 file.
+		*/
+		void writeUuidAttribute();
+
 	public:
 
 		/**
@@ -144,8 +149,7 @@ namespace COMMON_NS
 		virtual ~HdfProxy() {close();}
 
 		/**
-		* Open the file for reading and writing.
-		* Does never overwrite an existing file but append to it if it already exists.
+		* Create or open the file according to the chosen openingMode.
 		*/
 		void open();
 

--- a/src/common/HdfProxyFactory.h
+++ b/src/common/HdfProxyFactory.h
@@ -45,7 +45,7 @@ namespace COMMON_NS
 		/**
 		* Creates an instance of this class for serialization purpose.
 		*/
-		DLL_IMPORT_OR_EXPORT virtual AbstractHdfProxy* make(COMMON_NS::DataObjectRepository * repo, const std::string & guid, const std::string & title, const std::string & packageDirAbsolutePath, const std::string & externalFilePath, COMMON_NS::DataObjectRepository::openingMode hdfPermissionAccess = COMMON_NS::DataObjectRepository::READ_ONLY) {
+		DLL_IMPORT_OR_EXPORT virtual AbstractHdfProxy* make(COMMON_NS::DataObjectRepository * repo, const std::string & guid, const std::string & title, const std::string & packageDirAbsolutePath, const std::string & externalFilePath, COMMON_NS::DataObjectRepository::openingMode hdfPermissionAccess = COMMON_NS::DataObjectRepository::openingMode::READ_ONLY) {
 			return new RESQML2_0_1_NS::HdfProxy(repo, guid, title, packageDirAbsolutePath, externalFilePath, hdfPermissionAccess);
 		}
 

--- a/src/resqml2/AbstractFeatureInterpretation.cpp
+++ b/src/resqml2/AbstractFeatureInterpretation.cpp
@@ -40,6 +40,12 @@ void AbstractFeatureInterpretation::setInterpretedFeature(AbstractFeature * feat
 		feature->getRepository()->addOrReplaceDataObject(this);
 	}
 
+	if (gsoapProxy2_0_1 != nullptr) {
+		if (static_cast<gsoap_resqml2_0_1::resqml20__AbstractFeatureInterpretation*>(gsoapProxy2_0_1)->InterpretedFeature != nullptr) {
+			getRepository()->deleteRelationship(this, getInterpretedFeature());
+		}
+	}
+
 	repository->addRelationship(this, feature);
 
 	if (gsoapProxy2_0_1 != nullptr) {

--- a/src/resqml2/AbstractProperty.cpp
+++ b/src/resqml2/AbstractProperty.cpp
@@ -107,6 +107,12 @@ void AbstractProperty::setRepresentation(AbstractRepresentation * rep)
 		rep->getRepository()->addOrReplaceDataObject(this);
 	}
 
+	if (gsoapProxy2_0_1 != nullptr) {
+		if (static_cast<gsoap_resqml2_0_1::resqml20__AbstractProperty*>(gsoapProxy2_0_1)->SupportingRepresentation != nullptr) {
+			getRepository()->deleteRelationship(this, getRepresentation());
+		}
+	}
+
 	getRepository()->addRelationship(this, rep);
 
 	// XML
@@ -474,6 +480,13 @@ void AbstractProperty::setLocalPropertyKind(COMMON_NS::PropertyKind* propKind)
 	}
 	if (getRepository() == nullptr) {
 		propKind->getRepository()->addOrReplaceDataObject(this);
+	}
+
+	if (gsoapProxy2_0_1 != nullptr) {
+		if (static_cast<gsoap_resqml2_0_1::resqml20__AbstractProperty*>(gsoapProxy2_0_1)->PropertyKind != nullptr &&
+			static_cast<gsoap_resqml2_0_1::resqml20__AbstractProperty*>(gsoapProxy2_0_1)->PropertyKind->soap_type() == SOAP_TYPE_gsoap_resqml2_0_1_resqml20__LocalPropertyKind) {
+			getRepository()->deleteRelationship(this, getLocalPropertyKind());
+		}
 	}
 
 	getRepository()->addRelationship(this, propKind);

--- a/src/resqml2/AbstractRepresentation.cpp
+++ b/src/resqml2/AbstractRepresentation.cpp
@@ -204,6 +204,19 @@ void AbstractRepresentation::setInterpretation(AbstractFeatureInterpretation* in
 		interp->getRepository()->addOrReplaceDataObject(this);
 	}
 
+	if (gsoapProxy2_0_1 != nullptr) {
+		if (static_cast<gsoap_resqml2_0_1::resqml20__AbstractRepresentation*>(gsoapProxy2_0_1)->RepresentedInterpretation != nullptr) {
+			getRepository()->deleteRelationship(this, getInterpretation());
+		}
+	}
+#if WITH_EXPERIMENTAL
+	else if (gsoapProxy2_2 != nullptr) {
+		if (static_cast<gsoap_eml2_2::resqml22__AbstractRepresentation*>(gsoapProxy2_2)->RepresentedInterpretation != nullptr) {
+			getRepository()->deleteRelationship(this, getInterpretation());
+		}
+	}
+#endif
+
 	getRepository()->addRelationship(this, interp);
 
 	if (gsoapProxy2_0_1 != nullptr) {
@@ -226,8 +239,7 @@ AbstractFeatureInterpretation* AbstractRepresentation::getInterpretation() const
 gsoap_resqml2_0_1::eml20__DataObjectReference* AbstractRepresentation::getInterpretationDor() const
 {
 	if (gsoapProxy2_0_1 != nullptr) {
-		return static_cast<gsoap_resqml2_0_1::resqml20__AbstractRepresentation*>(gsoapProxy2_0_1)->RepresentedInterpretation != nullptr ?
-			static_cast<gsoap_resqml2_0_1::resqml20__AbstractRepresentation*>(gsoapProxy2_0_1)->RepresentedInterpretation : nullptr;
+		return static_cast<gsoap_resqml2_0_1::resqml20__AbstractRepresentation*>(gsoapProxy2_0_1)->RepresentedInterpretation;
 	}
 #if WITH_EXPERIMENTAL
 	else if (gsoapProxy2_2 != nullptr) {

--- a/src/resqml2_0_1/HdfProxy.h
+++ b/src/resqml2_0_1/HdfProxy.h
@@ -39,7 +39,7 @@ namespace RESQML2_0_1_NS
 		* @packageDirAbsolutePath	The directory where the EPC document is stored. Must end with a slash or back-slash
 		* @relativeFilePath			The relative file path of the associated HDF file. It is relative to the location of the package
 		*/
-		DLL_IMPORT_OR_EXPORT HdfProxy(COMMON_NS::DataObjectRepository * repo, const std::string & guid, const std::string & title, const std::string & packageDirAbsolutePath, const std::string & externalFilePath, COMMON_NS::DataObjectRepository::openingMode hdfPermissionAccess = COMMON_NS::DataObjectRepository::READ_ONLY);
+		DLL_IMPORT_OR_EXPORT HdfProxy(COMMON_NS::DataObjectRepository * repo, const std::string & guid, const std::string & title, const std::string & packageDirAbsolutePath, const std::string & externalFilePath, COMMON_NS::DataObjectRepository::openingMode hdfPermissionAccess = COMMON_NS::DataObjectRepository::openingMode::READ_ONLY);
 
 		DLL_IMPORT_OR_EXPORT HdfProxy(gsoap_resqml2_0_1::_eml20__EpcExternalPartReference* fromGsoap) :
 			COMMON_NS::HdfProxy(fromGsoap) {}

--- a/test/AbstractTest.cpp
+++ b/test/AbstractTest.cpp
@@ -37,7 +37,7 @@ AbstractTest::AbstractTest(COMMON_NS::DataObjectRepository* repo_) :
 void AbstractTest::serialize() {
 	COMMON_NS::EpcDocument epcDocument(epcDocPath);
 	repo = new COMMON_NS::DataObjectRepository();
-	repo->setDefaultHdfProxy(repo->createHdfProxy("75f5b460-3ccb-4102-a06e-e9c1019769b2", "Hdf Proxy Test", epcDocument.getStorageDirectory(), epcDocument.getName() + ".h5", COMMON_NS::DataObjectRepository::OVERWRITE));
+	repo->setDefaultHdfProxy(repo->createHdfProxy("75f5b460-3ccb-4102-a06e-e9c1019769b2", "Hdf Proxy Test", epcDocument.getStorageDirectory(), epcDocument.getName() + ".h5", COMMON_NS::DataObjectRepository::openingMode::OVERWRITE));
 	repo->setDefaultCrs(repo->createLocalDepth3dCrs("7b40b49e-b783-4b3f-8380-b3bdc42e8ae7", "Default CRS", 1000, 2000, 3000, .0, gsoap_resqml2_0_1::eml20__LengthUom__m, 23031, gsoap_resqml2_0_1::eml20__LengthUom__ft, "Unknown", false));
 
 	initRepo();

--- a/test/AbstractTest.h
+++ b/test/AbstractTest.h
@@ -22,10 +22,6 @@ under the License.
 
 #include "nsDefinitions.h"
 
-#if (defined(_WIN32) && _MSC_VER < 1600) || (defined(__GNUC__) && (__GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 6)))
-#include "tools/nullptr_emulation.h"
-#endif
-
 namespace COMMON_NS {
 	class DataObjectRepository;
 }

--- a/test/resqml2_0_1test/IjkGridExplicitRepresentationTest.cpp
+++ b/test/resqml2_0_1test/IjkGridExplicitRepresentationTest.cpp
@@ -19,9 +19,7 @@ under the License.
 #include "resqml2_0_1test/IjkGridExplicitRepresentationTest.h"
 
 #include "catch.hpp"
-#include "resqml2_0_1test/LocalDepth3dCrsTest.h"
 
-#include "resqml2_0_1/LocalDepth3dCrs.h"
 #include "resqml2_0_1/IjkGridExplicitRepresentation.h"
 
 using namespace std;

--- a/test/unitTest.cpp
+++ b/test/unitTest.cpp
@@ -24,6 +24,9 @@ under the License.
 
 #include "catch.hpp"
 
+#include "common/DataObjectRepository.h"
+#include "common/AbstractHdfProxy.h"
+
 #include "EpcDocumentTest.h"
 #include "resqml2_0_1test/LocalDepth3dCrsTest.h"
 #include "resqml2_0_1test/HorizonInterpretationTest.h"
@@ -102,8 +105,32 @@ TEST_CASE("Export and import an empty EPC document", "[repo]")
 	testIn.serialize();
 
 	// Check that the epc file extension has properly been added at previous step.
+
 	EpcDocumentTest testOut("../../EpcDocumentTest.epc");
 	testOut.deserialize();	
+}
+
+TEST_CASE("Test hdf5 opening mode", "[hdf]")
+{
+	std::remove("../../testingFile.h5");
+
+	COMMON_NS::DataObjectRepository repo;
+	COMMON_NS::AbstractHdfProxy* hdfProxy = repo.createHdfProxy("", "Hdf Proxy Test", "../../", "testingFile.h5", COMMON_NS::DataObjectRepository::openingMode::READ_ONLY);
+	REQUIRE_THROWS(hdfProxy->open());
+	hdfProxy->setOpeningMode(COMMON_NS::DataObjectRepository::openingMode::READ_WRITE_DO_NOT_CREATE);
+	REQUIRE_THROWS(hdfProxy->open());
+	hdfProxy->setOpeningMode(COMMON_NS::DataObjectRepository::openingMode::READ_WRITE);
+	REQUIRE_NOTHROW(hdfProxy->open());
+	hdfProxy->close();
+	hdfProxy->setOpeningMode(COMMON_NS::DataObjectRepository::openingMode::OVERWRITE);
+	REQUIRE_NOTHROW(hdfProxy->open());
+	hdfProxy->close();
+	hdfProxy->setOpeningMode(COMMON_NS::DataObjectRepository::openingMode::READ_WRITE_DO_NOT_CREATE);
+	REQUIRE_NOTHROW(hdfProxy->open());
+	hdfProxy->close();
+	hdfProxy->setOpeningMode(COMMON_NS::DataObjectRepository::openingMode::READ_ONLY);
+	REQUIRE_NOTHROW(hdfProxy->open());
+	hdfProxy->close();
 }
 
 FESAPI_TEST("Export and import a local depth 3d crs", "[crs]", LocalDepth3dCrsTest)
@@ -144,7 +171,7 @@ FESAPI_TEST("Export and import a LGR on a 4*3*2 explicit right handed ijk grid",
 
 FESAPI_TEST("Export and import an unstructured grid", "[grid]", OneTetrahedronUnstructuredGridRepresentationTest)
 
-FESAPI_TEST("Export and import a subrepresenation on a partial grid connection set", "[grid]", SubRepresentationOnPartialGridConnectionSet)
+FESAPI_TEST("Export and import a subrepresentation on a partial grid connection set", "[grid]", SubRepresentationOnPartialGridConnectionSet)
 
 FESAPI_TEST("Export and import a time series", "[property]", TimeSeriesTest)
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
You can now open an HDF5 file only if the file exists.
There would be an exception thrown if the HDF5 file does not exist.

Does this close any currently open issues?
------------------------------------------
Fix #201

Any other comments?
-------------------
Add an opening mode enumerated value READ_WRITE_DO_NOT_CREATE to support this behavior.

Where has this been tested?
---------------------------
**Operating System:** Win 10 64

**Platform:** VS 2017 64
