### PR TITLE
Fix Java build on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,12 +55,14 @@ addons:
       - uuid-dev
       - zlib1g-dev
       - libhdf5-dev #1.8.11
-      - swig
 
 jdk: oraclejdk8
 
 install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get purge cmake; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      sudo apt-get purge cmake;
+      sudo apt-get purge swig;
+    fi
   - sudo rm -rf /usr/local/cmake-*
   - mkdir ../dependencies
   - cd ../dependencies
@@ -69,4 +71,10 @@ install:
       tar -xzf minizip-1.1-linux-ubuntu1604-x86_64-gcc540.tar.gz;
       wget https://cmake.org/files/v3.12/cmake-3.12.0-Linux-x86_64.sh;
       sudo sh cmake-3.12.0-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir;
+      wget http://prdownloads.sourceforge.net/swig/swig-4.0.1.tar.gz
+      tar -xzf swig-4.0.1.tar.gz;
+      cd swig-4.0.1;
+      ./configure
+      make
+      sudo make install
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,10 +71,10 @@ install:
       tar -xzf minizip-1.1-linux-ubuntu1604-x86_64-gcc540.tar.gz;
       wget https://cmake.org/files/v3.12/cmake-3.12.0-Linux-x86_64.sh;
       sudo sh cmake-3.12.0-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir;
-      wget http://prdownloads.sourceforge.net/swig/swig-4.0.1.tar.gz
+      wget http://prdownloads.sourceforge.net/swig/swig-4.0.1.tar.gz;
       tar -xzf swig-4.0.1.tar.gz;
       cd swig-4.0.1;
-      ./configure
-      make
-      sudo make install
+      ./configure;
+      make;
+      sudo make install;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ matrix:
                 -DZLIB_INCLUDE_DIR=/usr/include
                 -DZLIB_LIBRARY_RELEASE=/usr/lib/x86_64-linux-gnu/libz.so
                 -DWITH_EXAMPLE=TRUE
+                -DWITH_JAVA_WRAPPING=TRUE
             - cmake --build . -- -j 2
             - ./example/example
             - ctest -V
@@ -55,6 +56,8 @@ addons:
       - zlib1g-dev
       - libhdf5-dev #1.8.11
       - swig
+
+jdk: oraclejdk8
 
 install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get purge cmake; fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ set (FESAPI_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
 # version mechanism
 set (Fesapi_VERSION_MAJOR 1)
 set (Fesapi_VERSION_MINOR 1)
-set (Fesapi_VERSION_PATCH 0)
+set (Fesapi_VERSION_PATCH 1)
 set (Fesapi_VERSION_TWEAK 0)
 
 set (Fesapi_VERSION ${Fesapi_VERSION_MAJOR}.${Fesapi_VERSION_MINOR}.${Fesapi_VERSION_PATCH}.${Fesapi_VERSION_TWEAK})

--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -8,14 +8,6 @@ include(UseJava)
 
 set(SWIG_LINKED_TO_RELEASE ON CACHE BOOL "Is your SWIG generated library linked to the release or debug version of FesapiCpp ?")
 
-if (SWIG_LINKED_TO_RELEASE)
-	set (ASSEMBLY_NAME ${CPP_LIBRARY_NAME}${CMAKE_RELEASE_POSTFIX}.${Fesapi_VERSION})
-	add_jar(fesapiJava${CMAKE_RELEASE_POSTFIX} ${SWIG_JAVA_FILES} VERSION ${Fesapi_VERSION})
-else (SWIG_LINKED_TO_RELEASE)
-	set (ASSEMBLY_NAME ${CPP_LIBRARY_NAME}${CMAKE_DEBUG_POSTFIX}.${Fesapi_VERSION})
-	add_jar(fesapiJava${CMAKE_DEBUG_POSTFIX} ${SWIG_JAVA_FILES} VERSION ${Fesapi_VERSION})
-endif (SWIG_LINKED_TO_RELEASE)
-
 message("Generating SWIG Java files...")
 #Cleaning
 file (GLOB TO_DELETE ${FESAPI_ROOT_DIR}/java/src/com/f2i/energisticsStandardsApi/*.java)
@@ -51,6 +43,13 @@ message("SWIG Java files have been generated.")
 
 # Building the jar
 file (GLOB_RECURSE SWIG_JAVA_FILES ${FESAPI_ROOT_DIR}/java/src/*.java)
+if (SWIG_LINKED_TO_RELEASE)
+	set (ASSEMBLY_NAME ${CPP_LIBRARY_NAME}${CMAKE_RELEASE_POSTFIX}.${Fesapi_VERSION})
+	add_jar(fesapiJava${CMAKE_RELEASE_POSTFIX} ${SWIG_JAVA_FILES} VERSION ${Fesapi_VERSION})
+else (SWIG_LINKED_TO_RELEASE)
+	set (ASSEMBLY_NAME ${CPP_LIBRARY_NAME}${CMAKE_DEBUG_POSTFIX}.${Fesapi_VERSION})
+	add_jar(fesapiJava${CMAKE_DEBUG_POSTFIX} ${SWIG_JAVA_FILES} VERSION ${Fesapi_VERSION})
+endif (SWIG_LINKED_TO_RELEASE)
 set(CMAKE_JAVA_COMPILE_FLAGS -g)
 
 target_sources(${CPP_LIBRARY_NAME} PRIVATE ${FESAPI_ROOT_DIR}/swig/swigGeneratedJavaWrapper.cpp)


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
It allows the jar install on Linux system

Does this close any currently open issues?
------------------------------------------
No

Any other comments?
-------------------
A regression has been released because the jar build works on Windows but not on Linux using cmake (only windows has been tested)

Where has this been tested?
---------------------------
**Operating System:** Trusty

**Platform:** Travis
