### PR TITLE
Fixing datum issue in WITSML 2.0 Well GroundElevation

### DIFF
--- a/src/witsml2_0/Well.cpp
+++ b/src/witsml2_0/Well.cpp
@@ -103,13 +103,41 @@ GETTER_AND_SETTER_GENERIC_OPTIONAL_ATTRIBUTE_IMPL(gsoap_eml2_1::witsml20__WellFl
 GETTER_AND_SETTER_GENERIC_OPTIONAL_ATTRIBUTE_IMPL(gsoap_eml2_1::witsml20__WellDirection, Well, DirectionWell, gsoap_eml2_1::soap_new_witsml20__WellDirection)
 
 GETTER_AND_SETTER_MEASURE_OPTIONAL_ATTRIBUTE_IMPL(Well, WaterDepth, gsoap_eml2_1::eml21__LengthUom, gsoap_eml2_1::soap_new_eml21__LengthMeasure)
-GETTER_AND_SETTER_MEASURE_OPTIONAL_ATTRIBUTE_IMPL(Well, GroundElevation, gsoap_eml2_1::eml21__LengthUom, gsoap_eml2_1::soap_new_witsml20__WellElevationCoord)
+GETTER_PRESENCE_ATTRIBUTE_IMPL(Well, GroundElevation)
 
 GETTER_AND_SETTER_MEASURE_OPTIONAL_ATTRIBUTE_IMPL(Well, PcInterest, gsoap_eml2_1::eml21__DimensionlessUom, gsoap_eml2_1::soap_new_eml21__DimensionlessMeasure)
 
 GETTER_AND_SETTER_TIME_T_OPTIONAL_ATTRIBUTE_IMPL(Well, DTimLicense)
 GETTER_AND_SETTER_TIME_T_OPTIONAL_ATTRIBUTE_IMPL(Well, DTimSpud)
 GETTER_AND_SETTER_TIME_T_OPTIONAL_ATTRIBUTE_IMPL(Well, DTimPa)
+
+void Well::setGroundElevation(double value, gsoap_eml2_1::eml21__LengthUom uom, const std::string& datum)
+{
+	if (value != value) { throw invalid_argument("You cannot set an undefined measure"); }
+	witsml20__Well* well = static_cast<witsml20__Well*>(gsoapProxy2_1);
+	if (well->GroundElevation == nullptr) { well->GroundElevation = soap_new_witsml20__WellElevationCoord(gsoapProxy2_1->soap); }
+	static_cast<witsml20__Well*>(gsoapProxy2_1)->GroundElevation->__item = value;
+	static_cast<witsml20__Well*>(gsoapProxy2_1)->GroundElevation->uom = uom;
+	static_cast<witsml20__Well*>(gsoapProxy2_1)->GroundElevation->datum = datum;
+}
+
+double Well::getGroundElevationValue() const
+{
+	if (!hasGroundElevation()) { throw invalid_argument("The measure attribute to get does not exist."); }\
+	return static_cast<witsml20__Well*>(gsoapProxy2_1)->GroundElevation->__item;
+}
+
+gsoap_eml2_1::eml21__LengthUom Well::getGroundElevationUom() const
+{
+	if (!hasGroundElevation()) { throw invalid_argument("The measure attribute to get does not exist."); }\
+	return static_cast<witsml20__Well*>(gsoapProxy2_1)->GroundElevation->uom;
+}
+
+std::string Well::getGroundElevationDatum() const
+{
+	if (!hasGroundElevation()) { throw invalid_argument("The measure attribute to get does not exist."); }\
+	return static_cast<witsml20__Well*>(gsoapProxy2_1)->GroundElevation->datum;
+}
 
 void Well::setTimeZone(bool direction, unsigned short hours, unsigned short minutes)
 {

--- a/src/witsml2_0/Well.cpp
+++ b/src/witsml2_0/Well.cpp
@@ -104,6 +104,8 @@ GETTER_AND_SETTER_GENERIC_OPTIONAL_ATTRIBUTE_IMPL(gsoap_eml2_1::witsml20__WellDi
 
 GETTER_AND_SETTER_MEASURE_OPTIONAL_ATTRIBUTE_IMPL(Well, WaterDepth, gsoap_eml2_1::eml21__LengthUom, gsoap_eml2_1::soap_new_eml21__LengthMeasure)
 GETTER_PRESENCE_ATTRIBUTE_IMPL(Well, GroundElevation)
+GETTER_VALUE_OF_MEASURE_ATTRIBUTE_IMPL(Well, GroundElevation)
+GETTER_UOM_OF_MEASURE_ATTRIBUTE_IMPL(Well, GroundElevation, gsoap_eml2_1::eml21__LengthUom)
 
 GETTER_AND_SETTER_MEASURE_OPTIONAL_ATTRIBUTE_IMPL(Well, PcInterest, gsoap_eml2_1::eml21__DimensionlessUom, gsoap_eml2_1::soap_new_eml21__DimensionlessMeasure)
 
@@ -119,18 +121,6 @@ void Well::setGroundElevation(double value, gsoap_eml2_1::eml21__LengthUom uom, 
 	static_cast<witsml20__Well*>(gsoapProxy2_1)->GroundElevation->__item = value;
 	static_cast<witsml20__Well*>(gsoapProxy2_1)->GroundElevation->uom = uom;
 	static_cast<witsml20__Well*>(gsoapProxy2_1)->GroundElevation->datum = datum;
-}
-
-double Well::getGroundElevationValue() const
-{
-	if (!hasGroundElevation()) { throw invalid_argument("The measure attribute to get does not exist."); }\
-	return static_cast<witsml20__Well*>(gsoapProxy2_1)->GroundElevation->__item;
-}
-
-gsoap_eml2_1::eml21__LengthUom Well::getGroundElevationUom() const
-{
-	if (!hasGroundElevation()) { throw invalid_argument("The measure attribute to get does not exist."); }\
-	return static_cast<witsml20__Well*>(gsoapProxy2_1)->GroundElevation->uom;
 }
 
 std::string Well::getGroundElevationDatum() const

--- a/src/witsml2_0/Well.h
+++ b/src/witsml2_0/Well.h
@@ -83,13 +83,51 @@ namespace WITSML2_0_NS
 		GETTER_AND_SETTER_GENERIC_OPTIONAL_ATTRIBUTE(gsoap_eml2_1::witsml20__WellDirection, DirectionWell)
 
 		GETTER_AND_SETTER_MEASURE_OPTIONAL_ATTRIBUTE(WaterDepth, gsoap_eml2_1::eml21__LengthUom)
-		GETTER_AND_SETTER_MEASURE_OPTIONAL_ATTRIBUTE(GroundElevation, gsoap_eml2_1::eml21__LengthUom)
+		GETTER_PRESENCE_ATTRIBUTE(GroundElevation)
 
 		GETTER_AND_SETTER_MEASURE_OPTIONAL_ATTRIBUTE(PcInterest, gsoap_eml2_1::eml21__DimensionlessUom)
 
 		GETTER_AND_SETTER_GENERIC_OPTIONAL_ATTRIBUTE(time_t, DTimLicense)
 		GETTER_AND_SETTER_GENERIC_OPTIONAL_ATTRIBUTE(time_t, DTimSpud)
 		GETTER_AND_SETTER_GENERIC_OPTIONAL_ATTRIBUTE(time_t, DTimPa)
+
+		/**
+		 * @brief	Sets the ground level elevation (land rigs)
+		 *
+		 * @exception	std::invalid_argument	If @p value is undefined.
+		 *
+		 * @param 	value	The elevation value.
+		 * @param 	uom  	The elevation unit of measure.
+		 * @param 	datum	The elevation datum.
+		 */
+		DLL_IMPORT_OR_EXPORT void setGroundElevation(double value, gsoap_eml2_1::eml21__LengthUom uom, const std::string& datum);
+
+		/**
+		 * @brief	Gets the ground level elevation value
+		 *
+		 * @exception	std::invalid_argument	If the ground elevation does not exist.
+		 *
+		 * @returns	The ground level elevation value.
+		 */
+		DLL_IMPORT_OR_EXPORT double getGroundElevationValue() const;
+
+		/**
+		 * @brief	Gets the ground level elevation unit of measure
+		 *
+		 * @exception	std::invalid_argument	If the ground elevation does not exist.
+		 *
+		 * @returns	The ground level elevation unit of measure.
+		 */
+		DLL_IMPORT_OR_EXPORT gsoap_eml2_1::eml21__LengthUom getGroundElevationUom() const;
+
+		/**
+		 * @brief	Gets the ground level elevation datum
+		 *
+		 * @exception	std::invalid_argument	If the ground elevation does not exist.
+		 *
+		 * @returns	The ground level elevation datum.
+		 */
+		DLL_IMPORT_OR_EXPORT std::string getGroundElevationDatum() const;
 
 		/**
 		* Set the time zone in which the well is located. It is the deviation in hours and minutes from UTC. This should be the normal time zone at the well and not a seasonally-adjusted value, such as daylight savings time

--- a/swig/swigWitsml2_0Include.i
+++ b/swig/swigWitsml2_0Include.i
@@ -1792,13 +1792,18 @@ namespace WITSML2_0_NS
 		GETTER_AND_SETTER_GENERIC_OPTIONAL_ATTRIBUTE(gsoap_eml2_1::witsml20__WellDirection, DirectionWell)
 
 		GETTER_AND_SETTER_MEASURE_OPTIONAL_ATTRIBUTE(WaterDepth, gsoap_eml2_1::eml21__LengthUom)
-		GETTER_AND_SETTER_MEASURE_OPTIONAL_ATTRIBUTE(GroundElevation, gsoap_eml2_1::eml21__LengthUom)
+		GETTER_PRESENCE_ATTRIBUTE(GroundElevation)
 
 		GETTER_AND_SETTER_MEASURE_OPTIONAL_ATTRIBUTE(PcInterest, gsoap_eml2_1::eml21__DimensionlessUom)
 
 		GETTER_AND_SETTER_GENERIC_OPTIONAL_ATTRIBUTE(time_t, DTimLicense)
 		GETTER_AND_SETTER_GENERIC_OPTIONAL_ATTRIBUTE(time_t, DTimSpud)
 		GETTER_AND_SETTER_GENERIC_OPTIONAL_ATTRIBUTE(time_t, DTimPa)
+		
+		void setGroundElevation(double value, gsoap_eml2_1::eml21__LengthUom uom, const std::string& datum);
+		double getGroundElevationValue() const;
+		gsoap_eml2_1::eml21__LengthUom getGroundElevationUom() const;
+		std::string getGroundElevationDatum() const;
 		
 		void setTimeZone(bool direction, unsigned short hours, unsigned short minutes = 0);
 		GETTER_PRESENCE_ATTRIBUTE(TimeZone)

--- a/test/witsml2_0test/WellTest.cpp
+++ b/test/witsml2_0test/WellTest.cpp
@@ -49,7 +49,7 @@ void WellTest::initRepoHandler() {
 	well->setBlock("my Block");
 	// No county
 	well->setDTimLicense(defaultTimestamp);
-	well->setGroundElevation(10, gsoap_eml2_1::eml21__LengthUom__m);
+	well->setGroundElevation(10, gsoap_eml2_1::eml21__LengthUom__m, "MSL");
 	REQUIRE_THROWS(well->setTimeZone(true, 24));
 	REQUIRE_THROWS(well->setTimeZone(true, 22, 65));
 	well->setTimeZone(true, 0); // time zone == 'Z'
@@ -65,6 +65,7 @@ void WellTest::readRepoHandler() {
 	REQUIRE(well->getDTimLicense() == defaultTimestamp);
 	REQUIRE(well->getGroundElevationValue() == 10);
 	REQUIRE(well->getGroundElevationUom() == gsoap_eml2_1::eml21__LengthUom__m);
+	REQUIRE(well->getGroundElevationDatum() == "MSL");
 	REQUIRE(well->getTimeZoneDirection() == true);
 	REQUIRE(well->getTimeZoneHours() == 0);
 	REQUIRE(well->getTimeZoneMinutes() == 0);


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
In WITSML 2.0 Well GroundElevation, no method allows to get/set mandatory datum. This PR fixes that.

Does this close any currently open issues?
------------------------------------------
No.

Any relevant logs, error output, etc?
-------------------------------------
No.

Any other comments?
-------------------
No.

Where has this been tested?
---------------------------
**Operating System:** Windows 10 64bits

**Platform:** Visual Studio Community 2019
