### PR TITLE
Upgrade to latest ETP draft schema (dev 14)

### DIFF
--- a/etpServerExample/main.cpp
+++ b/etpServerExample/main.cpp
@@ -43,7 +43,7 @@ void generateProperties(RESQML2_NS::AbstractRepresentation* ijkgrid)
 			gsoap_eml2_3::resqml22__IndexableElement__cells, gsoap_resqml2_0_1::resqml20__ResqmlUom__m, gsoap_resqml2_0_1::resqml20__ResqmlPropertyKind__length);
 
 		double prop1Values[2] = { i, i };
-		continuousProp->pushBackDoubleHdf5Array3dOfValues(prop1Values, 2, 1, 1, nullptr, -1);
+		continuousProp->pushBackDoubleHdf5Array3dOfValues(prop1Values, 2, 1, 1, nullptr);
 
 		std::cout << "A new discrete property has been added" << std::endl;
 

--- a/example/HdfProxyExample.h
+++ b/example/HdfProxyExample.h
@@ -68,13 +68,13 @@ public:
 	/**
 	 * Get the used (native) datatype in a dataset
 	 */
-	hdf5_hid_t getHdfDatatypeInDataset(const std::string & datasetName) { throw std::logic_error("Not implemented yet"); }
+	COMMON_NS::AbstractObject::hdfDatatypeEnum getHdfDatatypeInDataset(const std::string & datasetName) final { throw std::logic_error("Not implemented yet"); }
 
 	/**
 	* Get the used datatype class in a dataset
 	* To compare with H5T_INTEGER, H5T_FLOAT , H5T_STRING , etc...
 	*/
-	int getHdfDatatypeClassInDataset(const std::string & datasetName) { throw std::logic_error("Not implemented yet"); }
+	int getHdfDatatypeClassInDataset(const std::string & datasetName) final { throw std::logic_error("Not implemented yet"); }
 
 	/**
 	* Write an itemized list of list into the HDF file by means of a single group containing 2 datasets.

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -1175,19 +1175,19 @@ void serializeStructuralModel(COMMON_NS::DataObjectRepository & pck, EML2_NS::Ab
 
 	// Contact 0: fault1Interp1 HANGING_WALL_SIDE STOPS horizon1Interp1 BOTH_SIDES
 	structuralOrganizationInterpretation->pushBackBinaryContact(fault1Interp1, gsoap_resqml2_0_1::resqml20__ContactSide__hanging_x0020wall,
-		gsoap_eml2_3::resqml22__ContactVerb__stops,
+		gsoap_eml2_3::resqml22__ContactVerb__interrupts,
 		horizon1Interp1, gsoap_resqml2_0_1::resqml20__ContactSide__both);
 	// Contact 1: fault1Interp1 FOOT_WALL_SIDE STOPS horizon1Interp1 BOTH_SIDES
 	structuralOrganizationInterpretation->pushBackBinaryContact(fault1Interp1, gsoap_resqml2_0_1::resqml20__ContactSide__footwall,
-		gsoap_eml2_3::resqml22__ContactVerb__stops,
+		gsoap_eml2_3::resqml22__ContactVerb__interrupts,
 		horizon1Interp1, gsoap_resqml2_0_1::resqml20__ContactSide__both);
 	// Contact 2: fault1Interp1 HANGING_WALL_SIDE STOPS horizon2Interp1 BOTH_SIDES
 	structuralOrganizationInterpretation->pushBackBinaryContact(fault1Interp1, gsoap_resqml2_0_1::resqml20__ContactSide__hanging_x0020wall,
-		gsoap_eml2_3::resqml22__ContactVerb__stops,
+		gsoap_eml2_3::resqml22__ContactVerb__interrupts,
 		horizon2Interp1, gsoap_resqml2_0_1::resqml20__ContactSide__both);
 	// Contact 3: fault1Interp1 FOOT_WALL_SIDE STOPS horizon2Interp1 BOTH_SIDES
 	structuralOrganizationInterpretation->pushBackBinaryContact(fault1Interp1, gsoap_resqml2_0_1::resqml20__ContactSide__footwall,
-		gsoap_eml2_3::resqml22__ContactVerb__stops,
+		gsoap_eml2_3::resqml22__ContactVerb__interrupts,
 		horizon2Interp1, gsoap_resqml2_0_1::resqml20__ContactSide__both);
 
 	// Contact 4: horizon1Interp1 STOPS AT yMinusFrontierInterp

--- a/src/common/AbstractObject.h
+++ b/src/common/AbstractObject.h
@@ -301,7 +301,7 @@ namespace COMMON_NS
 
 		enum hdfDatatypeEnum { UNKNOWN = 0, DOUBLE = 1, FLOAT = 2, LONG_64 = 3, ULONG_64 = 4, INT = 5, UINT = 6, SHORT = 7, USHORT = 8, CHAR = 9, UCHAR = 10};
 
-		virtual ~AbstractObject() {}
+		virtual ~AbstractObject() = default;
 
 		/**
 		 * Indicates if this data object is actually a partial object. A partial object just contains a mime

--- a/src/eml2/AbstractHdfProxy.h
+++ b/src/eml2/AbstractHdfProxy.h
@@ -82,15 +82,14 @@ namespace EML2_NS
 		virtual void close() = 0;
 
 		/**
-		 * Gets the native datatype (@c H5T_NATIVE_INT, @c H5T_NATIVE_UINT,
-		 * @c H5T_NATIVE_FLOAT, etc.) of a dataset
+		 * Gets the native datatype of a dataset
 		 *
 		 * @param 	datasetName	Name of the dataset.
 		 *
 		 * @returns	The native HDF5 datatype identifier of the dataset if successful, otherwise returns a
 		 * 			negative value.
 		 */
-		virtual hdf5_hid_t getHdfDatatypeInDataset(const std::string & datasetName) = 0;
+		virtual COMMON_NS::AbstractObject::hdfDatatypeEnum getHdfDatatypeInDataset(const std::string & datasetName) = 0;
 
 		/**
 		 * Gets the datatype class (@c H5T_INTEGER, @c H5T_FLOAT, @c H5T_STRING, etc.) of a dataset

--- a/src/eml2/HdfProxy.cpp
+++ b/src/eml2/HdfProxy.cpp
@@ -331,7 +331,7 @@ void HdfProxy::readArrayNdOfValues(
 	}
 }
 
-hid_t HdfProxy::getHdfDatatypeInDataset(const std::string & datasetName)
+COMMON_NS::AbstractObject::hdfDatatypeEnum HdfProxy::getHdfDatatypeInDataset(const std::string & datasetName)
 {
 	if (!isOpened()) {
 		open();
@@ -344,7 +344,28 @@ hid_t HdfProxy::getHdfDatatypeInDataset(const std::string & datasetName)
 	H5Dclose(dataset);
 	H5Tclose(datatype);
 
-	return native_datatype;
+	if (H5Tequal(native_datatype, H5T_NATIVE_DOUBLE) > 0)
+		return COMMON_NS::AbstractObject::hdfDatatypeEnum::DOUBLE;
+	else if (H5Tequal(native_datatype, H5T_NATIVE_FLOAT) > 0)
+		return COMMON_NS::AbstractObject::hdfDatatypeEnum::FLOAT;
+	else if (H5Tequal(native_datatype, H5T_NATIVE_LLONG) > 0)
+		return COMMON_NS::AbstractObject::hdfDatatypeEnum::LONG_64;
+	else if (H5Tequal(native_datatype, H5T_NATIVE_ULLONG) > 0)
+		return COMMON_NS::AbstractObject::hdfDatatypeEnum::ULONG_64;
+	else if (H5Tequal(native_datatype, H5T_NATIVE_INT) > 0)
+		return COMMON_NS::AbstractObject::hdfDatatypeEnum::INT;
+	else if (H5Tequal(native_datatype, H5T_NATIVE_UINT) > 0)
+		return COMMON_NS::AbstractObject::hdfDatatypeEnum::UINT;
+	else if (H5Tequal(native_datatype, H5T_NATIVE_SHORT) > 0)
+		return COMMON_NS::AbstractObject::hdfDatatypeEnum::SHORT;
+	else if (H5Tequal(native_datatype, H5T_NATIVE_USHORT) > 0)
+		return COMMON_NS::AbstractObject::hdfDatatypeEnum::USHORT;
+	else if (H5Tequal(native_datatype, H5T_NATIVE_CHAR) > 0)
+		return COMMON_NS::AbstractObject::hdfDatatypeEnum::CHAR;
+	else if (H5Tequal(native_datatype, H5T_NATIVE_UCHAR) > 0)
+		return COMMON_NS::AbstractObject::hdfDatatypeEnum::UCHAR;
+
+	return COMMON_NS::AbstractObject::hdfDatatypeEnum::UNKNOWN;
 }
 
 int HdfProxy::getHdfDatatypeClassInDataset(const std::string & datasetName)

--- a/src/eml2/HdfProxy.h
+++ b/src/eml2/HdfProxy.h
@@ -52,7 +52,7 @@ namespace EML2_NS
 
 		void close() final;
 
-		hdf5_hid_t getHdfDatatypeInDataset(const std::string& groupName) final;
+		COMMON_NS::AbstractObject::hdfDatatypeEnum getHdfDatatypeInDataset(const std::string& groupName) final;
 
 		int getHdfDatatypeClassInDataset(const std::string& datasetName) final;
 

--- a/src/etp/EtpHdfProxy.cpp
+++ b/src/etp/EtpHdfProxy.cpp
@@ -45,7 +45,7 @@ void EtpHdfProxy::open()
 	session->run();
 }
 
-hdf5_hid_t EtpHdfProxy::getHdfDatatypeInDataset(const std::string & datasetName)
+COMMON_NS::AbstractObject::hdfDatatypeEnum EtpHdfProxy::getHdfDatatypeInDataset(const std::string & datasetName)
 {
 	throw logic_error("Not implemented yet");
 }

--- a/src/etp/EtpHdfProxy.h
+++ b/src/etp/EtpHdfProxy.h
@@ -73,9 +73,8 @@ namespace ETP_NS
 
 		/*
 		* Get the used (native) datatype in a dataset
-		* To compare with H5T_NATIVE_INT, H5T_NATIVE_UINT, H5T_NATIVE_FLOAT, etc...
 		*/
-		hdf5_hid_t getHdfDatatypeInDataset(const std::string & groupName);
+		COMMON_NS::AbstractObject::hdfDatatypeEnum getHdfDatatypeInDataset(const std::string & groupName);
 
 		/**
 		* Get the used datatype class in a dataset

--- a/src/etp/EtpMessages.h
+++ b/src/etp/EtpMessages.h
@@ -150,27 +150,6 @@ namespace Energistics {
 	namespace Etp {	
 		namespace v12 {		
 			namespace Datatypes {			
-				struct ArrayOfNullableInt{				
-					std::vector<boost::optional<int32_t>> values;
-				};				
-			};			
-		};		
-	};	
-};
-namespace avro {
-	template<> struct codec_traits<Energistics::Etp::v12::Datatypes::ArrayOfNullableInt> {	
-		static void encode(Encoder& e, const Energistics::Etp::v12::Datatypes::ArrayOfNullableInt& v) {		
-			avro::encode(e, v.values);
-		}		
-		static void decode(Decoder& e, Energistics::Etp::v12::Datatypes::ArrayOfNullableInt& v) {		
-			avro::decode(e, v.values);
-		}		
-	};	
-}
-namespace Energistics {
-	namespace Etp {	
-		namespace v12 {		
-			namespace Datatypes {			
 				struct ArrayOfNullableBoolean{				
 					std::vector<boost::optional<bool>> values;
 				};				
@@ -184,6 +163,27 @@ namespace avro {
 			avro::encode(e, v.values);
 		}		
 		static void decode(Decoder& e, Energistics::Etp::v12::Datatypes::ArrayOfNullableBoolean& v) {		
+			avro::decode(e, v.values);
+		}		
+	};	
+}
+namespace Energistics {
+	namespace Etp {	
+		namespace v12 {		
+			namespace Datatypes {			
+				struct ArrayOfNullableInt{				
+					std::vector<boost::optional<int32_t>> values;
+				};				
+			};			
+		};		
+	};	
+};
+namespace avro {
+	template<> struct codec_traits<Energistics::Etp::v12::Datatypes::ArrayOfNullableInt> {	
+		static void encode(Encoder& e, const Energistics::Etp::v12::Datatypes::ArrayOfNullableInt& v) {		
+			avro::encode(e, v.values);
+		}		
+		static void decode(Decoder& e, Energistics::Etp::v12::Datatypes::ArrayOfNullableInt& v) {		
 			avro::decode(e, v.values);
 		}		
 	};	
@@ -1427,7 +1427,8 @@ namespace Energistics {
 					MaxDataArraySize=8,
 					StreamingTimeoutPeriod=9,
 					CascadeOnDataObjectTypes=10,
-					FrameChangeDetectionPeriod=11
+					FrameChangeDetectionPeriod=11,
+					DeleteRetentionTime=12
 				};				
 			};			
 		};		
@@ -2140,35 +2141,6 @@ namespace Energistics {
 		namespace v12 {		
 			namespace Datatypes {			
 				namespace Object {				
-					struct ContextInfo{					
-						std::string uri;
-						int32_t depth;
-						std::vector<std::string> dataObjectTypes;
-					};					
-				};				
-			};			
-		};		
-	};	
-};
-namespace avro {
-	template<> struct codec_traits<Energistics::Etp::v12::Datatypes::Object::ContextInfo> {	
-		static void encode(Encoder& e, const Energistics::Etp::v12::Datatypes::Object::ContextInfo& v) {		
-			avro::encode(e, v.uri);
-			avro::encode(e, v.depth);
-			avro::encode(e, v.dataObjectTypes);
-		}		
-		static void decode(Decoder& e, Energistics::Etp::v12::Datatypes::Object::ContextInfo& v) {		
-			avro::decode(e, v.uri);
-			avro::decode(e, v.depth);
-			avro::decode(e, v.dataObjectTypes);
-		}		
-	};	
-}
-namespace Energistics {
-	namespace Etp {	
-		namespace v12 {		
-			namespace Datatypes {			
-				namespace Object {				
 					enum ContextScopeKind {					
 						self=0,
 						sources=1,
@@ -2220,6 +2192,64 @@ namespace avro {
 			avro::decode(e, v.path);
 			avro::decode(e, v.lastChanged);
 			avro::decode(e, v.customData);
+		}		
+	};	
+}
+namespace Energistics {
+	namespace Etp {	
+		namespace v12 {		
+			namespace Datatypes {			
+				namespace Object {				
+					struct DeletedResource{					
+						std::string uri;
+						std::string dataObjectType;
+						int64_t deletedTime;
+						std::map<std::string, std::string> customData;
+					};					
+				};				
+			};			
+		};		
+	};	
+};
+namespace avro {
+	template<> struct codec_traits<Energistics::Etp::v12::Datatypes::Object::DeletedResource> {	
+		static void encode(Encoder& e, const Energistics::Etp::v12::Datatypes::Object::DeletedResource& v) {		
+			avro::encode(e, v.uri);
+			avro::encode(e, v.dataObjectType);
+			avro::encode(e, v.deletedTime);
+			avro::encode(e, v.customData);
+		}		
+		static void decode(Decoder& e, Energistics::Etp::v12::Datatypes::Object::DeletedResource& v) {		
+			avro::decode(e, v.uri);
+			avro::decode(e, v.dataObjectType);
+			avro::decode(e, v.deletedTime);
+			avro::decode(e, v.customData);
+		}		
+	};	
+}
+namespace Energistics {
+	namespace Etp {	
+		namespace v12 {		
+			namespace Datatypes {			
+				namespace Object {				
+					struct Edge{					
+						std::string sourceUri;
+						std::string targetUri;
+					};					
+				};				
+			};			
+		};		
+	};	
+};
+namespace avro {
+	template<> struct codec_traits<Energistics::Etp::v12::Datatypes::Object::Edge> {	
+		static void encode(Encoder& e, const Energistics::Etp::v12::Datatypes::Object::Edge& v) {		
+			avro::encode(e, v.sourceUri);
+			avro::encode(e, v.targetUri);
+		}		
+		static void decode(Decoder& e, Energistics::Etp::v12::Datatypes::Object::Edge& v) {		
+			avro::decode(e, v.sourceUri);
+			avro::decode(e, v.targetUri);
 		}		
 	};	
 }
@@ -2546,6 +2576,63 @@ namespace Energistics {
 		namespace v12 {		
 			namespace Datatypes {			
 				namespace Object {				
+					enum RelationshipKind {					
+						Organizational=0,
+						Contextual=1,
+						Both=2
+					};					
+				};				
+			};			
+		};		
+	};	
+};
+namespace avro {
+	template<> struct codec_traits<Energistics::Etp::v12::Datatypes::Object::RelationshipKind> {	
+		static void encode(Encoder& e, const Energistics::Etp::v12::Datatypes::Object::RelationshipKind& v) {		
+			e.encodeEnum(v);
+		}		
+		static void decode(Decoder& e, Energistics::Etp::v12::Datatypes::Object::RelationshipKind& v) {		
+			v = static_cast<Energistics::Etp::v12::Datatypes::Object::RelationshipKind>(e.decodeEnum());
+		}		
+	};	
+}
+namespace Energistics {
+	namespace Etp {	
+		namespace v12 {		
+			namespace Datatypes {			
+				namespace Object {				
+					struct ContextInfo{					
+						std::string uri;
+						int32_t depth;
+						std::vector<std::string> dataObjectTypes;
+						Energistics::Etp::v12::Datatypes::Object::RelationshipKind relationshipKind;
+					};					
+				};				
+			};			
+		};		
+	};	
+};
+namespace avro {
+	template<> struct codec_traits<Energistics::Etp::v12::Datatypes::Object::ContextInfo> {	
+		static void encode(Encoder& e, const Energistics::Etp::v12::Datatypes::Object::ContextInfo& v) {		
+			avro::encode(e, v.uri);
+			avro::encode(e, v.depth);
+			avro::encode(e, v.dataObjectTypes);
+			avro::encode(e, v.relationshipKind);
+		}		
+		static void decode(Decoder& e, Energistics::Etp::v12::Datatypes::Object::ContextInfo& v) {		
+			avro::decode(e, v.uri);
+			avro::decode(e, v.depth);
+			avro::decode(e, v.dataObjectTypes);
+			avro::decode(e, v.relationshipKind);
+		}		
+	};	
+}
+namespace Energistics {
+	namespace Etp {	
+		namespace v12 {		
+			namespace Datatypes {			
+				namespace Object {				
 					struct Resource{					
 						std::string uri;
 						std::vector<std::string> alternateUris;
@@ -2716,410 +2803,6 @@ namespace avro {
 namespace Energistics {
 	namespace Etp {	
 		namespace v12 {		
-			namespace PrivateProtocols {			
-				namespace WitsmlSoap {				
-					struct WMLS_AddToStore{					
-						std::string WMLtypeIn;
-						std::string XMLin;
-						std::string OptionsIn;
-						std::string CapabilitiesIn;
-						static const int messageTypeId=1;
-						static const int protocolId=Energistics::Etp::v12::Datatypes::WitsmlSoap;
-					};					
-				};				
-			};			
-		};		
-	};	
-};
-namespace avro {
-	template<> struct codec_traits<Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_AddToStore> {	
-		static void encode(Encoder& e, const Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_AddToStore& v) {		
-			avro::encode(e, v.WMLtypeIn);
-			avro::encode(e, v.XMLin);
-			avro::encode(e, v.OptionsIn);
-			avro::encode(e, v.CapabilitiesIn);
-		}		
-		static void decode(Decoder& e, Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_AddToStore& v) {		
-			avro::decode(e, v.WMLtypeIn);
-			avro::decode(e, v.XMLin);
-			avro::decode(e, v.OptionsIn);
-			avro::decode(e, v.CapabilitiesIn);
-		}		
-	};	
-}
-namespace Energistics {
-	namespace Etp {	
-		namespace v12 {		
-			namespace PrivateProtocols {			
-				namespace WitsmlSoap {				
-					struct WMLS_AddToStoreResponse{					
-						int32_t Result;
-						std::string SuppMsgOut;
-						static const int messageTypeId=2;
-						static const int protocolId=Energistics::Etp::v12::Datatypes::WitsmlSoap;
-					};					
-				};				
-			};			
-		};		
-	};	
-};
-namespace avro {
-	template<> struct codec_traits<Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_AddToStoreResponse> {	
-		static void encode(Encoder& e, const Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_AddToStoreResponse& v) {		
-			avro::encode(e, v.Result);
-			avro::encode(e, v.SuppMsgOut);
-		}		
-		static void decode(Decoder& e, Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_AddToStoreResponse& v) {		
-			avro::decode(e, v.Result);
-			avro::decode(e, v.SuppMsgOut);
-		}		
-	};	
-}
-namespace Energistics {
-	namespace Etp {	
-		namespace v12 {		
-			namespace PrivateProtocols {			
-				namespace WitsmlSoap {				
-					struct WMLS_DeleteFromStore{					
-						std::string WMLtypeIn;
-						std::string XMLin;
-						std::string OptionsIn;
-						std::string CapabilitiesIn;
-						static const int messageTypeId=3;
-						static const int protocolId=Energistics::Etp::v12::Datatypes::WitsmlSoap;
-					};					
-				};				
-			};			
-		};		
-	};	
-};
-namespace avro {
-	template<> struct codec_traits<Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_DeleteFromStore> {	
-		static void encode(Encoder& e, const Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_DeleteFromStore& v) {		
-			avro::encode(e, v.WMLtypeIn);
-			avro::encode(e, v.XMLin);
-			avro::encode(e, v.OptionsIn);
-			avro::encode(e, v.CapabilitiesIn);
-		}		
-		static void decode(Decoder& e, Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_DeleteFromStore& v) {		
-			avro::decode(e, v.WMLtypeIn);
-			avro::decode(e, v.XMLin);
-			avro::decode(e, v.OptionsIn);
-			avro::decode(e, v.CapabilitiesIn);
-		}		
-	};	
-}
-namespace Energistics {
-	namespace Etp {	
-		namespace v12 {		
-			namespace PrivateProtocols {			
-				namespace WitsmlSoap {				
-					struct WMLS_DeleteFromStoreResponse{					
-						int32_t Result;
-						std::string SuppMsgOut;
-						static const int messageTypeId=4;
-						static const int protocolId=Energistics::Etp::v12::Datatypes::WitsmlSoap;
-					};					
-				};				
-			};			
-		};		
-	};	
-};
-namespace avro {
-	template<> struct codec_traits<Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_DeleteFromStoreResponse> {	
-		static void encode(Encoder& e, const Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_DeleteFromStoreResponse& v) {		
-			avro::encode(e, v.Result);
-			avro::encode(e, v.SuppMsgOut);
-		}		
-		static void decode(Decoder& e, Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_DeleteFromStoreResponse& v) {		
-			avro::decode(e, v.Result);
-			avro::decode(e, v.SuppMsgOut);
-		}		
-	};	
-}
-namespace Energistics {
-	namespace Etp {	
-		namespace v12 {		
-			namespace PrivateProtocols {			
-				namespace WitsmlSoap {				
-					struct WMLS_GetBaseMsg{					
-						int32_t ReturnValueIn;
-						static const int messageTypeId=5;
-						static const int protocolId=Energistics::Etp::v12::Datatypes::WitsmlSoap;
-					};					
-				};				
-			};			
-		};		
-	};	
-};
-namespace avro {
-	template<> struct codec_traits<Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetBaseMsg> {	
-		static void encode(Encoder& e, const Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetBaseMsg& v) {		
-			avro::encode(e, v.ReturnValueIn);
-		}		
-		static void decode(Decoder& e, Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetBaseMsg& v) {		
-			avro::decode(e, v.ReturnValueIn);
-		}		
-	};	
-}
-namespace Energistics {
-	namespace Etp {	
-		namespace v12 {		
-			namespace PrivateProtocols {			
-				namespace WitsmlSoap {				
-					struct WMLS_GetBaseMsgResponse{					
-						std::string Result;
-						static const int messageTypeId=6;
-						static const int protocolId=Energistics::Etp::v12::Datatypes::WitsmlSoap;
-					};					
-				};				
-			};			
-		};		
-	};	
-};
-namespace avro {
-	template<> struct codec_traits<Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetBaseMsgResponse> {	
-		static void encode(Encoder& e, const Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetBaseMsgResponse& v) {		
-			avro::encode(e, v.Result);
-		}		
-		static void decode(Decoder& e, Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetBaseMsgResponse& v) {		
-			avro::decode(e, v.Result);
-		}		
-	};	
-}
-namespace Energistics {
-	namespace Etp {	
-		namespace v12 {		
-			namespace PrivateProtocols {			
-				namespace WitsmlSoap {				
-					struct WMLS_GetCap{					
-						std::string OptionsIn;
-						static const int messageTypeId=7;
-						static const int protocolId=Energistics::Etp::v12::Datatypes::WitsmlSoap;
-					};					
-				};				
-			};			
-		};		
-	};	
-};
-namespace avro {
-	template<> struct codec_traits<Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetCap> {	
-		static void encode(Encoder& e, const Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetCap& v) {		
-			avro::encode(e, v.OptionsIn);
-		}		
-		static void decode(Decoder& e, Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetCap& v) {		
-			avro::decode(e, v.OptionsIn);
-		}		
-	};	
-}
-namespace Energistics {
-	namespace Etp {	
-		namespace v12 {		
-			namespace PrivateProtocols {			
-				namespace WitsmlSoap {				
-					struct WMLS_GetCapResponse{					
-						int32_t Result;
-						std::string CapabilitiesOut;
-						std::string SuppMsgOut;
-						static const int messageTypeId=8;
-						static const int protocolId=Energistics::Etp::v12::Datatypes::WitsmlSoap;
-					};					
-				};				
-			};			
-		};		
-	};	
-};
-namespace avro {
-	template<> struct codec_traits<Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetCapResponse> {	
-		static void encode(Encoder& e, const Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetCapResponse& v) {		
-			avro::encode(e, v.Result);
-			avro::encode(e, v.CapabilitiesOut);
-			avro::encode(e, v.SuppMsgOut);
-		}		
-		static void decode(Decoder& e, Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetCapResponse& v) {		
-			avro::decode(e, v.Result);
-			avro::decode(e, v.CapabilitiesOut);
-			avro::decode(e, v.SuppMsgOut);
-		}		
-	};	
-}
-namespace Energistics {
-	namespace Etp {	
-		namespace v12 {		
-			namespace PrivateProtocols {			
-				namespace WitsmlSoap {				
-					struct WMLS_GetFromStore{					
-						std::string WMLtypeIn;
-						std::string XMLin;
-						std::string OptionsIn;
-						std::string CapabilitiesIn;
-						static const int messageTypeId=9;
-						static const int protocolId=Energistics::Etp::v12::Datatypes::WitsmlSoap;
-					};					
-				};				
-			};			
-		};		
-	};	
-};
-namespace avro {
-	template<> struct codec_traits<Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetFromStore> {	
-		static void encode(Encoder& e, const Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetFromStore& v) {		
-			avro::encode(e, v.WMLtypeIn);
-			avro::encode(e, v.XMLin);
-			avro::encode(e, v.OptionsIn);
-			avro::encode(e, v.CapabilitiesIn);
-		}		
-		static void decode(Decoder& e, Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetFromStore& v) {		
-			avro::decode(e, v.WMLtypeIn);
-			avro::decode(e, v.XMLin);
-			avro::decode(e, v.OptionsIn);
-			avro::decode(e, v.CapabilitiesIn);
-		}		
-	};	
-}
-namespace Energistics {
-	namespace Etp {	
-		namespace v12 {		
-			namespace PrivateProtocols {			
-				namespace WitsmlSoap {				
-					struct WMLS_GetFromStoreResponse{					
-						int32_t Result;
-						std::string XMLout;
-						std::string SuppMsgOut;
-						static const int messageTypeId=10;
-						static const int protocolId=Energistics::Etp::v12::Datatypes::WitsmlSoap;
-					};					
-				};				
-			};			
-		};		
-	};	
-};
-namespace avro {
-	template<> struct codec_traits<Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetFromStoreResponse> {	
-		static void encode(Encoder& e, const Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetFromStoreResponse& v) {		
-			avro::encode(e, v.Result);
-			avro::encode(e, v.XMLout);
-			avro::encode(e, v.SuppMsgOut);
-		}		
-		static void decode(Decoder& e, Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetFromStoreResponse& v) {		
-			avro::decode(e, v.Result);
-			avro::decode(e, v.XMLout);
-			avro::decode(e, v.SuppMsgOut);
-		}		
-	};	
-}
-namespace Energistics {
-	namespace Etp {	
-		namespace v12 {		
-			namespace PrivateProtocols {			
-				namespace WitsmlSoap {				
-					struct WMLS_GetVersion{					
-						static const int messageTypeId=11;
-						static const int protocolId=Energistics::Etp::v12::Datatypes::WitsmlSoap;
-					};					
-				};				
-			};			
-		};		
-	};	
-};
-namespace avro {
-	template<> struct codec_traits<Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetVersion> {	
-		static void encode(Encoder&, const Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetVersion&) {		
-		}		
-		static void decode(Decoder&, Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetVersion&) {		
-		}		
-	};	
-}
-namespace Energistics {
-	namespace Etp {	
-		namespace v12 {		
-			namespace PrivateProtocols {			
-				namespace WitsmlSoap {				
-					struct WMLS_GetVersionResponse{					
-						std::string Result;
-						static const int messageTypeId=12;
-						static const int protocolId=Energistics::Etp::v12::Datatypes::WitsmlSoap;
-					};					
-				};				
-			};			
-		};		
-	};	
-};
-namespace avro {
-	template<> struct codec_traits<Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetVersionResponse> {	
-		static void encode(Encoder& e, const Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetVersionResponse& v) {		
-			avro::encode(e, v.Result);
-		}		
-		static void decode(Decoder& e, Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetVersionResponse& v) {		
-			avro::decode(e, v.Result);
-		}		
-	};	
-}
-namespace Energistics {
-	namespace Etp {	
-		namespace v12 {		
-			namespace PrivateProtocols {			
-				namespace WitsmlSoap {				
-					struct WMLS_UpdateInStore{					
-						std::string WMLtypeIn;
-						std::string XMLin;
-						std::string OptionsIn;
-						std::string CapabilitiesIn;
-						static const int messageTypeId=13;
-						static const int protocolId=Energistics::Etp::v12::Datatypes::WitsmlSoap;
-					};					
-				};				
-			};			
-		};		
-	};	
-};
-namespace avro {
-	template<> struct codec_traits<Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_UpdateInStore> {	
-		static void encode(Encoder& e, const Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_UpdateInStore& v) {		
-			avro::encode(e, v.WMLtypeIn);
-			avro::encode(e, v.XMLin);
-			avro::encode(e, v.OptionsIn);
-			avro::encode(e, v.CapabilitiesIn);
-		}		
-		static void decode(Decoder& e, Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_UpdateInStore& v) {		
-			avro::decode(e, v.WMLtypeIn);
-			avro::decode(e, v.XMLin);
-			avro::decode(e, v.OptionsIn);
-			avro::decode(e, v.CapabilitiesIn);
-		}		
-	};	
-}
-namespace Energistics {
-	namespace Etp {	
-		namespace v12 {		
-			namespace PrivateProtocols {			
-				namespace WitsmlSoap {				
-					struct WMLS_UpdateInStoreResponse{					
-						int32_t Result;
-						std::string SuppMsgOut;
-						static const int messageTypeId=14;
-						static const int protocolId=Energistics::Etp::v12::Datatypes::WitsmlSoap;
-					};					
-				};				
-			};			
-		};		
-	};	
-};
-namespace avro {
-	template<> struct codec_traits<Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_UpdateInStoreResponse> {	
-		static void encode(Encoder& e, const Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_UpdateInStoreResponse& v) {		
-			avro::encode(e, v.Result);
-			avro::encode(e, v.SuppMsgOut);
-		}		
-		static void decode(Decoder& e, Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_UpdateInStoreResponse& v) {		
-			avro::decode(e, v.Result);
-			avro::decode(e, v.SuppMsgOut);
-		}		
-	};	
-}
-namespace Energistics {
-	namespace Etp {	
-		namespace v12 {		
 			namespace Protocol {			
 				namespace ChannelDataFrame {				
 					struct CancelGetFrame{					
@@ -3203,31 +2886,6 @@ namespace Energistics {
 		namespace v12 {		
 			namespace Protocol {			
 				namespace ChannelDataFrame {				
-					struct GetFrameResponseHeader{					
-						std::vector<std::string> channelUris;
-						static const int messageTypeId=4;
-						static const int protocolId=Energistics::Etp::v12::Datatypes::ChannelDataFrame;
-					};					
-				};				
-			};			
-		};		
-	};	
-};
-namespace avro {
-	template<> struct codec_traits<Energistics::Etp::v12::Protocol::ChannelDataFrame::GetFrameResponseHeader> {	
-		static void encode(Encoder& e, const Energistics::Etp::v12::Protocol::ChannelDataFrame::GetFrameResponseHeader& v) {		
-			avro::encode(e, v.channelUris);
-		}		
-		static void decode(Decoder& e, Energistics::Etp::v12::Protocol::ChannelDataFrame::GetFrameResponseHeader& v) {		
-			avro::decode(e, v.channelUris);
-		}		
-	};	
-}
-namespace Energistics {
-	namespace Etp {	
-		namespace v12 {		
-			namespace Protocol {			
-				namespace ChannelDataFrame {				
 					struct GetFrameMetadataResponse{					
 						std::string uri;
 						std::vector<Energistics::Etp::v12::Datatypes::ChannelData::IndexMetadataRecord> indexes;
@@ -3259,6 +2917,31 @@ namespace Energistics {
 		namespace v12 {		
 			namespace Protocol {			
 				namespace ChannelDataFrame {				
+					struct GetFrameResponseHeader{					
+						std::vector<std::string> channelUris;
+						static const int messageTypeId=4;
+						static const int protocolId=Energistics::Etp::v12::Datatypes::ChannelDataFrame;
+					};					
+				};				
+			};			
+		};		
+	};	
+};
+namespace avro {
+	template<> struct codec_traits<Energistics::Etp::v12::Protocol::ChannelDataFrame::GetFrameResponseHeader> {	
+		static void encode(Encoder& e, const Energistics::Etp::v12::Protocol::ChannelDataFrame::GetFrameResponseHeader& v) {		
+			avro::encode(e, v.channelUris);
+		}		
+		static void decode(Decoder& e, Energistics::Etp::v12::Protocol::ChannelDataFrame::GetFrameResponseHeader& v) {		
+			avro::decode(e, v.channelUris);
+		}		
+	};	
+}
+namespace Energistics {
+	namespace Etp {	
+		namespace v12 {		
+			namespace Protocol {			
+				namespace ChannelDataFrame {				
 					struct GetFrameResponseRows{					
 						std::vector<Energistics::Etp::v12::Datatypes::ChannelData::FrameRow> frame;
 						static const int messageTypeId=6;
@@ -3276,125 +2959,6 @@ namespace avro {
 		}		
 		static void decode(Decoder& e, Energistics::Etp::v12::Protocol::ChannelDataFrame::GetFrameResponseRows& v) {		
 			avro::decode(e, v.frame);
-		}		
-	};	
-}
-namespace Energistics {
-	namespace Etp {	
-		namespace v12 {		
-			namespace Protocol {			
-				namespace ChannelStreaming {				
-					struct ChannelData{					
-						std::vector<Energistics::Etp::v12::Datatypes::ChannelData::DataItem> data;
-						static const int messageTypeId=2;
-						static const int protocolId=Energistics::Etp::v12::Datatypes::ChannelStreaming;
-					};					
-				};				
-			};			
-		};		
-	};	
-};
-namespace avro {
-	template<> struct codec_traits<Energistics::Etp::v12::Protocol::ChannelStreaming::ChannelData> {	
-		static void encode(Encoder& e, const Energistics::Etp::v12::Protocol::ChannelStreaming::ChannelData& v) {		
-			avro::encode(e, v.data);
-		}		
-		static void decode(Decoder& e, Energistics::Etp::v12::Protocol::ChannelStreaming::ChannelData& v) {		
-			avro::decode(e, v.data);
-		}		
-	};	
-}
-namespace Energistics {
-	namespace Etp {	
-		namespace v12 {		
-			namespace Protocol {			
-				namespace ChannelStreaming {				
-					struct ChannelMetadata{					
-						std::vector<Energistics::Etp::v12::Datatypes::ChannelData::ChannelMetadataRecord> channels;
-						static const int messageTypeId=1;
-						static const int protocolId=Energistics::Etp::v12::Datatypes::ChannelStreaming;
-					};					
-				};				
-			};			
-		};		
-	};	
-};
-namespace avro {
-	template<> struct codec_traits<Energistics::Etp::v12::Protocol::ChannelStreaming::ChannelMetadata> {	
-		static void encode(Encoder& e, const Energistics::Etp::v12::Protocol::ChannelStreaming::ChannelMetadata& v) {		
-			avro::encode(e, v.channels);
-		}		
-		static void decode(Decoder& e, Energistics::Etp::v12::Protocol::ChannelStreaming::ChannelMetadata& v) {		
-			avro::decode(e, v.channels);
-		}		
-	};	
-}
-namespace Energistics {
-	namespace Etp {	
-		namespace v12 {		
-			namespace Protocol {			
-				namespace ChannelStreaming {				
-					struct StartStreaming{					
-						static const int messageTypeId=3;
-						static const int protocolId=Energistics::Etp::v12::Datatypes::ChannelStreaming;
-					};					
-				};				
-			};			
-		};		
-	};	
-};
-namespace avro {
-	template<> struct codec_traits<Energistics::Etp::v12::Protocol::ChannelStreaming::StartStreaming> {	
-		static void encode(Encoder&, const Energistics::Etp::v12::Protocol::ChannelStreaming::StartStreaming&) {		
-		}		
-		static void decode(Decoder&, Energistics::Etp::v12::Protocol::ChannelStreaming::StartStreaming&) {		
-		}		
-	};	
-}
-namespace Energistics {
-	namespace Etp {	
-		namespace v12 {		
-			namespace Protocol {			
-				namespace ChannelStreaming {				
-					struct StopStreaming{					
-						static const int messageTypeId=4;
-						static const int protocolId=Energistics::Etp::v12::Datatypes::ChannelStreaming;
-					};					
-				};				
-			};			
-		};		
-	};	
-};
-namespace avro {
-	template<> struct codec_traits<Energistics::Etp::v12::Protocol::ChannelStreaming::StopStreaming> {	
-		static void encode(Encoder&, const Energistics::Etp::v12::Protocol::ChannelStreaming::StopStreaming&) {		
-		}		
-		static void decode(Decoder&, Energistics::Etp::v12::Protocol::ChannelStreaming::StopStreaming&) {		
-		}		
-	};	
-}
-namespace Energistics {
-	namespace Etp {	
-		namespace v12 {		
-			namespace Protocol {			
-				namespace ChannelStreaming {				
-					struct TruncateChannels{					
-						std::vector<Energistics::Etp::v12::Datatypes::ChannelData::TruncateInfo> channels;
-						static const int messageTypeId=5;
-						static const int protocolId=Energistics::Etp::v12::Datatypes::ChannelStreaming;
-					};					
-				};				
-			};			
-		};		
-	};	
-};
-namespace avro {
-	template<> struct codec_traits<Energistics::Etp::v12::Protocol::ChannelStreaming::TruncateChannels> {	
-		static void encode(Encoder& e, const Energistics::Etp::v12::Protocol::ChannelStreaming::TruncateChannels& v) {		
-			avro::encode(e, v.channels);
-		}		
-		static void decode(Decoder& e, Energistics::Etp::v12::Protocol::ChannelStreaming::TruncateChannels& v) {		
-			avro::decode(e, v.channels);
 		}		
 	};	
 }
@@ -3626,6 +3190,125 @@ namespace avro {
 		}		
 		static void decode(Decoder& e, Energistics::Etp::v12::Protocol::ChannelDataLoad::TruncateChannelsResponse& v) {		
 			avro::decode(e, v.channelsTruncatedTime);
+		}		
+	};	
+}
+namespace Energistics {
+	namespace Etp {	
+		namespace v12 {		
+			namespace Protocol {			
+				namespace ChannelStreaming {				
+					struct ChannelData{					
+						std::vector<Energistics::Etp::v12::Datatypes::ChannelData::DataItem> data;
+						static const int messageTypeId=2;
+						static const int protocolId=Energistics::Etp::v12::Datatypes::ChannelStreaming;
+					};					
+				};				
+			};			
+		};		
+	};	
+};
+namespace avro {
+	template<> struct codec_traits<Energistics::Etp::v12::Protocol::ChannelStreaming::ChannelData> {	
+		static void encode(Encoder& e, const Energistics::Etp::v12::Protocol::ChannelStreaming::ChannelData& v) {		
+			avro::encode(e, v.data);
+		}		
+		static void decode(Decoder& e, Energistics::Etp::v12::Protocol::ChannelStreaming::ChannelData& v) {		
+			avro::decode(e, v.data);
+		}		
+	};	
+}
+namespace Energistics {
+	namespace Etp {	
+		namespace v12 {		
+			namespace Protocol {			
+				namespace ChannelStreaming {				
+					struct ChannelMetadata{					
+						std::vector<Energistics::Etp::v12::Datatypes::ChannelData::ChannelMetadataRecord> channels;
+						static const int messageTypeId=1;
+						static const int protocolId=Energistics::Etp::v12::Datatypes::ChannelStreaming;
+					};					
+				};				
+			};			
+		};		
+	};	
+};
+namespace avro {
+	template<> struct codec_traits<Energistics::Etp::v12::Protocol::ChannelStreaming::ChannelMetadata> {	
+		static void encode(Encoder& e, const Energistics::Etp::v12::Protocol::ChannelStreaming::ChannelMetadata& v) {		
+			avro::encode(e, v.channels);
+		}		
+		static void decode(Decoder& e, Energistics::Etp::v12::Protocol::ChannelStreaming::ChannelMetadata& v) {		
+			avro::decode(e, v.channels);
+		}		
+	};	
+}
+namespace Energistics {
+	namespace Etp {	
+		namespace v12 {		
+			namespace Protocol {			
+				namespace ChannelStreaming {				
+					struct StartStreaming{					
+						static const int messageTypeId=3;
+						static const int protocolId=Energistics::Etp::v12::Datatypes::ChannelStreaming;
+					};					
+				};				
+			};			
+		};		
+	};	
+};
+namespace avro {
+	template<> struct codec_traits<Energistics::Etp::v12::Protocol::ChannelStreaming::StartStreaming> {	
+		static void encode(Encoder&, const Energistics::Etp::v12::Protocol::ChannelStreaming::StartStreaming&) {		
+		}		
+		static void decode(Decoder&, Energistics::Etp::v12::Protocol::ChannelStreaming::StartStreaming&) {		
+		}		
+	};	
+}
+namespace Energistics {
+	namespace Etp {	
+		namespace v12 {		
+			namespace Protocol {			
+				namespace ChannelStreaming {				
+					struct StopStreaming{					
+						static const int messageTypeId=4;
+						static const int protocolId=Energistics::Etp::v12::Datatypes::ChannelStreaming;
+					};					
+				};				
+			};			
+		};		
+	};	
+};
+namespace avro {
+	template<> struct codec_traits<Energistics::Etp::v12::Protocol::ChannelStreaming::StopStreaming> {	
+		static void encode(Encoder&, const Energistics::Etp::v12::Protocol::ChannelStreaming::StopStreaming&) {		
+		}		
+		static void decode(Decoder&, Energistics::Etp::v12::Protocol::ChannelStreaming::StopStreaming&) {		
+		}		
+	};	
+}
+namespace Energistics {
+	namespace Etp {	
+		namespace v12 {		
+			namespace Protocol {			
+				namespace ChannelStreaming {				
+					struct TruncateChannels{					
+						std::vector<Energistics::Etp::v12::Datatypes::ChannelData::TruncateInfo> channels;
+						static const int messageTypeId=5;
+						static const int protocolId=Energistics::Etp::v12::Datatypes::ChannelStreaming;
+					};					
+				};				
+			};			
+		};		
+	};	
+};
+namespace avro {
+	template<> struct codec_traits<Energistics::Etp::v12::Protocol::ChannelStreaming::TruncateChannels> {	
+		static void encode(Encoder& e, const Energistics::Etp::v12::Protocol::ChannelStreaming::TruncateChannels& v) {		
+			avro::encode(e, v.channels);
+		}		
+		static void decode(Decoder& e, Energistics::Etp::v12::Protocol::ChannelStreaming::TruncateChannels& v) {		
+			avro::decode(e, v.channels);
 		}		
 	};	
 }
@@ -4725,12 +4408,69 @@ namespace Energistics {
 		namespace v12 {		
 			namespace Protocol {			
 				namespace Discovery {				
+					struct GetDeletedResources{					
+						std::string dataspaceUri;
+						boost::optional<int64_t> deleteTimeFilter;
+						std::vector<std::string> dataObjectTypes;
+						static const int messageTypeId=5;
+						static const int protocolId=Energistics::Etp::v12::Datatypes::Discovery;
+					};					
+				};				
+			};			
+		};		
+	};	
+};
+namespace avro {
+	template<> struct codec_traits<Energistics::Etp::v12::Protocol::Discovery::GetDeletedResources> {	
+		static void encode(Encoder& e, const Energistics::Etp::v12::Protocol::Discovery::GetDeletedResources& v) {		
+			avro::encode(e, v.dataspaceUri);
+			avro::encode(e, v.deleteTimeFilter);
+			avro::encode(e, v.dataObjectTypes);
+		}		
+		static void decode(Decoder& e, Energistics::Etp::v12::Protocol::Discovery::GetDeletedResources& v) {		
+			avro::decode(e, v.dataspaceUri);
+			avro::decode(e, v.deleteTimeFilter);
+			avro::decode(e, v.dataObjectTypes);
+		}		
+	};	
+}
+namespace Energistics {
+	namespace Etp {	
+		namespace v12 {		
+			namespace Protocol {			
+				namespace Discovery {				
+					struct GetDeletedResourcesResponse{					
+						std::vector<Energistics::Etp::v12::Datatypes::Object::DeletedResource> deletedResources;
+						static const int messageTypeId=6;
+						static const int protocolId=Energistics::Etp::v12::Datatypes::Discovery;
+					};					
+				};				
+			};			
+		};		
+	};	
+};
+namespace avro {
+	template<> struct codec_traits<Energistics::Etp::v12::Protocol::Discovery::GetDeletedResourcesResponse> {	
+		static void encode(Encoder& e, const Energistics::Etp::v12::Protocol::Discovery::GetDeletedResourcesResponse& v) {		
+			avro::encode(e, v.deletedResources);
+		}		
+		static void decode(Decoder& e, Energistics::Etp::v12::Protocol::Discovery::GetDeletedResourcesResponse& v) {		
+			avro::decode(e, v.deletedResources);
+		}		
+	};	
+}
+namespace Energistics {
+	namespace Etp {	
+		namespace v12 {		
+			namespace Protocol {			
+				namespace Discovery {				
 					struct GetResources{					
 						Energistics::Etp::v12::Datatypes::Object::ContextInfo context;
 						Energistics::Etp::v12::Datatypes::Object::ContextScopeKind scope;
 						bool countObjects=false;
 						boost::optional<int64_t> storeLastWriteFilter;
 						boost::optional<Energistics::Etp::v12::Datatypes::Object::ActiveStatusKind> activeStatusFilter;
+						bool includeEdges=false;
 						static const int messageTypeId=1;
 						static const int protocolId=Energistics::Etp::v12::Datatypes::Discovery;
 					};					
@@ -4747,6 +4487,7 @@ namespace avro {
 			avro::encode(e, v.countObjects);
 			avro::encode(e, v.storeLastWriteFilter);
 			avro::encode(e, v.activeStatusFilter);
+			avro::encode(e, v.includeEdges);
 		}		
 		static void decode(Decoder& e, Energistics::Etp::v12::Protocol::Discovery::GetResources& v) {		
 			avro::decode(e, v.context);
@@ -4754,6 +4495,32 @@ namespace avro {
 			avro::decode(e, v.countObjects);
 			avro::decode(e, v.storeLastWriteFilter);
 			avro::decode(e, v.activeStatusFilter);
+			avro::decode(e, v.includeEdges);
+		}		
+	};	
+}
+namespace Energistics {
+	namespace Etp {	
+		namespace v12 {		
+			namespace Protocol {			
+				namespace Discovery {				
+					struct GetResourcesEdgesResponse{					
+						std::vector<Energistics::Etp::v12::Datatypes::Object::Edge> edges;
+						static const int messageTypeId=7;
+						static const int protocolId=Energistics::Etp::v12::Datatypes::Discovery;
+					};					
+				};				
+			};			
+		};		
+	};	
+};
+namespace avro {
+	template<> struct codec_traits<Energistics::Etp::v12::Protocol::Discovery::GetResourcesEdgesResponse> {	
+		static void encode(Encoder& e, const Energistics::Etp::v12::Protocol::Discovery::GetResourcesEdgesResponse& v) {		
+			avro::encode(e, v.edges);
+		}		
+		static void decode(Decoder& e, Energistics::Etp::v12::Protocol::Discovery::GetResourcesEdgesResponse& v) {		
+			avro::decode(e, v.edges);
 		}		
 	};	
 }
@@ -6392,6 +6159,410 @@ namespace avro {
 			avro::decode(e, v.transactionUuid);
 			avro::decode(e, v.successful);
 			avro::decode(e, v.failureReason);
+		}		
+	};	
+}
+namespace Energistics {
+	namespace Etp {	
+		namespace v12 {		
+			namespace PrivateProtocols {			
+				namespace WitsmlSoap {				
+					struct WMLS_AddToStore{					
+						std::string WMLtypeIn;
+						std::string XMLin;
+						std::string OptionsIn;
+						std::string CapabilitiesIn;
+						static const int messageTypeId=1;
+						static const int protocolId=Energistics::Etp::v12::Datatypes::WitsmlSoap;
+					};					
+				};				
+			};			
+		};		
+	};	
+};
+namespace avro {
+	template<> struct codec_traits<Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_AddToStore> {	
+		static void encode(Encoder& e, const Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_AddToStore& v) {		
+			avro::encode(e, v.WMLtypeIn);
+			avro::encode(e, v.XMLin);
+			avro::encode(e, v.OptionsIn);
+			avro::encode(e, v.CapabilitiesIn);
+		}		
+		static void decode(Decoder& e, Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_AddToStore& v) {		
+			avro::decode(e, v.WMLtypeIn);
+			avro::decode(e, v.XMLin);
+			avro::decode(e, v.OptionsIn);
+			avro::decode(e, v.CapabilitiesIn);
+		}		
+	};	
+}
+namespace Energistics {
+	namespace Etp {	
+		namespace v12 {		
+			namespace PrivateProtocols {			
+				namespace WitsmlSoap {				
+					struct WMLS_AddToStoreResponse{					
+						int32_t Result;
+						std::string SuppMsgOut;
+						static const int messageTypeId=2;
+						static const int protocolId=Energistics::Etp::v12::Datatypes::WitsmlSoap;
+					};					
+				};				
+			};			
+		};		
+	};	
+};
+namespace avro {
+	template<> struct codec_traits<Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_AddToStoreResponse> {	
+		static void encode(Encoder& e, const Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_AddToStoreResponse& v) {		
+			avro::encode(e, v.Result);
+			avro::encode(e, v.SuppMsgOut);
+		}		
+		static void decode(Decoder& e, Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_AddToStoreResponse& v) {		
+			avro::decode(e, v.Result);
+			avro::decode(e, v.SuppMsgOut);
+		}		
+	};	
+}
+namespace Energistics {
+	namespace Etp {	
+		namespace v12 {		
+			namespace PrivateProtocols {			
+				namespace WitsmlSoap {				
+					struct WMLS_DeleteFromStore{					
+						std::string WMLtypeIn;
+						std::string XMLin;
+						std::string OptionsIn;
+						std::string CapabilitiesIn;
+						static const int messageTypeId=3;
+						static const int protocolId=Energistics::Etp::v12::Datatypes::WitsmlSoap;
+					};					
+				};				
+			};			
+		};		
+	};	
+};
+namespace avro {
+	template<> struct codec_traits<Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_DeleteFromStore> {	
+		static void encode(Encoder& e, const Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_DeleteFromStore& v) {		
+			avro::encode(e, v.WMLtypeIn);
+			avro::encode(e, v.XMLin);
+			avro::encode(e, v.OptionsIn);
+			avro::encode(e, v.CapabilitiesIn);
+		}		
+		static void decode(Decoder& e, Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_DeleteFromStore& v) {		
+			avro::decode(e, v.WMLtypeIn);
+			avro::decode(e, v.XMLin);
+			avro::decode(e, v.OptionsIn);
+			avro::decode(e, v.CapabilitiesIn);
+		}		
+	};	
+}
+namespace Energistics {
+	namespace Etp {	
+		namespace v12 {		
+			namespace PrivateProtocols {			
+				namespace WitsmlSoap {				
+					struct WMLS_DeleteFromStoreResponse{					
+						int32_t Result;
+						std::string SuppMsgOut;
+						static const int messageTypeId=4;
+						static const int protocolId=Energistics::Etp::v12::Datatypes::WitsmlSoap;
+					};					
+				};				
+			};			
+		};		
+	};	
+};
+namespace avro {
+	template<> struct codec_traits<Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_DeleteFromStoreResponse> {	
+		static void encode(Encoder& e, const Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_DeleteFromStoreResponse& v) {		
+			avro::encode(e, v.Result);
+			avro::encode(e, v.SuppMsgOut);
+		}		
+		static void decode(Decoder& e, Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_DeleteFromStoreResponse& v) {		
+			avro::decode(e, v.Result);
+			avro::decode(e, v.SuppMsgOut);
+		}		
+	};	
+}
+namespace Energistics {
+	namespace Etp {	
+		namespace v12 {		
+			namespace PrivateProtocols {			
+				namespace WitsmlSoap {				
+					struct WMLS_GetBaseMsg{					
+						int32_t ReturnValueIn;
+						static const int messageTypeId=5;
+						static const int protocolId=Energistics::Etp::v12::Datatypes::WitsmlSoap;
+					};					
+				};				
+			};			
+		};		
+	};	
+};
+namespace avro {
+	template<> struct codec_traits<Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetBaseMsg> {	
+		static void encode(Encoder& e, const Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetBaseMsg& v) {		
+			avro::encode(e, v.ReturnValueIn);
+		}		
+		static void decode(Decoder& e, Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetBaseMsg& v) {		
+			avro::decode(e, v.ReturnValueIn);
+		}		
+	};	
+}
+namespace Energistics {
+	namespace Etp {	
+		namespace v12 {		
+			namespace PrivateProtocols {			
+				namespace WitsmlSoap {				
+					struct WMLS_GetBaseMsgResponse{					
+						std::string Result;
+						static const int messageTypeId=6;
+						static const int protocolId=Energistics::Etp::v12::Datatypes::WitsmlSoap;
+					};					
+				};				
+			};			
+		};		
+	};	
+};
+namespace avro {
+	template<> struct codec_traits<Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetBaseMsgResponse> {	
+		static void encode(Encoder& e, const Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetBaseMsgResponse& v) {		
+			avro::encode(e, v.Result);
+		}		
+		static void decode(Decoder& e, Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetBaseMsgResponse& v) {		
+			avro::decode(e, v.Result);
+		}		
+	};	
+}
+namespace Energistics {
+	namespace Etp {	
+		namespace v12 {		
+			namespace PrivateProtocols {			
+				namespace WitsmlSoap {				
+					struct WMLS_GetCap{					
+						std::string OptionsIn;
+						static const int messageTypeId=7;
+						static const int protocolId=Energistics::Etp::v12::Datatypes::WitsmlSoap;
+					};					
+				};				
+			};			
+		};		
+	};	
+};
+namespace avro {
+	template<> struct codec_traits<Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetCap> {	
+		static void encode(Encoder& e, const Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetCap& v) {		
+			avro::encode(e, v.OptionsIn);
+		}		
+		static void decode(Decoder& e, Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetCap& v) {		
+			avro::decode(e, v.OptionsIn);
+		}		
+	};	
+}
+namespace Energistics {
+	namespace Etp {	
+		namespace v12 {		
+			namespace PrivateProtocols {			
+				namespace WitsmlSoap {				
+					struct WMLS_GetCapResponse{					
+						int32_t Result;
+						std::string CapabilitiesOut;
+						std::string SuppMsgOut;
+						static const int messageTypeId=8;
+						static const int protocolId=Energistics::Etp::v12::Datatypes::WitsmlSoap;
+					};					
+				};				
+			};			
+		};		
+	};	
+};
+namespace avro {
+	template<> struct codec_traits<Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetCapResponse> {	
+		static void encode(Encoder& e, const Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetCapResponse& v) {		
+			avro::encode(e, v.Result);
+			avro::encode(e, v.CapabilitiesOut);
+			avro::encode(e, v.SuppMsgOut);
+		}		
+		static void decode(Decoder& e, Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetCapResponse& v) {		
+			avro::decode(e, v.Result);
+			avro::decode(e, v.CapabilitiesOut);
+			avro::decode(e, v.SuppMsgOut);
+		}		
+	};	
+}
+namespace Energistics {
+	namespace Etp {	
+		namespace v12 {		
+			namespace PrivateProtocols {			
+				namespace WitsmlSoap {				
+					struct WMLS_GetFromStore{					
+						std::string WMLtypeIn;
+						std::string XMLin;
+						std::string OptionsIn;
+						std::string CapabilitiesIn;
+						static const int messageTypeId=9;
+						static const int protocolId=Energistics::Etp::v12::Datatypes::WitsmlSoap;
+					};					
+				};				
+			};			
+		};		
+	};	
+};
+namespace avro {
+	template<> struct codec_traits<Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetFromStore> {	
+		static void encode(Encoder& e, const Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetFromStore& v) {		
+			avro::encode(e, v.WMLtypeIn);
+			avro::encode(e, v.XMLin);
+			avro::encode(e, v.OptionsIn);
+			avro::encode(e, v.CapabilitiesIn);
+		}		
+		static void decode(Decoder& e, Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetFromStore& v) {		
+			avro::decode(e, v.WMLtypeIn);
+			avro::decode(e, v.XMLin);
+			avro::decode(e, v.OptionsIn);
+			avro::decode(e, v.CapabilitiesIn);
+		}		
+	};	
+}
+namespace Energistics {
+	namespace Etp {	
+		namespace v12 {		
+			namespace PrivateProtocols {			
+				namespace WitsmlSoap {				
+					struct WMLS_GetFromStoreResponse{					
+						int32_t Result;
+						std::string XMLout;
+						std::string SuppMsgOut;
+						static const int messageTypeId=10;
+						static const int protocolId=Energistics::Etp::v12::Datatypes::WitsmlSoap;
+					};					
+				};				
+			};			
+		};		
+	};	
+};
+namespace avro {
+	template<> struct codec_traits<Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetFromStoreResponse> {	
+		static void encode(Encoder& e, const Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetFromStoreResponse& v) {		
+			avro::encode(e, v.Result);
+			avro::encode(e, v.XMLout);
+			avro::encode(e, v.SuppMsgOut);
+		}		
+		static void decode(Decoder& e, Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetFromStoreResponse& v) {		
+			avro::decode(e, v.Result);
+			avro::decode(e, v.XMLout);
+			avro::decode(e, v.SuppMsgOut);
+		}		
+	};	
+}
+namespace Energistics {
+	namespace Etp {	
+		namespace v12 {		
+			namespace PrivateProtocols {			
+				namespace WitsmlSoap {				
+					struct WMLS_GetVersion{					
+						static const int messageTypeId=11;
+						static const int protocolId=Energistics::Etp::v12::Datatypes::WitsmlSoap;
+					};					
+				};				
+			};			
+		};		
+	};	
+};
+namespace avro {
+	template<> struct codec_traits<Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetVersion> {	
+		static void encode(Encoder&, const Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetVersion&) {		
+		}		
+		static void decode(Decoder&, Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetVersion&) {		
+		}		
+	};	
+}
+namespace Energistics {
+	namespace Etp {	
+		namespace v12 {		
+			namespace PrivateProtocols {			
+				namespace WitsmlSoap {				
+					struct WMLS_GetVersionResponse{					
+						std::string Result;
+						static const int messageTypeId=12;
+						static const int protocolId=Energistics::Etp::v12::Datatypes::WitsmlSoap;
+					};					
+				};				
+			};			
+		};		
+	};	
+};
+namespace avro {
+	template<> struct codec_traits<Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetVersionResponse> {	
+		static void encode(Encoder& e, const Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetVersionResponse& v) {		
+			avro::encode(e, v.Result);
+		}		
+		static void decode(Decoder& e, Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_GetVersionResponse& v) {		
+			avro::decode(e, v.Result);
+		}		
+	};	
+}
+namespace Energistics {
+	namespace Etp {	
+		namespace v12 {		
+			namespace PrivateProtocols {			
+				namespace WitsmlSoap {				
+					struct WMLS_UpdateInStore{					
+						std::string WMLtypeIn;
+						std::string XMLin;
+						std::string OptionsIn;
+						std::string CapabilitiesIn;
+						static const int messageTypeId=13;
+						static const int protocolId=Energistics::Etp::v12::Datatypes::WitsmlSoap;
+					};					
+				};				
+			};			
+		};		
+	};	
+};
+namespace avro {
+	template<> struct codec_traits<Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_UpdateInStore> {	
+		static void encode(Encoder& e, const Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_UpdateInStore& v) {		
+			avro::encode(e, v.WMLtypeIn);
+			avro::encode(e, v.XMLin);
+			avro::encode(e, v.OptionsIn);
+			avro::encode(e, v.CapabilitiesIn);
+		}		
+		static void decode(Decoder& e, Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_UpdateInStore& v) {		
+			avro::decode(e, v.WMLtypeIn);
+			avro::decode(e, v.XMLin);
+			avro::decode(e, v.OptionsIn);
+			avro::decode(e, v.CapabilitiesIn);
+		}		
+	};	
+}
+namespace Energistics {
+	namespace Etp {	
+		namespace v12 {		
+			namespace PrivateProtocols {			
+				namespace WitsmlSoap {				
+					struct WMLS_UpdateInStoreResponse{					
+						int32_t Result;
+						std::string SuppMsgOut;
+						static const int messageTypeId=14;
+						static const int protocolId=Energistics::Etp::v12::Datatypes::WitsmlSoap;
+					};					
+				};				
+			};			
+		};		
+	};	
+};
+namespace avro {
+	template<> struct codec_traits<Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_UpdateInStoreResponse> {	
+		static void encode(Encoder& e, const Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_UpdateInStoreResponse& v) {		
+			avro::encode(e, v.Result);
+			avro::encode(e, v.SuppMsgOut);
+		}		
+		static void decode(Decoder& e, Energistics::Etp::v12::PrivateProtocols::WitsmlSoap::WMLS_UpdateInStoreResponse& v) {		
+			avro::decode(e, v.Result);
+			avro::decode(e, v.SuppMsgOut);
 		}		
 	};	
 }

--- a/src/resqml2/AbstractOrganizationInterpretation.cpp
+++ b/src/resqml2/AbstractOrganizationInterpretation.cpp
@@ -82,9 +82,11 @@ namespace {
 	}
 
 	resqml20__ContactVerb mapVerbFrom(gsoap_eml2_3::resqml22__ContactVerb verb) {
-		return verb == gsoap_eml2_3::resqml22__ContactVerb::resqml22__ContactVerb__crosses
-			? resqml20__ContactVerb::resqml20__ContactVerb__crosses
-			: resqml20__ContactVerb::resqml20__ContactVerb__interrupts;
+		switch (verb) {
+		case gsoap_eml2_3::resqml22__ContactVerb::resqml22__ContactVerb__crosses : return resqml20__ContactVerb::resqml20__ContactVerb__crosses;
+		case gsoap_eml2_3::resqml22__ContactVerb::resqml22__ContactVerb__interrupts :return resqml20__ContactVerb::resqml20__ContactVerb__splits; // see https://energistics.atlassian.net/browse/RESQML-578
+		case gsoap_eml2_3::resqml22__ContactVerb::resqml22__ContactVerb__stops:return resqml20__ContactVerb::resqml20__ContactVerb__stops_x0020at;
+		}
 	}
 }
 
@@ -105,9 +107,13 @@ void AbstractOrganizationInterpretation::pushBackBinaryContact(AbstractFeatureIn
 		org->ContactInterpretation.push_back(contact);
 
 		contact->ContactRelationship = computeFrom(subject, directObject);
-		contact->Subject = subject->newContactElementReference2_0_1(); // Not to add for EPC relationships since by business rule it must be present in the object listing/stack of the organization
+		contact->Subject = verb == gsoap_eml2_3::resqml22__ContactVerb::resqml22__ContactVerb__stops // stops is mapped with stops at in 2.0.1
+			? directObject->newContactElementReference2_0_1()
+			: subject->newContactElementReference2_0_1();
 		contact->Verb = mapVerbFrom(verb);
-		contact->DirectObject = directObject->newContactElementReference2_0_1(); // Not to add for EPC relationships since by business rule it must be present in the object listing/stack of the organization
+		contact->DirectObject = verb == gsoap_eml2_3::resqml22__ContactVerb::resqml22__ContactVerb__stops // stops is mapped with stops at in 2.0.1
+			? subject->newContactElementReference2_0_1()
+			: directObject->newContactElementReference2_0_1();
 	}
 	else if (gsoapProxy2_3 != nullptr) {
 		gsoap_eml2_3::resqml22__AbstractOrganizationInterpretation* org = static_cast<gsoap_eml2_3::resqml22__AbstractOrganizationInterpretation*>(gsoapProxy2_3);
@@ -129,8 +135,14 @@ void AbstractOrganizationInterpretation::pushBackBinaryContact(AbstractFeatureIn
 	if (gsoapProxy2_0_1 != nullptr) {
 		resqml20__AbstractOrganizationInterpretation* org = static_cast<resqml20__AbstractOrganizationInterpretation*>(gsoapProxy2_0_1);
 		resqml20__BinaryContactInterpretationPart* contact = static_cast<resqml20__BinaryContactInterpretationPart*>(org->ContactInterpretation[org->ContactInterpretation.size() - 1]);
-		contact->DirectObject->Qualifier = static_cast<resqml20__ContactSide*>(soap_malloc(gsoapProxy2_0_1->soap, sizeof(resqml20__ContactSide)));
-		*(contact->DirectObject->Qualifier) = static_cast<resqml20__ContactSide>(directObjectQualifier);
+		if (gsoap_eml2_3::resqml22__ContactVerb::resqml22__ContactVerb__stops) { // stops is mapped with stops at in 2.0.1)
+			contact->Subject->Qualifier = static_cast<resqml20__ContactSide*>(soap_malloc(gsoapProxy2_0_1->soap, sizeof(resqml20__ContactSide)));
+			*(contact->Subject->Qualifier) = static_cast<resqml20__ContactSide>(directObjectQualifier);
+		}
+		else {
+			contact->DirectObject->Qualifier = static_cast<resqml20__ContactSide*>(soap_malloc(gsoapProxy2_0_1->soap, sizeof(resqml20__ContactSide)));
+			*(contact->DirectObject->Qualifier) = static_cast<resqml20__ContactSide>(directObjectQualifier);
+		}
 	}
 	else if (gsoapProxy2_3 != nullptr) {
 		gsoap_eml2_3::resqml22__AbstractOrganizationInterpretation* org = static_cast<gsoap_eml2_3::resqml22__AbstractOrganizationInterpretation*>(gsoapProxy2_3);
@@ -149,8 +161,14 @@ void AbstractOrganizationInterpretation::pushBackBinaryContact(AbstractFeatureIn
 	if (gsoapProxy2_0_1 != nullptr) {
 		resqml20__AbstractOrganizationInterpretation* org = static_cast<resqml20__AbstractOrganizationInterpretation*>(gsoapProxy2_0_1);
 		resqml20__BinaryContactInterpretationPart* contact = static_cast<resqml20__BinaryContactInterpretationPart*>(org->ContactInterpretation[org->ContactInterpretation.size() - 1]);
-		contact->Subject->Qualifier = static_cast<resqml20__ContactSide*>(soap_malloc(gsoapProxy2_0_1->soap, sizeof(resqml20__ContactSide)));
-		*(contact->Subject->Qualifier) = static_cast<resqml20__ContactSide>(subjectQualifier);
+		if (gsoap_eml2_3::resqml22__ContactVerb::resqml22__ContactVerb__stops) { // stops is mapped with stops at in 2.0.1)
+			contact->DirectObject->Qualifier = static_cast<resqml20__ContactSide*>(soap_malloc(gsoapProxy2_0_1->soap, sizeof(resqml20__ContactSide)));
+			*(contact->DirectObject->Qualifier) = static_cast<resqml20__ContactSide>(subjectQualifier);
+		}
+		else {
+			contact->Subject->Qualifier = static_cast<resqml20__ContactSide*>(soap_malloc(gsoapProxy2_0_1->soap, sizeof(resqml20__ContactSide)));
+			*(contact->Subject->Qualifier) = static_cast<resqml20__ContactSide>(subjectQualifier);
+		}
 	}
 	else if (gsoapProxy2_3 != nullptr) {
 		gsoap_eml2_3::resqml22__AbstractOrganizationInterpretation* org = static_cast<gsoap_eml2_3::resqml22__AbstractOrganizationInterpretation*>(gsoapProxy2_3);

--- a/src/resqml2/AbstractOrganizationInterpretation.h
+++ b/src/resqml2/AbstractOrganizationInterpretation.h
@@ -46,7 +46,7 @@ namespace RESQML2_NS
 	public:
 
 		/** Destructor does nothing since the memory is managed by the gsoap context. */
-		virtual ~AbstractOrganizationInterpretation() {}
+		virtual ~AbstractOrganizationInterpretation() = default;
 
 		/**
 		 * Adds a binary contact to this organization interpretation by means of a simple sentence.

--- a/src/resqml2/AbstractProperty.cpp
+++ b/src/resqml2/AbstractProperty.cpp
@@ -604,29 +604,7 @@ COMMON_NS::AbstractObject::hdfDatatypeEnum AbstractProperty::getValuesHdfDatatyp
 	std::string dsPath;
 	EML2_NS::AbstractHdfProxy * hdfProxy = getDatasetOfPatch(0, nullValue, dsPath);
 
-	const hid_t dt = hdfProxy->getHdfDatatypeInDataset(dsPath);
-	if (H5Tequal(dt, H5T_NATIVE_DOUBLE) > 0)
-		return COMMON_NS::AbstractObject::hdfDatatypeEnum::DOUBLE;
-	else if (H5Tequal(dt, H5T_NATIVE_FLOAT) > 0)
-		return COMMON_NS::AbstractObject::hdfDatatypeEnum::FLOAT;
-	else if (H5Tequal(dt, H5T_NATIVE_LLONG) > 0)
-		return COMMON_NS::AbstractObject::hdfDatatypeEnum::LONG_64;
-	else if (H5Tequal(dt, H5T_NATIVE_ULLONG) > 0)
-		return COMMON_NS::AbstractObject::hdfDatatypeEnum::ULONG_64;
-	else if (H5Tequal(dt, H5T_NATIVE_INT) > 0)
-		return COMMON_NS::AbstractObject::hdfDatatypeEnum::INT;
-	else if (H5Tequal(dt, H5T_NATIVE_UINT) > 0)
-		return COMMON_NS::AbstractObject::hdfDatatypeEnum::UINT;
-	else if (H5Tequal(dt, H5T_NATIVE_SHORT) > 0)
-		return COMMON_NS::AbstractObject::hdfDatatypeEnum::SHORT;
-	else if (H5Tequal(dt, H5T_NATIVE_USHORT) > 0)
-		return COMMON_NS::AbstractObject::hdfDatatypeEnum::USHORT;
-	else if (H5Tequal(dt, H5T_NATIVE_CHAR) > 0)
-		return COMMON_NS::AbstractObject::hdfDatatypeEnum::CHAR;
-	else if (H5Tequal(dt, H5T_NATIVE_UCHAR) > 0)
-		return COMMON_NS::AbstractObject::hdfDatatypeEnum::UCHAR;
-
-	return COMMON_NS::AbstractObject::hdfDatatypeEnum::UNKNOWN; // unknwown datatype...
+	return hdfProxy->getHdfDatatypeInDataset(dsPath);
 }
 
 unsigned int AbstractProperty::getValuesCountOfDimensionOfPatch(unsigned int dimIndex, unsigned int patchIndex) const

--- a/src/resqml2/AbstractSeismicLineFeature.cpp
+++ b/src/resqml2/AbstractSeismicLineFeature.cpp
@@ -108,7 +108,7 @@ std::vector<std::string> AbstractSeismicLineFeature::getTraceLabels() const
 			return result;
 		}
 		// Check if the hdf dataset really contains unsigned char values.
-		if (H5Tequal(hdfProxy->getHdfDatatypeInDataset(dsPart->PathInExternalFile), H5T_NATIVE_UCHAR) > 0) {
+		if (hdfProxy->getHdfDatatypeInDataset(dsPart->PathInExternalFile) != COMMON_NS::AbstractObject::hdfDatatypeEnum::UCHAR) {
 			return result;
 		}
 

--- a/src/resqml2/SeismicWellboreFrameRepresentation.cpp
+++ b/src/resqml2/SeismicWellboreFrameRepresentation.cpp
@@ -123,7 +123,7 @@ unsigned int SeismicWellboreFrameRepresentation::getTimeValuesCount() const
 	return getMdValuesCount();
 }
 
-RESQML2_NS::AbstractValuesProperty::hdfDatatypeEnum SeismicWellboreFrameRepresentation::getTimeHdfDatatype() const
+COMMON_NS::AbstractObject::hdfDatatypeEnum SeismicWellboreFrameRepresentation::getTimeHdfDatatype() const
 {
 	_resqml22__SeismicWellboreFrameRepresentation* frame = static_cast<_resqml22__SeismicWellboreFrameRepresentation*>(gsoapProxy2_3);
 	if (frame->NodeTimeValues->soap_type() == SOAP_TYPE_gsoap_eml2_3_eml23__FloatingPointExternalArray)
@@ -133,27 +133,7 @@ RESQML2_NS::AbstractValuesProperty::hdfDatatypeEnum SeismicWellboreFrameRepresen
 		if (hdfProxy == nullptr) {
 			throw invalid_argument("The HDF proxy is missing.");
 		}
-		hid_t dt = hdfProxy->getHdfDatatypeInDataset(dataset->ExternalFileProxy[0]->PathInExternalFile);
-		if (H5Tequal(dt, H5T_NATIVE_DOUBLE) > 0)
-			return RESQML2_NS::AbstractValuesProperty::DOUBLE;
-		else if (H5Tequal(dt, H5T_NATIVE_FLOAT) > 0)
-			return RESQML2_NS::AbstractValuesProperty::FLOAT;
-		else if (H5Tequal(dt, H5T_NATIVE_LLONG) > 0)
-			return RESQML2_NS::AbstractValuesProperty::LONG_64;
-		else if (H5Tequal(dt, H5T_NATIVE_ULLONG) > 0)
-			return RESQML2_NS::AbstractValuesProperty::ULONG_64;
-		else if (H5Tequal(dt, H5T_NATIVE_INT) > 0)
-			return RESQML2_NS::AbstractValuesProperty::INT;
-		else if (H5Tequal(dt, H5T_NATIVE_UINT) > 0)
-			return RESQML2_NS::AbstractValuesProperty::UINT;
-		else if (H5Tequal(dt, H5T_NATIVE_SHORT) > 0)
-			return RESQML2_NS::AbstractValuesProperty::SHORT;
-		else if (H5Tequal(dt, H5T_NATIVE_USHORT) > 0)
-			return RESQML2_NS::AbstractValuesProperty::USHORT;
-		else if (H5Tequal(dt, H5T_NATIVE_CHAR) > 0)
-			return RESQML2_NS::AbstractValuesProperty::CHAR;
-		else if (H5Tequal(dt, H5T_NATIVE_UCHAR) > 0)
-			return RESQML2_NS::AbstractValuesProperty::UCHAR;
+		return hdfProxy->getHdfDatatypeInDataset(dataset->ExternalFileProxy[0]->PathInExternalFile);
 	}
 	else if (frame->NodeTimeValues->soap_type() == SOAP_TYPE_gsoap_eml2_3_eml23__FloatingPointLatticeArray)
 	{

--- a/src/resqml2/SeismicWellboreFrameRepresentation.h
+++ b/src/resqml2/SeismicWellboreFrameRepresentation.h
@@ -27,7 +27,7 @@ namespace RESQML2_NS
 	{
 	public:
 
-		virtual ~SeismicWellboreFrameRepresentation() {}
+		virtual ~SeismicWellboreFrameRepresentation() = default;
 	
 		/**
 		* Set the time values of this SeismicWellboreFrameRepresentation frame to an array 1d of explicit values.
@@ -70,7 +70,7 @@ namespace RESQML2_NS
 		/**
 		* Get the time values datatype in the HDF dataset
 		*/
-		DLL_IMPORT_OR_EXPORT RESQML2_NS::AbstractValuesProperty::hdfDatatypeEnum getTimeHdfDatatype() const;
+		DLL_IMPORT_OR_EXPORT COMMON_NS::AbstractObject::hdfDatatypeEnum getTimeHdfDatatype() const;
 
 		/**
 		* Get all the time values of the instance which are supposed to be double ones.

--- a/src/resqml2/WellboreFrameRepresentation.cpp
+++ b/src/resqml2/WellboreFrameRepresentation.cpp
@@ -271,7 +271,7 @@ unsigned int WellboreFrameRepresentation::getMdValuesCount() const
 	throw invalid_argument("Not implemented yet");
 }
 
-RESQML2_NS::AbstractValuesProperty::hdfDatatypeEnum WellboreFrameRepresentation::getMdHdfDatatype() const
+COMMON_NS::AbstractObject::hdfDatatypeEnum WellboreFrameRepresentation::getMdHdfDatatype() const
 {
 	if (gsoapProxy2_0_1 != nullptr) {
 		_resqml20__WellboreFrameRepresentation* frame = static_cast<_resqml20__WellboreFrameRepresentation*>(gsoapProxy2_0_1);
@@ -282,27 +282,7 @@ RESQML2_NS::AbstractValuesProperty::hdfDatatypeEnum WellboreFrameRepresentation:
 			if (hdfProxy == nullptr) {
 				throw invalid_argument("The HDF proxy is missing.");
 			}
-			hid_t dt = hdfProxy->getHdfDatatypeInDataset(dataset->PathInHdfFile);
-			if (H5Tequal(dt, H5T_NATIVE_DOUBLE) > 0)
-				return RESQML2_NS::AbstractValuesProperty::DOUBLE;
-			else if (H5Tequal(dt, H5T_NATIVE_FLOAT) > 0)
-				return RESQML2_NS::AbstractValuesProperty::FLOAT;
-			else if (H5Tequal(dt, H5T_NATIVE_LLONG) > 0)
-				return RESQML2_NS::AbstractValuesProperty::LONG_64;
-			else if (H5Tequal(dt, H5T_NATIVE_ULLONG) > 0)
-				return RESQML2_NS::AbstractValuesProperty::ULONG_64;
-			else if (H5Tequal(dt, H5T_NATIVE_INT) > 0)
-				return RESQML2_NS::AbstractValuesProperty::INT;
-			else if (H5Tequal(dt, H5T_NATIVE_UINT) > 0)
-				return RESQML2_NS::AbstractValuesProperty::UINT;
-			else if (H5Tequal(dt, H5T_NATIVE_SHORT) > 0)
-				return RESQML2_NS::AbstractValuesProperty::SHORT;
-			else if (H5Tequal(dt, H5T_NATIVE_USHORT) > 0)
-				return RESQML2_NS::AbstractValuesProperty::USHORT;
-			else if (H5Tequal(dt, H5T_NATIVE_CHAR) > 0)
-				return RESQML2_NS::AbstractValuesProperty::CHAR;
-			else if (H5Tequal(dt, H5T_NATIVE_UCHAR) > 0)
-				return RESQML2_NS::AbstractValuesProperty::UCHAR;
+			return hdfProxy->getHdfDatatypeInDataset(dataset->PathInHdfFile);
 		}
 		else if (frame->NodeMd->soap_type() == SOAP_TYPE_gsoap_resqml2_0_1_resqml20__DoubleLatticeArray)
 		{

--- a/src/resqml2/WellboreFrameRepresentation.cpp
+++ b/src/resqml2/WellboreFrameRepresentation.cpp
@@ -300,34 +300,12 @@ COMMON_NS::AbstractObject::hdfDatatypeEnum WellboreFrameRepresentation::getMdHdf
 			if (hdfProxy == nullptr) {
 				throw invalid_argument("The HDF proxy is missing.");
 			}
-			hid_t dt = hdfProxy->getHdfDatatypeInDataset(dataset->ExternalFileProxy[0]->PathInExternalFile);
-			if (H5Tequal(dt, H5T_NATIVE_DOUBLE) > 0)
-				return RESQML2_NS::AbstractValuesProperty::DOUBLE;
-			else if (H5Tequal(dt, H5T_NATIVE_FLOAT) > 0)
-				return RESQML2_NS::AbstractValuesProperty::FLOAT;
-			else if (H5Tequal(dt, H5T_NATIVE_LLONG) > 0)
-				return RESQML2_NS::AbstractValuesProperty::LONG_64;
-			else if (H5Tequal(dt, H5T_NATIVE_ULLONG) > 0)
-				return RESQML2_NS::AbstractValuesProperty::ULONG_64;
-			else if (H5Tequal(dt, H5T_NATIVE_INT) > 0)
-				return RESQML2_NS::AbstractValuesProperty::INT;
-			else if (H5Tequal(dt, H5T_NATIVE_UINT) > 0)
-				return RESQML2_NS::AbstractValuesProperty::UINT;
-			else if (H5Tequal(dt, H5T_NATIVE_SHORT) > 0)
-				return RESQML2_NS::AbstractValuesProperty::SHORT;
-			else if (H5Tequal(dt, H5T_NATIVE_USHORT) > 0)
-				return RESQML2_NS::AbstractValuesProperty::USHORT;
-			else if (H5Tequal(dt, H5T_NATIVE_CHAR) > 0)
-				return RESQML2_NS::AbstractValuesProperty::CHAR;
-			else if (H5Tequal(dt, H5T_NATIVE_UCHAR) > 0)
-				return RESQML2_NS::AbstractValuesProperty::UCHAR;
+			return hdfProxy->getHdfDatatypeInDataset(dataset->ExternalFileProxy[0]->PathInExternalFile);
 		}
 		else if (frame->NodeMd->soap_type() == SOAP_TYPE_gsoap_eml2_3_eml23__FloatingPointLatticeArray)
 		{
 			return RESQML2_NS::AbstractValuesProperty::DOUBLE;
 		}
-
-		return RESQML2_NS::AbstractValuesProperty::UNKNOWN; // unknwown datatype...
 	}
 
 	throw invalid_argument("Not implemented yet");

--- a/src/resqml2/WellboreFrameRepresentation.h
+++ b/src/resqml2/WellboreFrameRepresentation.h
@@ -130,7 +130,7 @@ namespace RESQML2_NS
 		 * 			Returns @c DOUBLE if MD values are stored as a regular discretization along the
 		 * 			wellbore trajectory.
 		 */
-		DLL_IMPORT_OR_EXPORT RESQML2_NS::AbstractValuesProperty::hdfDatatypeEnum getMdHdfDatatype() const;
+		DLL_IMPORT_OR_EXPORT COMMON_NS::AbstractObject::hdfDatatypeEnum getMdHdfDatatype() const;
 
 		/**
 		 * Gets all the MD values of this instance which are supposed to be double ones.


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
* Upgrade to latest ETP draft schema (dev 14)
* Fix binary contact relationships mapping between 2.0.1 and 2.2
* Fix return type for HDF5 dataset datype

Does this close any currently open issues?
------------------------------------------
No

Where has this been tested?
---------------------------
**Operating System:** Win10 64

**Platform:**VS2017 64
