### PR TITLE
Bug fix : empty ContentType in DOR and missing Swig support for ETP

### DIFF
--- a/etpServerExample/MyOwnStoreProtocolHandlers.cpp
+++ b/etpServerExample/MyOwnStoreProtocolHandlers.cpp
@@ -89,8 +89,15 @@ void MyOwnStoreProtocolHandlers::on_PutDataObjects(const Energistics::Etp::v12::
 		}
 	}
 
+	Energistics::Etp::v12::Protocol::Store::PutDataObjectsResponse objResponse;
+
 	if (!pe.errors.empty()) {
+		session->send(objResponse, correlationId);
 		session->send(pe, correlationId, 0x02);
+	}
+	else
+	{
+		session->send(objResponse, correlationId, 0x02);
 	}
 }
 

--- a/etpServerExample/MyOwnStoreProtocolHandlers.cpp
+++ b/etpServerExample/MyOwnStoreProtocolHandlers.cpp
@@ -67,6 +67,8 @@ void MyOwnStoreProtocolHandlers::on_GetDataObjects(const Energistics::Etp::v12::
 
 void MyOwnStoreProtocolHandlers::on_PutDataObjects(const Energistics::Etp::v12::Protocol::Store::PutDataObjects & msg, int64_t correlationId)
 {
+	Energistics::Etp::v12::Protocol::Store::PutDataObjectsResponse objResponse;
+
 	Energistics::Etp::v12::Protocol::Core::ProtocolException pe;
 	for (const auto & pair : msg.dataObjects) {
 		std::cout << "Store received data object : " << pair.second.resource.dataObjectType << " (" << pair.second.resource.uri << ")" << std::endl;
@@ -78,6 +80,8 @@ void MyOwnStoreProtocolHandlers::on_PutDataObjects(const Energistics::Etp::v12::
 			continue;
 		}
 
+		objResponse.success[pair.first] = Energistics::Etp::v12::Datatypes::Object::PutResponse();
+
 		importedObj->loadTargetRelationships();
 
 		if (pair.second.resource.dataObjectType == "resqml20.obj_IjkGridRepresentation") {
@@ -88,8 +92,6 @@ void MyOwnStoreProtocolHandlers::on_PutDataObjects(const Energistics::Etp::v12::
 			gcsr->pushBackSupportingGridRepresentation(static_cast<RESQML2_NS::AbstractGridRepresentation*>(importedObj));
 		}
 	}
-
-	Energistics::Etp::v12::Protocol::Store::PutDataObjectsResponse objResponse;
 
 	if (!pe.errors.empty()) {
 		session->send(objResponse, correlationId);

--- a/src/common/DataObjectRepository.cpp
+++ b/src/common/DataObjectRepository.cpp
@@ -832,8 +832,8 @@ COMMON_NS::AbstractObject* DataObjectRepository::createPartial(const std::string
 		if (dataType.compare(EML2_NS::EpcExternalPartReference::XML_TAG) == 0)
 		{
 			gsoap_resqml2_0_1::eml20__DataObjectReference* dor = createDor(uuid, title, version);
+			dor->ContentType = contentType;
 			COMMON_NS::AbstractObject* result = hdfProxyFactory->make(dor);
-			dor->ContentType = result->getContentType();
 			addOrReplaceDataObject(result);
 			return result;
 		}

--- a/swig/swigEtp1_2Include.i
+++ b/swig/swigEtp1_2Include.i
@@ -20,6 +20,7 @@ under the License.
 #include "../src/etp/ClientSessionLaunchers.h"
 #include "../src/etp/Server.h"
 #include "../src/etp/PlainServerSession.h"
+#include "../src/etp/EtpHelpers.h"
 %}
 
 #if defined(SWIGJAVA) || defined(SWIGCSHARP)
@@ -1117,6 +1118,15 @@ namespace ETP_NS
 		
 		void close();
 	};
+
+	namespace EtpHelpers {
+		Energistics::Etp::v12::Datatypes::ErrorInfo validateUri(const std::string & uri, ETP_NS::AbstractSession* session = nullptr);
+		Energistics::Etp::v12::Datatypes::ErrorInfo validateDataObjectUri(const std::string & uri, ETP_NS::AbstractSession* session = nullptr);
+		std::string buildUriFromEnergisticsObject(const COMMON_NS::AbstractObject * const obj);
+		Energistics::Etp::v12::Datatypes::Object::Resource buildEtpResourceFromEnergisticsObject(const COMMON_NS::AbstractObject * const obj, bool countRels = true);
+		Energistics::Etp::v12::Datatypes::Object::DataObject buildEtpDataObjectFromEnergisticsObject(COMMON_NS::AbstractObject * obj, bool includeSerialization = true);	
+		Energistics::Etp::v12::Protocol::Core::ProtocolException buildSingleMessageProtocolException(int32_t m_code, const std::string & m_message);
+	}
 
 	/******************* CLIENT ***************************/
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- Bug fix : empty ContentType in DataObjectReference while creating EML2.0 partial object
- Bug fix : missing Swig support for ETP
- Send PutDataObjectsResponse in ETP server example

Does this close any currently open issues?
------------------------------------------
No.

Any relevant logs, error output, etc?
-------------------------------------
No.

Any other comments?
-------------------
No.

Where has this been tested?
---------------------------
**Operating System:** Windows 10 64bits

**Platform:** Visual Studio Community 2019
