### PR TITLE
Bug fix : not up to date customData map in ETP Resource structure

### DIFF
--- a/src/common/DataObjectRepository.cpp
+++ b/src/common/DataObjectRepository.cpp
@@ -805,6 +805,18 @@ const std::vector<std::string> & DataObjectRepository::getWarnings() const
 	return warnings;
 }
 
+std::vector<std::string> DataObjectRepository::getUuids() const
+{
+	std::vector<std::string> keys;
+	keys.reserve(dataObjects.size());
+	
+	for (auto kv : dataObjects) {
+		keys.push_back(kv.first);
+	}
+
+	return keys;
+}
+
 COMMON_NS::AbstractObject* DataObjectRepository::createPartial(const std::string & uuid, const std::string & title, const std::string & contentType, const std::string & version)
 {
 	size_t characterPos = contentType.find_last_of('_'); // The XML tag is after "obj_"

--- a/src/common/DataObjectRepository.h
+++ b/src/common/DataObjectRepository.h
@@ -654,6 +654,13 @@ namespace COMMON_NS
 		}
 
 		/**
+		 * Gets all the data object uuids which are part of this repository
+		 *
+		 * @returns	A vector of uuids.
+		 */
+		DLL_IMPORT_OR_EXPORT std::vector<std::string> getUuids() const;
+
+		/**
 		* Create a partial object i.e. a data object reference (DOR) based on an UUID + a title + a content type + a version
 		*/
 		COMMON_NS::AbstractObject* createPartial(const std::string & uuid, const std::string & title, const std::string & contentType, const std::string & version = "");

--- a/swig/swigEtp1_2Include.i
+++ b/swig/swigEtp1_2Include.i
@@ -373,7 +373,7 @@ namespace Energistics {
 						boost::optional<int32_t> targetCount;
 						int64_t lastChanged;
 						int64_t storeLastWrite;
-						std::map<std::string, std::string> customData;
+						std::map<std::string, Energistics::Etp::v12::Datatypes::DataValue> customData;
 					};					
 				};				
 			};			

--- a/swig/swigModule.i
+++ b/swig/swigModule.i
@@ -373,6 +373,8 @@ namespace COMMON_NS
 #ifdef WITH_RESQML2_2
 		%template(getGraphicalInformationSets) getDataObjects<EML2_3_NS::GraphicalInformationSet>;
 #endif
+
+		std::vector<std::string> getUuids() const;
 		
 		EML2_NS::AbstractHdfProxy* createHdfProxy(const std::string & guid, const std::string & title, const std::string & packageDirAbsolutePath, const std::string & externalFilePath, DataObjectRepository::openingMode hdfPermissionAccess);
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- Bug fix : not up to date (according to ETP1.2 Dev15) customData map in ETP Resource structure
- adds capability for the repository to deliver all data object uuids

Does this close any currently open issues?
------------------------------------------
No

Any relevant logs, error output, etc?
-------------------------------------
No.

Any other comments?
-------------------
No.

Where has this been tested?
---------------------------
**Operating System:** Windows 10 64bits

**Platform:** Visual Studio Community 2019
