### PR TITLE
More support for PRODML PVT

### DIFF
--- a/src/MacroDefinitions.h
+++ b/src/MacroDefinitions.h
@@ -26,6 +26,24 @@ under the License.
  */
 #define CHECK_RANGE(vector, index) if (index >= vector.size()) { throw std::range_error("The index is out of range"); }
 
+ /**
+  * A macro that defines getter setter of a mandatory attribute
+  *
+  * @param 	gsoapClassName   	Name of the gsoap class.
+  * @param 	proxyVariable	 	The proxy variable.
+  * @param 	attributeName	 	Name of the attribute.
+  * @param 	attributeDatatype	The attribute datatype.
+  */
+#define GETTER_SETTER_ATTRIBUTE(gsoapClassName, proxyVariable, attributeName, attributeDatatype)\
+	DLL_IMPORT_OR_EXPORT void set##attributeName(const attributeDatatype& value) {\
+		if (isPartial()) { throw std::logic_error("Cannot set an attribute of a partial dataobject."); }\
+		static_cast<gsoapClassName*>(proxyVariable)->attributeName = value;\
+	}\
+	DLL_IMPORT_OR_EXPORT attributeDatatype get##attributeName() const {\
+		if (isPartial()) { throw std::logic_error("Cannot get an attribute of a partial dataobject."); }\
+		return static_cast<gsoapClassName*>(proxyVariable)->attributeName;\
+	}
+
 /**
  * A macro that defines checker presence attribute
  *
@@ -33,7 +51,10 @@ under the License.
  * @param 	proxyVariable 	The proxy variable.
  * @param 	attributeName 	Name of the attribute.
  */
-#define CHECKER_PRESENCE_ATTRIBUTE(gsoapClassName, proxyVariable, attributeName) DLL_IMPORT_OR_EXPORT bool has##attributeName() const { return static_cast<gsoapClassName*>(proxyVariable)->attributeName != nullptr; }
+#define CHECKER_PRESENCE_ATTRIBUTE(gsoapClassName, proxyVariable, attributeName)\
+	DLL_IMPORT_OR_EXPORT bool has##attributeName() const {\
+		return static_cast<gsoapClassName*>(proxyVariable)->attributeName != nullptr;\
+	}
 
 /**
  * A macro that defines checker presence attribute in vector
@@ -43,13 +64,14 @@ under the License.
  * @param 	vectorName	  	Name of the vector.
  * @param 	attributeName 	Name of the attribute.
  */
-#define CHECKER_PRESENCE_ATTRIBUTE_IN_VECTOR(gsoapClassName, proxyVariable, vectorName, attributeName) DLL_IMPORT_OR_EXPORT bool has##vectorName##attributeName(unsigned int index) const {\
+#define CHECKER_PRESENCE_ATTRIBUTE_IN_VECTOR(gsoapClassName, proxyVariable, vectorName, attributeName)\
+	DLL_IMPORT_OR_EXPORT bool has##vectorName##attributeName(unsigned int index) const {\
 	CHECK_RANGE(static_cast<gsoapClassName*>(proxyVariable)->vectorName, index)\
 	return static_cast<gsoapClassName*>(proxyVariable)->vectorName[index]->attributeName != nullptr;\
 }
 
 /**
- * A macro that defines getter setter optional attribute
+ * A macro that defines getter setter of an optional attribute
  *
  * @param 	gsoapClassName   	Name of the gsoap class.
  * @param 	proxyVariable	 	The proxy variable.
@@ -59,6 +81,7 @@ under the License.
 #define GETTER_SETTER_OPTIONAL_ATTRIBUTE(gsoapClassName, proxyVariable, attributeName, attributeDatatype)\
 	DLL_IMPORT_OR_EXPORT void set##attributeName(const attributeDatatype& value);\
 	DLL_IMPORT_OR_EXPORT attributeDatatype get##attributeName() const {\
+		if (isPartial()) { throw std::logic_error("Cannot get an attribute of a partial dataobject."); }\
 		if (!has##attributeName()) { throw std::invalid_argument("The attribute does not exist"); }\
 		return *static_cast<gsoapClassName*>(proxyVariable)->attributeName;\
 	}\
@@ -135,6 +158,7 @@ under the License.
 #define SETTER_OPTIONAL_ATTRIBUTE_IMPL(className, gsoapClassName, proxyVariable, attributeName, attributeDatatype, constructor)\
 void className::set##attributeName(const attributeDatatype& value)\
 {\
+	if (isPartial()) { throw std::logic_error("Cannot set an attribute of a partial dataobject."); }\
 	static_cast<gsoapClassName*>(proxyVariable)->attributeName = constructor(proxyVariable->soap);\
 	*static_cast<gsoapClassName*>(proxyVariable)->attributeName = value;\
 }

--- a/src/MacroDefinitions.h
+++ b/src/MacroDefinitions.h
@@ -125,14 +125,14 @@ under the License.
 /**
  * A macro that defines setter optional attribute Implementation
  *
- * @param 	className	  	Name of the class.
- * @param 	gsoapClassName	Name of the gsoap class.
- * @param 	proxyVariable 	The proxy variable.
- * @param 	attributeName 	Name of the attribute.
- * @param 	uomDatatype   	The uom datatype.
- * @param 	constructor   	The constructor.
+ * @param 	className	  		Name of the class.
+ * @param 	gsoapClassName		Name of the gsoap class.
+ * @param 	proxyVariable 		The proxy variable.
+ * @param 	attributeName 		Name of the attribute.
+ * @param 	attributeDatatype	The attribute datatype.
+ * @param 	constructor   		The constructor.
  */
-#define SETTER_OPTIONAL_ATTRIBUTE_IMPL(className, gsoapClassName, proxyVariable, attributeName, uomDatatype, constructor)\
+#define SETTER_OPTIONAL_ATTRIBUTE_IMPL(className, gsoapClassName, proxyVariable, attributeName, attributeDatatype, constructor)\
 void className::set##attributeName(const attributeDatatype& value)\
 {\
 	static_cast<gsoapClassName*>(proxyVariable)->attributeName = constructor(proxyVariable->soap);\

--- a/src/common/DataObjectRepository.cpp
+++ b/src/common/DataObjectRepository.cpp
@@ -2855,6 +2855,19 @@ PRODML2_1_NS::FluidSystem* DataObjectRepository::createFluidSystem(const std::st
 		gasOilRatio, gasOilRatioUom);
 }
 
+PRODML2_1_NS::FluidSystem* DataObjectRepository::createFluidSystem(const std::string & guid,
+	const std::string & title,
+	gsoap_eml2_2::eml22__ReferenceCondition referenceCondition,
+	gsoap_eml2_2::prodml21__ReservoirFluidKind reservoirFluidKind,
+	double gasOilRatio, gsoap_eml2_2::eml22__VolumePerVolumeUom gasOilRatioUom)
+{
+	return new PRODML2_1_NS::FluidSystem(this,
+		guid, title,
+		referenceCondition,
+		reservoirFluidKind,
+		gasOilRatio, gasOilRatioUom);
+}
+
 PRODML2_1_NS::FluidCharacterization* DataObjectRepository::createFluidCharacterization(const std::string & guid, const std::string & title)
 {
 	return new PRODML2_1_NS::FluidCharacterization(this, guid, title);

--- a/src/common/DataObjectRepository.h
+++ b/src/common/DataObjectRepository.h
@@ -3383,6 +3383,26 @@ namespace COMMON_NS
 			double gasOilRatio, gsoap_eml2_2::eml22__VolumePerVolumeUom gasOilRatioUom);
 
 		/**
+		 * Creates a fluid system into this repository
+		 *
+		 * @param 	guid			  	The guid to set to the fluid system. If empty then a new guid
+		 * 								will be generated.
+		 * @param 	title			  	The title to set to the fluid system. If empty then \"unknown\"
+		 * 								title will be set.
+		 * @param   referenceCondition	A wellknown couple of temperature-pressure.
+		 * @param 	reservoirFluidKind	The kind of the reservoir fluid.
+		 * @param 	gasOilRatio		  	The gas oil ratio.
+		 * @param 	gasOilRatioUom	  	The gas oil ratio unit of measure.
+		 *
+		 * @returns	A pointer to the new fluid system.
+		 */
+		DLL_IMPORT_OR_EXPORT PRODML2_1_NS::FluidSystem* createFluidSystem(const std::string & guid,
+			const std::string & title,
+			gsoap_eml2_2::eml22__ReferenceCondition referenceCondition,
+			gsoap_eml2_2::prodml21__ReservoirFluidKind reservoirFluidKind,
+			double gasOilRatio, gsoap_eml2_2::eml22__VolumePerVolumeUom gasOilRatioUom);
+
+		/**
 		 * Creates a fluid characterization into this repository
 		 *
 		 * @param 	guid 	The guid to set to the fluid characterization. If empty then a new guid will

--- a/src/prodml2_1/FluidCharacterization.cpp
+++ b/src/prodml2_1/FluidCharacterization.cpp
@@ -50,6 +50,10 @@ FluidCharacterization::FluidCharacterization(COMMON_NS::DataObjectRepository * r
 	repo->addOrReplaceDataObject(this);
 }
 
+SETTER_OPTIONAL_ATTRIBUTE_IMPL(FluidCharacterization, prodml21__FluidCharacterization, gsoapProxy2_2, FluidCharacterizationType, std::string, soap_new_std__string)
+SETTER_OPTIONAL_ATTRIBUTE_IMPL(FluidCharacterization, prodml21__FluidCharacterization, gsoapProxy2_2, IntendedUsage, std::string, soap_new_std__string)
+SETTER_OPTIONAL_ATTRIBUTE_IMPL(FluidCharacterization, prodml21__FluidCharacterization, gsoapProxy2_2, Remark, std::string, soap_new_std__string)
+
 void FluidCharacterization::setStandardConditions(double temperatureValue, gsoap_eml2_2::eml22__ThermodynamicTemperatureUom temperatureUom,
 	double pressureValue, gsoap_eml2_2::eml22__PressureUom pressureUom)
 {
@@ -77,9 +81,14 @@ double FluidCharacterization::getStandardTemperatureValue() const
 	if (fc->StandardConditions->soap_type() == SOAP_TYPE_gsoap_eml2_2_eml22__TemperaturePressure) {
 		return static_cast<eml22__TemperaturePressure*>(fc->StandardConditions)->Temperature->__item;
 	}
-	else {
-		throw logic_error("Reference conditions are not supported yet.");
+	else if (fc->StandardConditions->soap_type() == SOAP_TYPE_gsoap_eml2_2_eml22__ReferenceTemperaturePressure) {
+		istringstream iss(*static_cast<eml22__ReferenceTemperaturePressure*>(fc->StandardConditions)->union_ReferenceTemperaturePressure_.ReferenceTempPres);
+		double result;
+		iss >> result;
+		return result;
 	}
+
+	throw logic_error("Unrecognized datatype for StandardConditions.");
 }
 
 gsoap_eml2_2::eml22__ThermodynamicTemperatureUom FluidCharacterization::getStandardTemperatureUom() const
@@ -92,9 +101,14 @@ gsoap_eml2_2::eml22__ThermodynamicTemperatureUom FluidCharacterization::getStand
 	if (fc->StandardConditions->soap_type() == SOAP_TYPE_gsoap_eml2_2_eml22__TemperaturePressure) {
 		return static_cast<eml22__TemperaturePressure*>(fc->StandardConditions)->Temperature->uom;
 	}
-	else {
-		throw logic_error("Reference conditions are not supported yet.");
+	else if (fc->StandardConditions->soap_type() == SOAP_TYPE_gsoap_eml2_2_eml22__ReferenceTemperaturePressure) {
+		const std::string str = *static_cast<eml22__ReferenceTemperaturePressure*>(fc->StandardConditions)->union_ReferenceTemperaturePressure_.ReferenceTempPres;
+		if (str.find("degC") != std::string::npos) return gsoap_eml2_2::eml22__ThermodynamicTemperatureUom__degC;
+		if (str.find("degF") != std::string::npos) return gsoap_eml2_2::eml22__ThermodynamicTemperatureUom__degF;
+		throw logic_error("Unrecognized temperature uom in " + str);
 	}
+
+	throw logic_error("Unrecognized datatype for StandardConditions.");
 }
 
 double FluidCharacterization::getStandardPressureValue() const
@@ -107,9 +121,19 @@ double FluidCharacterization::getStandardPressureValue() const
 	if (fc->StandardConditions->soap_type() == SOAP_TYPE_gsoap_eml2_2_eml22__TemperaturePressure) {
 		return static_cast<eml22__TemperaturePressure*>(fc->StandardConditions)->Pressure->__item;
 	}
-	else {
-		throw logic_error("Reference conditions are not supported yet.");
+	else if (fc->StandardConditions->soap_type() == SOAP_TYPE_gsoap_eml2_2_eml22__ReferenceTemperaturePressure) {
+		const std::string str = *static_cast<eml22__ReferenceTemperaturePressure*>(fc->StandardConditions)->union_ReferenceTemperaturePressure_.ReferenceTempPres;
+		istringstream iss(str);
+		int tempValue;
+		iss >> tempValue;
+		std::string  tempUom;
+		iss >> tempUom;
+		int pressureValue;
+		iss >> pressureValue;
+		return pressureValue;
 	}
+
+	throw logic_error("Unrecognized datatype for StandardConditions.");
 }
 
 gsoap_eml2_2::eml22__PressureUom FluidCharacterization::getStandardPressureUom() const
@@ -127,9 +151,15 @@ gsoap_eml2_2::eml22__PressureUom FluidCharacterization::getStandardPressureUom()
 		}
 		return result;
 	}
-	else {
-		throw logic_error("Reference conditions are not supported yet.");
+	else if (fc->StandardConditions->soap_type() == SOAP_TYPE_gsoap_eml2_2_eml22__ReferenceTemperaturePressure) {
+		const std::string str = *static_cast<eml22__ReferenceTemperaturePressure*>(fc->StandardConditions)->union_ReferenceTemperaturePressure_.ReferenceTempPres;
+		if (str.find("bar") != std::string::npos) return gsoap_eml2_2::eml22__PressureUom__bar;
+		if (str.find("atm") != std::string::npos) return gsoap_eml2_2::eml22__PressureUom__atm;
+		if (str.find("degF") != std::string::npos && str.find("in Hg") != std::string::npos) return gsoap_eml2_2::eml22__PressureUom__inHg_x005b60degF_x005d;
+		throw logic_error("Unrecognized pressure uom in " + str);
 	}
+
+	throw logic_error("Unrecognized datatype for StandardConditions.");
 }
 
 void FluidCharacterization::setRockFluidUnit(RESQML2_NS::RockFluidUnitInterpretation* rockFluidUnit)

--- a/src/prodml2_1/FluidCharacterization.cpp
+++ b/src/prodml2_1/FluidCharacterization.cpp
@@ -182,7 +182,7 @@ RESQML2_NS::RockFluidUnitInterpretation* FluidCharacterization::getRockFluidUnit
 	return getRepository()->getDataObjectByUuid<RESQML2_NS::RockFluidUnitInterpretation>(getRockFluidUnitDor().getUuid());
 }
 
-#define SETTER_FLUID_COMPONENT_OPTIONAL_ATTRIBUTE_IMPL(vectorName, attributeName, attributeDatatype, constructor)\
+#define SETTER_FLUID_CATALOG_COMPONENT_OPTIONAL_ATTRIBUTE_IMPL(vectorName, attributeName, attributeDatatype, constructor)\
 void FluidCharacterization::set##vectorName##attributeName(unsigned int index, const attributeDatatype& value)\
 {\
 	if (static_cast<prodml21__FluidCharacterization*>(gsoapProxy2_2)->FluidComponentCatalog == nullptr || index >= static_cast<prodml21__FluidCharacterization*>(gsoapProxy2_2)->FluidComponentCatalog->vectorName.size()) {throw std::out_of_range("This index is out of range.");}\
@@ -190,7 +190,7 @@ void FluidCharacterization::set##vectorName##attributeName(unsigned int index, c
 	*static_cast<prodml21__FluidCharacterization*>(gsoapProxy2_2)->FluidComponentCatalog->vectorName[index]->attributeName = value;\
 }
 
-#define SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE_IMPL(vectorName, attributeName, uomDatatype, constructor)\
+#define SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE_IMPL(vectorName, attributeName, uomDatatype, constructor)\
 void FluidCharacterization::set##vectorName##attributeName(unsigned int index, double value, uomDatatype uom)\
 {\
 	if (static_cast<prodml21__FluidCharacterization*>(gsoapProxy2_2)->FluidComponentCatalog == nullptr || index >= static_cast<prodml21__FluidCharacterization*>(gsoapProxy2_2)->FluidComponentCatalog->vectorName.size()) {throw std::out_of_range("This index is out of range.");}\
@@ -199,10 +199,10 @@ void FluidCharacterization::set##vectorName##attributeName(unsigned int index, d
 	static_cast<prodml21__FluidCharacterization*>(gsoapProxy2_2)->FluidComponentCatalog->vectorName[index]->attributeName->uom = uom;\
 }
 
-#define SETTER_FLUID_COMPONENT_COMMON_ATTRIBUTES_IMPL(vectorName)\
-SETTER_FLUID_COMPONENT_OPTIONAL_ATTRIBUTE_IMPL(vectorName, Remark, std::string, soap_new_std__string)\
-SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE_IMPL(vectorName, MassFraction, eml22__MassPerMassUom, soap_new_eml22__MassPerMassMeasure)\
-SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE_IMPL(vectorName, MoleFraction, eml22__AmountOfSubstancePerAmountOfSubstanceUom, soap_new_eml22__AmountOfSubstancePerAmountOfSubstanceMeasure)
+#define SETTER_FLUID_CATALOG_COMPONENT_COMMON_ATTRIBUTES_IMPL(vectorName)\
+SETTER_FLUID_CATALOG_COMPONENT_OPTIONAL_ATTRIBUTE_IMPL(vectorName, Remark, std::string, soap_new_std__string)\
+SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE_IMPL(vectorName, MassFraction, eml22__MassPerMassUom, soap_new_eml22__MassPerMassMeasure)\
+SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE_IMPL(vectorName, MoleFraction, eml22__AmountOfSubstancePerAmountOfSubstanceUom, soap_new_eml22__AmountOfSubstancePerAmountOfSubstanceMeasure)
 
 unsigned int FluidCharacterization::getFormationWaterCount() const
 {
@@ -226,9 +226,9 @@ void FluidCharacterization::pushBackFormationWater(const std::string & uid)
 	result->uid = uid;
 	static_cast<prodml21__FluidCharacterization*>(gsoapProxy2_2)->FluidComponentCatalog->FormationWater.push_back(result);
 }
-SETTER_FLUID_COMPONENT_COMMON_ATTRIBUTES_IMPL(FormationWater)
-SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE_IMPL(FormationWater, Salinity, gsoap_eml2_2::eml22__MassPerMassUom, gsoap_eml2_2::soap_new_eml22__MassPerMassMeasure)
-SETTER_FLUID_COMPONENT_OPTIONAL_ATTRIBUTE_IMPL(FormationWater, SpecificGravity, double, soap_new_double)
+SETTER_FLUID_CATALOG_COMPONENT_COMMON_ATTRIBUTES_IMPL(FormationWater)
+SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE_IMPL(FormationWater, Salinity, gsoap_eml2_2::eml22__MassPerMassUom, gsoap_eml2_2::soap_new_eml22__MassPerMassMeasure)
+SETTER_FLUID_CATALOG_COMPONENT_OPTIONAL_ATTRIBUTE_IMPL(FormationWater, SpecificGravity, double, soap_new_double)
 
 unsigned int FluidCharacterization::getPureFluidComponentCount() const
 {
@@ -254,8 +254,8 @@ void FluidCharacterization::pushBackPureFluidComponent(const std::string & uid, 
 	result->HydrocarbonFlag = hydrocarbonFlag;
 	static_cast<prodml21__FluidCharacterization*>(gsoapProxy2_2)->FluidComponentCatalog->PureFluidComponent.push_back(result);
 }
-SETTER_FLUID_COMPONENT_COMMON_ATTRIBUTES_IMPL(PureFluidComponent)
-SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE_IMPL(PureFluidComponent, MolecularWeight, gsoap_eml2_2::eml22__MolecularWeightUom, gsoap_eml2_2::soap_new_eml22__MolecularWeightMeasure)
+SETTER_FLUID_CATALOG_COMPONENT_COMMON_ATTRIBUTES_IMPL(PureFluidComponent)
+SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE_IMPL(PureFluidComponent, MolecularWeight, gsoap_eml2_2::eml22__MolecularWeightUom, gsoap_eml2_2::soap_new_eml22__MolecularWeightMeasure)
 
 unsigned int FluidCharacterization::getPlusFluidComponentCount() const
 {
@@ -280,12 +280,12 @@ void FluidCharacterization::pushBackPlusFluidComponent(const std::string & uid, 
 	result->Kind = gsoap_eml2_2::soap_prodml21__PlusComponentEnum2s(getGsoapContext(), kind);
 	static_cast<prodml21__FluidCharacterization*>(gsoapProxy2_2)->FluidComponentCatalog->PlusFluidComponent.push_back(result);
 }
-SETTER_FLUID_COMPONENT_COMMON_ATTRIBUTES_IMPL(PlusFluidComponent)
-SETTER_FLUID_COMPONENT_OPTIONAL_ATTRIBUTE_IMPL(PlusFluidComponent, SpecificGravity, double, soap_new_double)
-SETTER_FLUID_COMPONENT_OPTIONAL_ATTRIBUTE_IMPL(PlusFluidComponent, StartingCarbonNumber, uint64_t, soap_new_ULONG64)
-SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE_IMPL(PlusFluidComponent, StartingBoilingPoint, gsoap_eml2_2::eml22__ThermodynamicTemperatureUom, gsoap_eml2_2::soap_new_eml22__ThermodynamicTemperatureMeasure)
-SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE_IMPL(PlusFluidComponent, AvgDensity, std::string, gsoap_eml2_2::soap_new_eml22__MassPerVolumeMeasure)
-SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE_IMPL(PlusFluidComponent, AvgMolecularWeight, gsoap_eml2_2::eml22__MolecularWeightUom, gsoap_eml2_2::soap_new_eml22__MolecularWeightMeasure)
+SETTER_FLUID_CATALOG_COMPONENT_COMMON_ATTRIBUTES_IMPL(PlusFluidComponent)
+SETTER_FLUID_CATALOG_COMPONENT_OPTIONAL_ATTRIBUTE_IMPL(PlusFluidComponent, SpecificGravity, double, soap_new_double)
+SETTER_FLUID_CATALOG_COMPONENT_OPTIONAL_ATTRIBUTE_IMPL(PlusFluidComponent, StartingCarbonNumber, uint64_t, soap_new_ULONG64)
+SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE_IMPL(PlusFluidComponent, StartingBoilingPoint, gsoap_eml2_2::eml22__ThermodynamicTemperatureUom, gsoap_eml2_2::soap_new_eml22__ThermodynamicTemperatureMeasure)
+SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE_IMPL(PlusFluidComponent, AvgDensity, std::string, gsoap_eml2_2::soap_new_eml22__MassPerVolumeMeasure)
+SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE_IMPL(PlusFluidComponent, AvgMolecularWeight, gsoap_eml2_2::eml22__MolecularWeightUom, gsoap_eml2_2::soap_new_eml22__MolecularWeightMeasure)
 
 unsigned int FluidCharacterization::getStockTankOilCount() const
 {
@@ -309,13 +309,13 @@ void FluidCharacterization::pushBackStockTankOil(const std::string & uid)
 	result->uid = uid;
 	static_cast<prodml21__FluidCharacterization*>(gsoapProxy2_2)->FluidComponentCatalog->StockTankOil.push_back(result);
 }
-SETTER_FLUID_COMPONENT_COMMON_ATTRIBUTES_IMPL(StockTankOil)
-SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE_IMPL(StockTankOil, APIGravity, gsoap_eml2_2::eml22__APIGravityUom, gsoap_eml2_2::soap_new_eml22__APIGravityMeasure)
-SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE_IMPL(StockTankOil, MolecularWeight, gsoap_eml2_2::eml22__MolecularWeightUom, gsoap_eml2_2::soap_new_eml22__MolecularWeightMeasure)
-SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE_IMPL(StockTankOil, GrossEnergyContentPerUnitMass, gsoap_eml2_2::eml22__EnergyPerMassUom, gsoap_eml2_2::soap_new_eml22__EnergyPerMassMeasure)
-SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE_IMPL(StockTankOil, NetEnergyContentPerUnitMass, gsoap_eml2_2::eml22__EnergyPerMassUom, gsoap_eml2_2::soap_new_eml22__EnergyPerMassMeasure)
-SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE_IMPL(StockTankOil, GrossEnergyContentPerUnitVolume, gsoap_eml2_2::eml22__EnergyPerVolumeUom, gsoap_eml2_2::soap_new_eml22__EnergyPerVolumeMeasure)
-SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE_IMPL(StockTankOil, NetEnergyContentPerUnitVolume, gsoap_eml2_2::eml22__EnergyPerVolumeUom, gsoap_eml2_2::soap_new_eml22__EnergyPerVolumeMeasure)
+SETTER_FLUID_CATALOG_COMPONENT_COMMON_ATTRIBUTES_IMPL(StockTankOil)
+SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE_IMPL(StockTankOil, APIGravity, gsoap_eml2_2::eml22__APIGravityUom, gsoap_eml2_2::soap_new_eml22__APIGravityMeasure)
+SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE_IMPL(StockTankOil, MolecularWeight, gsoap_eml2_2::eml22__MolecularWeightUom, gsoap_eml2_2::soap_new_eml22__MolecularWeightMeasure)
+SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE_IMPL(StockTankOil, GrossEnergyContentPerUnitMass, gsoap_eml2_2::eml22__EnergyPerMassUom, gsoap_eml2_2::soap_new_eml22__EnergyPerMassMeasure)
+SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE_IMPL(StockTankOil, NetEnergyContentPerUnitMass, gsoap_eml2_2::eml22__EnergyPerMassUom, gsoap_eml2_2::soap_new_eml22__EnergyPerMassMeasure)
+SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE_IMPL(StockTankOil, GrossEnergyContentPerUnitVolume, gsoap_eml2_2::eml22__EnergyPerVolumeUom, gsoap_eml2_2::soap_new_eml22__EnergyPerVolumeMeasure)
+SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE_IMPL(StockTankOil, NetEnergyContentPerUnitVolume, gsoap_eml2_2::eml22__EnergyPerVolumeUom, gsoap_eml2_2::soap_new_eml22__EnergyPerVolumeMeasure)
 
 unsigned int FluidCharacterization::getNaturalGasCount() const
 {
@@ -339,13 +339,13 @@ void FluidCharacterization::pushBackNaturalGas(const std::string & uid)
 	result->uid = uid;
 	static_cast<prodml21__FluidCharacterization*>(gsoapProxy2_2)->FluidComponentCatalog->NaturalGas.push_back(result);
 }
-SETTER_FLUID_COMPONENT_COMMON_ATTRIBUTES_IMPL(NaturalGas)
-SETTER_FLUID_COMPONENT_OPTIONAL_ATTRIBUTE_IMPL(NaturalGas, GasGravity, double, soap_new_double)
-SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE_IMPL(NaturalGas, MolecularWeight, gsoap_eml2_2::eml22__MolecularWeightUom, gsoap_eml2_2::soap_new_eml22__MolecularWeightMeasure)
-SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE_IMPL(NaturalGas, GrossEnergyContentPerUnitMass, gsoap_eml2_2::eml22__EnergyPerMassUom, gsoap_eml2_2::soap_new_eml22__EnergyPerMassMeasure)
-SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE_IMPL(NaturalGas, NetEnergyContentPerUnitMass, gsoap_eml2_2::eml22__EnergyPerMassUom, gsoap_eml2_2::soap_new_eml22__EnergyPerMassMeasure)
-SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE_IMPL(NaturalGas, GrossEnergyContentPerUnitVolume, gsoap_eml2_2::eml22__EnergyPerVolumeUom, gsoap_eml2_2::soap_new_eml22__EnergyPerVolumeMeasure)
-SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE_IMPL(NaturalGas, NetEnergyContentPerUnitVolume, gsoap_eml2_2::eml22__EnergyPerVolumeUom, gsoap_eml2_2::soap_new_eml22__EnergyPerVolumeMeasure)
+SETTER_FLUID_CATALOG_COMPONENT_COMMON_ATTRIBUTES_IMPL(NaturalGas)
+SETTER_FLUID_CATALOG_COMPONENT_OPTIONAL_ATTRIBUTE_IMPL(NaturalGas, GasGravity, double, soap_new_double)
+SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE_IMPL(NaturalGas, MolecularWeight, gsoap_eml2_2::eml22__MolecularWeightUom, gsoap_eml2_2::soap_new_eml22__MolecularWeightMeasure)
+SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE_IMPL(NaturalGas, GrossEnergyContentPerUnitMass, gsoap_eml2_2::eml22__EnergyPerMassUom, gsoap_eml2_2::soap_new_eml22__EnergyPerMassMeasure)
+SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE_IMPL(NaturalGas, NetEnergyContentPerUnitMass, gsoap_eml2_2::eml22__EnergyPerMassUom, gsoap_eml2_2::soap_new_eml22__EnergyPerMassMeasure)
+SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE_IMPL(NaturalGas, GrossEnergyContentPerUnitVolume, gsoap_eml2_2::eml22__EnergyPerVolumeUom, gsoap_eml2_2::soap_new_eml22__EnergyPerVolumeMeasure)
+SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE_IMPL(NaturalGas, NetEnergyContentPerUnitVolume, gsoap_eml2_2::eml22__EnergyPerVolumeUom, gsoap_eml2_2::soap_new_eml22__EnergyPerVolumeMeasure)
 
 unsigned int FluidCharacterization::getPseudoFluidComponentCount() const
 {
@@ -370,15 +370,15 @@ void FluidCharacterization::pushBackPseudoFluidComponent(const std::string & uid
 	result->Kind = gsoap_eml2_2::soap_prodml21__PseudoComponentEnum2s(getGsoapContext(), kind);
 	static_cast<prodml21__FluidCharacterization*>(gsoapProxy2_2)->FluidComponentCatalog->PseudoFluidComponent.push_back(result);
 }
-SETTER_FLUID_COMPONENT_COMMON_ATTRIBUTES_IMPL(PseudoFluidComponent)
-SETTER_FLUID_COMPONENT_OPTIONAL_ATTRIBUTE_IMPL(PseudoFluidComponent, SpecificGravity, double, soap_new_double)
-SETTER_FLUID_COMPONENT_OPTIONAL_ATTRIBUTE_IMPL(PseudoFluidComponent, StartingCarbonNumber, uint64_t, soap_new_ULONG64)
-SETTER_FLUID_COMPONENT_OPTIONAL_ATTRIBUTE_IMPL(PseudoFluidComponent, EndingCarbonNumber, uint64_t, soap_new_ULONG64)
-SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE_IMPL(PseudoFluidComponent, StartingBoilingPoint, gsoap_eml2_2::eml22__ThermodynamicTemperatureUom, gsoap_eml2_2::soap_new_eml22__ThermodynamicTemperatureMeasure)
-SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE_IMPL(PseudoFluidComponent, EndingBoilingPoint, gsoap_eml2_2::eml22__ThermodynamicTemperatureUom, gsoap_eml2_2::soap_new_eml22__ThermodynamicTemperatureMeasure)
-SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE_IMPL(PseudoFluidComponent, AvgBoilingPoint, gsoap_eml2_2::eml22__ThermodynamicTemperatureUom, gsoap_eml2_2::soap_new_eml22__ThermodynamicTemperatureMeasure)
-SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE_IMPL(PseudoFluidComponent, AvgDensity, std::string, gsoap_eml2_2::soap_new_eml22__MassPerVolumeMeasure)
-SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE_IMPL(PseudoFluidComponent, AvgMolecularWeight, gsoap_eml2_2::eml22__MolecularWeightUom, gsoap_eml2_2::soap_new_eml22__MolecularWeightMeasure)
+SETTER_FLUID_CATALOG_COMPONENT_COMMON_ATTRIBUTES_IMPL(PseudoFluidComponent)
+SETTER_FLUID_CATALOG_COMPONENT_OPTIONAL_ATTRIBUTE_IMPL(PseudoFluidComponent, SpecificGravity, double, soap_new_double)
+SETTER_FLUID_CATALOG_COMPONENT_OPTIONAL_ATTRIBUTE_IMPL(PseudoFluidComponent, StartingCarbonNumber, uint64_t, soap_new_ULONG64)
+SETTER_FLUID_CATALOG_COMPONENT_OPTIONAL_ATTRIBUTE_IMPL(PseudoFluidComponent, EndingCarbonNumber, uint64_t, soap_new_ULONG64)
+SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE_IMPL(PseudoFluidComponent, StartingBoilingPoint, gsoap_eml2_2::eml22__ThermodynamicTemperatureUom, gsoap_eml2_2::soap_new_eml22__ThermodynamicTemperatureMeasure)
+SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE_IMPL(PseudoFluidComponent, EndingBoilingPoint, gsoap_eml2_2::eml22__ThermodynamicTemperatureUom, gsoap_eml2_2::soap_new_eml22__ThermodynamicTemperatureMeasure)
+SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE_IMPL(PseudoFluidComponent, AvgBoilingPoint, gsoap_eml2_2::eml22__ThermodynamicTemperatureUom, gsoap_eml2_2::soap_new_eml22__ThermodynamicTemperatureMeasure)
+SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE_IMPL(PseudoFluidComponent, AvgDensity, std::string, gsoap_eml2_2::soap_new_eml22__MassPerVolumeMeasure)
+SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE_IMPL(PseudoFluidComponent, AvgMolecularWeight, gsoap_eml2_2::eml22__MolecularWeightUom, gsoap_eml2_2::soap_new_eml22__MolecularWeightMeasure)
 
 unsigned int FluidCharacterization::getModelCount() const
 {

--- a/src/prodml2_1/FluidCharacterization.h
+++ b/src/prodml2_1/FluidCharacterization.h
@@ -148,6 +148,10 @@ namespace PRODML2_1_NS
 			}
 		}
 
+		GETTER_SETTER_OPTIONAL_ATTRIBUTE(gsoap_eml2_2::prodml21__FluidCharacterization, gsoapProxy2_2, FluidCharacterizationType, std::string)
+		GETTER_SETTER_OPTIONAL_ATTRIBUTE(gsoap_eml2_2::prodml21__FluidCharacterization, gsoapProxy2_2, IntendedUsage, std::string)
+		GETTER_SETTER_OPTIONAL_ATTRIBUTE(gsoap_eml2_2::prodml21__FluidCharacterization, gsoapProxy2_2, Remark, std::string)
+
 		/**
 		 * Sets standard conditions
 		 *

--- a/src/prodml2_1/FluidCharacterization.h
+++ b/src/prodml2_1/FluidCharacterization.h
@@ -35,7 +35,7 @@ namespace RESQML2_NS
  * @param 	attributeName	 	Name of the attribute.
  * @param 	attributeDatatype	The attribute datatype.
  */
-#define GETTER_FLUID_COMPONENT_ATTRIBUTE(vectorName, attributeName, attributeDatatype)\
+#define GETTER_FLUID_CATALOG_COMPONENT_ATTRIBUTE(vectorName, attributeName, attributeDatatype)\
 	DLL_IMPORT_OR_EXPORT attributeDatatype get##vectorName##attributeName(unsigned int index) const {\
 		if (static_cast<gsoap_eml2_2::prodml21__FluidCharacterization*>(gsoapProxy2_2)->FluidComponentCatalog == nullptr ||\
 			static_cast<gsoap_eml2_2::prodml21__FluidCharacterization*>(gsoapProxy2_2)->FluidComponentCatalog->vectorName.size() <= index) { throw std::out_of_range("The index is out of range"); }\
@@ -49,7 +49,7 @@ namespace RESQML2_NS
  * @param 	attributeName	 	Name of the attribute.
  * @param 	attributeDatatype	The attribute datatype.
  */
-#define GETTER_AND_SETTER_FLUID_COMPONENT_OPTIONAL_ATTRIBUTE(vectorName, attributeName, attributeDatatype)\
+#define GETTER_AND_SETTER_FLUID_CATALOG_COMPONENT_OPTIONAL_ATTRIBUTE(vectorName, attributeName, attributeDatatype)\
 	DLL_IMPORT_OR_EXPORT void set##vectorName##attributeName(unsigned int index, const attributeDatatype& value);\
 	DLL_IMPORT_OR_EXPORT bool has##vectorName##attributeName(unsigned int index) const {\
 		return	static_cast<gsoap_eml2_2::prodml21__FluidCharacterization*>(gsoapProxy2_2)->FluidComponentCatalog != nullptr &&\
@@ -68,9 +68,9 @@ namespace RESQML2_NS
  * @param 	attributeName	Name of the attribute.
  * @param 	uomDatatype  	The uom datatype.
  */
-#define GETTER_AND_SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE(vectorName, attributeName, uomDatatype)\
+#define GETTER_AND_SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE(vectorName, attributeName, uomDatatype)\
 	DLL_IMPORT_OR_EXPORT void set##vectorName##attributeName(unsigned int index, double value, uomDatatype uom);\
-	DLL_IMPORT_OR_EXPORT double has##vectorName##attributeName(unsigned int index) const {\
+	DLL_IMPORT_OR_EXPORT bool has##vectorName##attributeName(unsigned int index) const {\
 		return	static_cast<gsoap_eml2_2::prodml21__FluidCharacterization*>(gsoapProxy2_2)->FluidComponentCatalog != nullptr &&\
 				static_cast<gsoap_eml2_2::prodml21__FluidCharacterization*>(gsoapProxy2_2)->FluidComponentCatalog->vectorName.size() > index &&\
 				static_cast<gsoap_eml2_2::prodml21__FluidCharacterization*>(gsoapProxy2_2)->FluidComponentCatalog->vectorName[index]->attributeName != nullptr;\
@@ -89,11 +89,11 @@ namespace RESQML2_NS
  *
  * @param 	vectorName	Name of the vector.
  */
-#define GETTER_AND_SETTER_FLUID_COMPONENT_COMMON_ATTRIBUTES(vectorName)\
-	GETTER_FLUID_COMPONENT_ATTRIBUTE(vectorName, uid, std::string)\
-	GETTER_AND_SETTER_FLUID_COMPONENT_OPTIONAL_ATTRIBUTE(vectorName, Remark, std::string)\
-	GETTER_AND_SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE(vectorName, MassFraction, gsoap_eml2_2::eml22__MassPerMassUom)\
-	GETTER_AND_SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE(vectorName, MoleFraction, gsoap_eml2_2::eml22__AmountOfSubstancePerAmountOfSubstanceUom)
+#define GETTER_AND_SETTER_FLUID_CATALOG_COMPONENT_COMMON_ATTRIBUTES(vectorName)\
+	GETTER_FLUID_CATALOG_COMPONENT_ATTRIBUTE(vectorName, uid, std::string)\
+	GETTER_AND_SETTER_FLUID_CATALOG_COMPONENT_OPTIONAL_ATTRIBUTE(vectorName, Remark, std::string)\
+	GETTER_AND_SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE(vectorName, MassFraction, gsoap_eml2_2::eml22__MassPerMassUom)\
+	GETTER_AND_SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE(vectorName, MoleFraction, gsoap_eml2_2::eml22__AmountOfSubstancePerAmountOfSubstanceUom)
 
 namespace PRODML2_1_NS
 {
@@ -232,9 +232,9 @@ namespace PRODML2_1_NS
 		 * @param 	uid	The UID.
 		 */
 		DLL_IMPORT_OR_EXPORT void pushBackFormationWater(const std::string & uid);
-		GETTER_AND_SETTER_FLUID_COMPONENT_COMMON_ATTRIBUTES(FormationWater)
-		GETTER_AND_SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE(FormationWater, Salinity, gsoap_eml2_2::eml22__MassPerMassUom)
-		GETTER_AND_SETTER_FLUID_COMPONENT_OPTIONAL_ATTRIBUTE(FormationWater, SpecificGravity, double)
+		GETTER_AND_SETTER_FLUID_CATALOG_COMPONENT_COMMON_ATTRIBUTES(FormationWater)
+		GETTER_AND_SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE(FormationWater, Salinity, gsoap_eml2_2::eml22__MassPerMassUom)
+		GETTER_AND_SETTER_FLUID_CATALOG_COMPONENT_OPTIONAL_ATTRIBUTE(FormationWater, SpecificGravity, double)
 
 		/**
 		 * Gets pure fluid component count
@@ -251,10 +251,10 @@ namespace PRODML2_1_NS
 		 * @param 	hydrocarbonFlag	True to hydrocarbon flag.
 		 */
 		DLL_IMPORT_OR_EXPORT void pushBackPureFluidComponent(const std::string & uid, gsoap_eml2_2::prodml21__PureComponentEnum kind, bool hydrocarbonFlag);
-		GETTER_AND_SETTER_FLUID_COMPONENT_COMMON_ATTRIBUTES(PureFluidComponent)
-		GETTER_FLUID_COMPONENT_ATTRIBUTE(PureFluidComponent, Kind, std::string)
-		GETTER_FLUID_COMPONENT_ATTRIBUTE(PureFluidComponent, HydrocarbonFlag, bool)
-		GETTER_AND_SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE(PureFluidComponent, MolecularWeight, gsoap_eml2_2::eml22__MolecularWeightUom)
+		GETTER_AND_SETTER_FLUID_CATALOG_COMPONENT_COMMON_ATTRIBUTES(PureFluidComponent)
+		GETTER_FLUID_CATALOG_COMPONENT_ATTRIBUTE(PureFluidComponent, Kind, std::string)
+		GETTER_FLUID_CATALOG_COMPONENT_ATTRIBUTE(PureFluidComponent, HydrocarbonFlag, bool)
+		GETTER_AND_SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE(PureFluidComponent, MolecularWeight, gsoap_eml2_2::eml22__MolecularWeightUom)
 
 		/**
 		 * Gets plus fluid component count
@@ -270,12 +270,12 @@ namespace PRODML2_1_NS
 		 * @param 	kind	The kind.
 		 */
 		DLL_IMPORT_OR_EXPORT void pushBackPlusFluidComponent(const std::string & uid, gsoap_eml2_2::prodml21__PlusComponentEnum kind);
-		GETTER_AND_SETTER_FLUID_COMPONENT_COMMON_ATTRIBUTES(PlusFluidComponent)
-		GETTER_AND_SETTER_FLUID_COMPONENT_OPTIONAL_ATTRIBUTE(PlusFluidComponent, SpecificGravity, double)
-		GETTER_AND_SETTER_FLUID_COMPONENT_OPTIONAL_ATTRIBUTE(PlusFluidComponent, StartingCarbonNumber, uint64_t)
-		GETTER_AND_SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE(PlusFluidComponent, StartingBoilingPoint, gsoap_eml2_2::eml22__ThermodynamicTemperatureUom)
-		GETTER_AND_SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE(PlusFluidComponent, AvgDensity, std::string)
-		GETTER_AND_SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE(PlusFluidComponent, AvgMolecularWeight, gsoap_eml2_2::eml22__MolecularWeightUom)
+		GETTER_AND_SETTER_FLUID_CATALOG_COMPONENT_COMMON_ATTRIBUTES(PlusFluidComponent)
+		GETTER_AND_SETTER_FLUID_CATALOG_COMPONENT_OPTIONAL_ATTRIBUTE(PlusFluidComponent, SpecificGravity, double)
+		GETTER_AND_SETTER_FLUID_CATALOG_COMPONENT_OPTIONAL_ATTRIBUTE(PlusFluidComponent, StartingCarbonNumber, uint64_t)
+		GETTER_AND_SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE(PlusFluidComponent, StartingBoilingPoint, gsoap_eml2_2::eml22__ThermodynamicTemperatureUom)
+		GETTER_AND_SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE(PlusFluidComponent, AvgDensity, std::string)
+		GETTER_AND_SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE(PlusFluidComponent, AvgMolecularWeight, gsoap_eml2_2::eml22__MolecularWeightUom)
 
 		/**
 		 * Gets stock tank oil count
@@ -290,13 +290,13 @@ namespace PRODML2_1_NS
 		 * @param 	uid	The UID.
 		 */
 		DLL_IMPORT_OR_EXPORT void pushBackStockTankOil(const std::string & uid);
-		GETTER_AND_SETTER_FLUID_COMPONENT_COMMON_ATTRIBUTES(StockTankOil)
-		GETTER_AND_SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE(StockTankOil, APIGravity, gsoap_eml2_2::eml22__APIGravityUom)
-		GETTER_AND_SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE(StockTankOil, MolecularWeight, gsoap_eml2_2::eml22__MolecularWeightUom)
-		GETTER_AND_SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE(StockTankOil, GrossEnergyContentPerUnitMass, gsoap_eml2_2::eml22__EnergyPerMassUom)
-		GETTER_AND_SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE(StockTankOil, NetEnergyContentPerUnitMass, gsoap_eml2_2::eml22__EnergyPerMassUom)
-		GETTER_AND_SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE(StockTankOil, GrossEnergyContentPerUnitVolume, gsoap_eml2_2::eml22__EnergyPerVolumeUom)
-		GETTER_AND_SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE(StockTankOil, NetEnergyContentPerUnitVolume, gsoap_eml2_2::eml22__EnergyPerVolumeUom)
+		GETTER_AND_SETTER_FLUID_CATALOG_COMPONENT_COMMON_ATTRIBUTES(StockTankOil)
+		GETTER_AND_SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE(StockTankOil, APIGravity, gsoap_eml2_2::eml22__APIGravityUom)
+		GETTER_AND_SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE(StockTankOil, MolecularWeight, gsoap_eml2_2::eml22__MolecularWeightUom)
+		GETTER_AND_SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE(StockTankOil, GrossEnergyContentPerUnitMass, gsoap_eml2_2::eml22__EnergyPerMassUom)
+		GETTER_AND_SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE(StockTankOil, NetEnergyContentPerUnitMass, gsoap_eml2_2::eml22__EnergyPerMassUom)
+		GETTER_AND_SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE(StockTankOil, GrossEnergyContentPerUnitVolume, gsoap_eml2_2::eml22__EnergyPerVolumeUom)
+		GETTER_AND_SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE(StockTankOil, NetEnergyContentPerUnitVolume, gsoap_eml2_2::eml22__EnergyPerVolumeUom)
 
 		/**
 		 * Gets natural gas count
@@ -311,13 +311,13 @@ namespace PRODML2_1_NS
 		 * @param 	uid	The UID.
 		 */
 		DLL_IMPORT_OR_EXPORT void pushBackNaturalGas(const std::string & uid);
-		GETTER_AND_SETTER_FLUID_COMPONENT_COMMON_ATTRIBUTES(NaturalGas)
-		GETTER_AND_SETTER_FLUID_COMPONENT_OPTIONAL_ATTRIBUTE(NaturalGas, GasGravity, double)
-		GETTER_AND_SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE(NaturalGas, MolecularWeight, gsoap_eml2_2::eml22__MolecularWeightUom)
-		GETTER_AND_SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE(NaturalGas, GrossEnergyContentPerUnitMass, gsoap_eml2_2::eml22__EnergyPerMassUom)
-		GETTER_AND_SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE(NaturalGas, NetEnergyContentPerUnitMass, gsoap_eml2_2::eml22__EnergyPerMassUom)
-		GETTER_AND_SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE(NaturalGas, GrossEnergyContentPerUnitVolume, gsoap_eml2_2::eml22__EnergyPerVolumeUom)
-		GETTER_AND_SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE(NaturalGas, NetEnergyContentPerUnitVolume, gsoap_eml2_2::eml22__EnergyPerVolumeUom)
+		GETTER_AND_SETTER_FLUID_CATALOG_COMPONENT_COMMON_ATTRIBUTES(NaturalGas)
+		GETTER_AND_SETTER_FLUID_CATALOG_COMPONENT_OPTIONAL_ATTRIBUTE(NaturalGas, GasGravity, double)
+		GETTER_AND_SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE(NaturalGas, MolecularWeight, gsoap_eml2_2::eml22__MolecularWeightUom)
+		GETTER_AND_SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE(NaturalGas, GrossEnergyContentPerUnitMass, gsoap_eml2_2::eml22__EnergyPerMassUom)
+		GETTER_AND_SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE(NaturalGas, NetEnergyContentPerUnitMass, gsoap_eml2_2::eml22__EnergyPerMassUom)
+		GETTER_AND_SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE(NaturalGas, GrossEnergyContentPerUnitVolume, gsoap_eml2_2::eml22__EnergyPerVolumeUom)
+		GETTER_AND_SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE(NaturalGas, NetEnergyContentPerUnitVolume, gsoap_eml2_2::eml22__EnergyPerVolumeUom)
 
 		/**
 		 * Gets pseudo fluid component count
@@ -333,15 +333,15 @@ namespace PRODML2_1_NS
 		 * @param 	kind	The kind.
 		 */
 		DLL_IMPORT_OR_EXPORT void pushBackPseudoFluidComponent(const std::string & uid, gsoap_eml2_2::prodml21__PseudoComponentEnum kind);
-		GETTER_AND_SETTER_FLUID_COMPONENT_COMMON_ATTRIBUTES(PseudoFluidComponent)
-		GETTER_AND_SETTER_FLUID_COMPONENT_OPTIONAL_ATTRIBUTE(PseudoFluidComponent, SpecificGravity, double)
-		GETTER_AND_SETTER_FLUID_COMPONENT_OPTIONAL_ATTRIBUTE(PseudoFluidComponent, StartingCarbonNumber, uint64_t)
-		GETTER_AND_SETTER_FLUID_COMPONENT_OPTIONAL_ATTRIBUTE(PseudoFluidComponent, EndingCarbonNumber, uint64_t)
-		GETTER_AND_SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE(PseudoFluidComponent, StartingBoilingPoint, gsoap_eml2_2::eml22__ThermodynamicTemperatureUom)
-		GETTER_AND_SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE(PseudoFluidComponent, EndingBoilingPoint, gsoap_eml2_2::eml22__ThermodynamicTemperatureUom)
-		GETTER_AND_SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE(PseudoFluidComponent, AvgBoilingPoint, gsoap_eml2_2::eml22__ThermodynamicTemperatureUom)
-		GETTER_AND_SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE(PseudoFluidComponent, AvgDensity, std::string)
-		GETTER_AND_SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE(PseudoFluidComponent, AvgMolecularWeight, gsoap_eml2_2::eml22__MolecularWeightUom)
+		GETTER_AND_SETTER_FLUID_CATALOG_COMPONENT_COMMON_ATTRIBUTES(PseudoFluidComponent)
+		GETTER_AND_SETTER_FLUID_CATALOG_COMPONENT_OPTIONAL_ATTRIBUTE(PseudoFluidComponent, SpecificGravity, double)
+		GETTER_AND_SETTER_FLUID_CATALOG_COMPONENT_OPTIONAL_ATTRIBUTE(PseudoFluidComponent, StartingCarbonNumber, uint64_t)
+		GETTER_AND_SETTER_FLUID_CATALOG_COMPONENT_OPTIONAL_ATTRIBUTE(PseudoFluidComponent, EndingCarbonNumber, uint64_t)
+		GETTER_AND_SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE(PseudoFluidComponent, StartingBoilingPoint, gsoap_eml2_2::eml22__ThermodynamicTemperatureUom)
+		GETTER_AND_SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE(PseudoFluidComponent, EndingBoilingPoint, gsoap_eml2_2::eml22__ThermodynamicTemperatureUom)
+		GETTER_AND_SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE(PseudoFluidComponent, AvgBoilingPoint, gsoap_eml2_2::eml22__ThermodynamicTemperatureUom)
+		GETTER_AND_SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE(PseudoFluidComponent, AvgDensity, std::string)
+		GETTER_AND_SETTER_FLUID_CATALOG_COMPONENT_MEASURE_ATTRIBUTE(PseudoFluidComponent, AvgMolecularWeight, gsoap_eml2_2::eml22__MolecularWeightUom)
 
 		/** Values that represent model specifications */
 		enum ModelSpecification {

--- a/src/prodml2_1/FluidCharacterization.h
+++ b/src/prodml2_1/FluidCharacterization.h
@@ -220,6 +220,27 @@ namespace PRODML2_1_NS
 		DLL_IMPORT_OR_EXPORT RESQML2_NS::RockFluidUnitInterpretation* getRockFluidUnit() const;
 
 		/**
+		 * Sets the assocaited fluid system
+		 *
+		 * @param [in,out]	rockFluidUnit	If non-null, the rock fluid unit.
+		 */
+		DLL_IMPORT_OR_EXPORT void setFluidSystem(class FluidSystem* fluidSystem);
+
+		/**
+		 * Gets the associated FluidSystem dor
+		 *
+		 * @returns	Empty if it fails, else the FluidSystem dor.
+		 */
+		COMMON_NS::DataObjectReference getFluidSystemDor() const;
+
+		/**
+		 * Gets the associated FluidSystem
+		 *
+		 * @returns	Null if it fails, else the FluidSystem.
+		 */
+		DLL_IMPORT_OR_EXPORT class FluidSystem* getFluidSystem() const;
+
+		/**
 		 * Gets formation water count
 		 *
 		 * @returns	The formation water count.
@@ -415,6 +436,15 @@ namespace PRODML2_1_NS
 		DLL_IMPORT_OR_EXPORT void pushBackTableFormat(const std::string & uid = "");
 
 		/**
+		 * Gets the count of a table format column
+		 *
+		 * @param	tableFormatUid	The uid of the table format.
+		 * @param	columnIndex		The zero-based index of the column.
+		 * @returns	The uom of a table format column
+		 */
+		DLL_IMPORT_OR_EXPORT uint64_t getTableFormatColumnCount(const std::string & tableFormatUid) const;
+
+		/**
 		 * Gets the uom of a table format column
 		 *
 		 * @param	tableFormatUid	The uid of the table format.
@@ -439,7 +469,7 @@ namespace PRODML2_1_NS
 		* @param 	uom					The uom associated to the values of this column
 		* @param	fluidProperty		The property that this column contains
 		*/
-		DLL_IMPORT_OR_EXPORT void pushBackTableFormatColumn(unsigned int tableFormatIndex, const std::string & uom, gsoap_eml2_2::prodml21__OutputFluidProperty fluidProperty);
+		DLL_IMPORT_OR_EXPORT void pushBackTableFormatColumn(unsigned int tableFormatIndex, gsoap_eml2_2::eml22__UnitOfMeasure uom, gsoap_eml2_2::prodml21__OutputFluidProperty fluidProperty);
 
 		/**
 		* Pushes a table format colum
@@ -510,9 +540,9 @@ namespace PRODML2_1_NS
 		*
 		* @param	modelIndex		Zero-based index of the model in this fluid characterization.
 		* @param 	tableIndex		Zero-based index of the table in a model of this fluid characterization.
-		* @param 	rowContent		The string containing the content of the row in the table.
+		* @param 	rowContent		The values representing the content of the row in the table.
 		*/
-		DLL_IMPORT_OR_EXPORT void pushBackTableRow(unsigned int modelIndex, unsigned int tableIndex, const std::string & rowContent);
+		DLL_IMPORT_OR_EXPORT void pushBackTableRow(unsigned int modelIndex, unsigned int tableIndex, const std::vector<double> & rowContent);
 
 		/**
 		 * The standard XML tag without XML namespace for serializing this data object.

--- a/src/prodml2_1/FluidSystem.cpp
+++ b/src/prodml2_1/FluidSystem.cpp
@@ -20,6 +20,8 @@ under the License.
 
 #include <stdexcept>
 
+#include "../resqml2/RockFluidOrganizationInterpretation.h"
+
 using namespace std;
 using namespace PRODML2_1_NS;
 using namespace gsoap_eml2_2;
@@ -93,6 +95,10 @@ FluidSystem::FluidSystem(COMMON_NS::DataObjectRepository * repo,
 
 	repo->addOrReplaceDataObject(this);
 }
+
+SETTER_OPTIONAL_ATTRIBUTE_IMPL(FluidSystem, gsoap_eml2_2::prodml21__FluidSystem, gsoapProxy2_2, PhasesPresent, gsoap_eml2_2::prodml21__PhasePresent, soap_new_prodml21__PhasePresent)
+SETTER_OPTIONAL_ATTRIBUTE_IMPL(FluidSystem, ::prodml21__FluidSystem, gsoapProxy2_2, ReservoirLifeCycleState, gsoap_eml2_2::prodml21__ReservoirLifeCycleState, soap_new_prodml21__ReservoirLifeCycleState)
+SETTER_OPTIONAL_ATTRIBUTE_IMPL(FluidSystem, gsoap_eml2_2::prodml21__FluidSystem, gsoapProxy2_2, Remark, std::string, soap_new_std__string)
 
 double FluidSystem::getStandardTemperatureValue() const
 {
@@ -173,12 +179,146 @@ double FluidSystem::getSolutionGORValue() const {
 	return static_cast<prodml21__FluidSystem*>(gsoapProxy2_2)->SolutionGOR->__item;
 }
 
-gsoap_eml2_2::eml22__VolumePerVolumeUom FluidSystem::getSolutionGORUom() const {
-	gsoap_eml2_2::eml22__VolumePerVolumeUom* result;
-	gsoap_eml2_2::soap_s2eml22__VolumePerVolumeUom(getGsoapContext(), static_cast<prodml21__FluidSystem*>(gsoapProxy2_2)->SolutionGOR->uom.c_str(), result);
-	if (result == nullptr) {
-		throw logic_error("Cannot recognize the exotic volume per volume uom : " + static_cast<prodml21__FluidSystem*>(gsoapProxy2_2)->SolutionGOR->uom);
+gsoap_eml2_2::eml22__VolumePerVolumeUom FluidSystem::getSolutionGORUom() const
+{
+	gsoap_eml2_2::eml22__VolumePerVolumeUom result;
+	if (gsoap_eml2_2::soap_s2eml22__VolumePerVolumeUom(getGsoapContext(), static_cast<prodml21__FluidSystem*>(gsoapProxy2_2)->SolutionGOR->uom.c_str(), &result) == SOAP_OK) {
+		return result;
+	}
+	throw logic_error("Cannot recognize the exotic volume per volume uom : " + static_cast<prodml21__FluidSystem*>(gsoapProxy2_2)->SolutionGOR->uom);
+}
+
+void FluidSystem::setSaturationPressure(double value, gsoap_eml2_2::eml22__PressureUom pressureUom, gsoap_eml2_2::prodml21__SaturationPointKind saturationPointKind)
+{
+	prodml21__FluidSystem* fs = static_cast<prodml21__FluidSystem*>(gsoapProxy2_2);
+	if (fs->SaturationPressure == nullptr) {
+		fs->SaturationPressure = soap_new_prodml21__SaturationPressure(getGsoapContext());
+	}
+	fs->SaturationPressure->kind = saturationPointKind;
+	fs->SaturationPressure->uom = soap_eml22__PressureUom2s(getGsoapContext(), pressureUom);
+	fs->SaturationPressure->__item = value;
+}
+
+bool FluidSystem::hasSaturationPressureValue() const
+{
+	return static_cast<prodml21__FluidSystem*>(gsoapProxy2_2)->SaturationPressure != nullptr;
+}
+
+double FluidSystem::getSaturationPressureValue() const
+{
+	if (!hasSaturationPressureValue()) {
+		throw logic_error("There is no saturation pressure value");
+	}
+	return static_cast<prodml21__FluidSystem*>(gsoapProxy2_2)->SaturationPressure->__item;
+}
+
+ gsoap_eml2_2::eml22__PressureUom FluidSystem::getSaturationPressureUom() const
+ {
+	 if (!hasSaturationPressureValue()) {
+		 throw logic_error("There is no saturation pressure value");
+	 }
+	 string uomStr = static_cast<prodml21__FluidSystem*>(gsoapProxy2_2)->SaturationPressure->uom;
+	 gsoap_eml2_2::eml22__PressureUom result;
+	 if (gsoap_eml2_2::soap_s2eml22__PressureUom(getGsoapContext(), uomStr.c_str(), &result) == SOAP_OK) {
+		 return result;
+	 }
+	 throw logic_error("The exotic saturation pressure uom is not recognized : " + uomStr);
+ }
+
+gsoap_eml2_2::prodml21__SaturationPointKind FluidSystem::getSaturationPressurePointKind() const
+{
+	if (!hasSaturationPressureValue()) {
+		throw logic_error("There is no saturation pressure value");
+	}
+	return static_cast<prodml21__FluidSystem*>(gsoapProxy2_2)->SaturationPressure->kind;
+}
+
+#define SETTER_FLUID_COMPONENT_OPTIONAL_ATTRIBUTE_IMPL(componentName, attributeName, attributeDatatype, constructor)\
+void FluidSystem::set##componentName##attributeName(const attributeDatatype& value)\
+{\
+	if (static_cast<prodml21__FluidSystem*>(gsoapProxy2_2)->componentName == nullptr) {\
+		static_cast<prodml21__FluidSystem*>(gsoapProxy2_2)->componentName = soap_new_prodml21__##componentName(getGsoapContext());\
+		static_cast<prodml21__FluidSystem*>(gsoapProxy2_2)->componentName->uid = "0";\
+	}\
+	static_cast<prodml21__FluidSystem*>(gsoapProxy2_2)->componentName->attributeName = constructor(getGsoapContext());\
+	*static_cast<prodml21__FluidSystem*>(gsoapProxy2_2)->componentName->attributeName = value;\
+}
+
+#define SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE_IMPL(componentName, attributeName, uomDatatype, constructor)\
+void FluidSystem::set##componentName##attributeName( double value, uomDatatype uom)\
+{\
+	if (static_cast<prodml21__FluidSystem*>(gsoapProxy2_2)->componentName == nullptr) {\
+		static_cast<prodml21__FluidSystem*>(gsoapProxy2_2)->componentName = soap_new_prodml21__##componentName(getGsoapContext());\
+		static_cast<prodml21__FluidSystem*>(gsoapProxy2_2)->componentName->uid = "0";\
+	}\
+	static_cast<prodml21__FluidSystem*>(gsoapProxy2_2)->componentName->attributeName = constructor(getGsoapContext());\
+	static_cast<prodml21__FluidSystem*>(gsoapProxy2_2)->componentName->attributeName->__item = value;\
+	static_cast<prodml21__FluidSystem*>(gsoapProxy2_2)->componentName->attributeName->uom = uom;\
+}
+
+#define SETTER_FLUID_COMPONENT_COMMON_ATTRIBUTES_IMPL(componentName)\
+SETTER_FLUID_COMPONENT_OPTIONAL_ATTRIBUTE_IMPL(componentName, Remark, std::string, soap_new_std__string)\
+SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE_IMPL(componentName, MassFraction, eml22__MassPerMassUom, soap_new_eml22__MassPerMassMeasure)\
+SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE_IMPL(componentName, MoleFraction, eml22__AmountOfSubstancePerAmountOfSubstanceUom, soap_new_eml22__AmountOfSubstancePerAmountOfSubstanceMeasure)
+
+SETTER_FLUID_COMPONENT_COMMON_ATTRIBUTES_IMPL(FormationWater)
+SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE_IMPL(FormationWater, Salinity, gsoap_eml2_2::eml22__MassPerMassUom, gsoap_eml2_2::soap_new_eml22__MassPerMassMeasure)
+SETTER_FLUID_COMPONENT_OPTIONAL_ATTRIBUTE_IMPL(FormationWater, SpecificGravity, double, soap_new_double)
+
+SETTER_FLUID_COMPONENT_COMMON_ATTRIBUTES_IMPL(StockTankOil)
+SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE_IMPL(StockTankOil, APIGravity, gsoap_eml2_2::eml22__APIGravityUom, gsoap_eml2_2::soap_new_eml22__APIGravityMeasure)
+SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE_IMPL(StockTankOil, MolecularWeight, gsoap_eml2_2::eml22__MolecularWeightUom, gsoap_eml2_2::soap_new_eml22__MolecularWeightMeasure)
+SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE_IMPL(StockTankOil, GrossEnergyContentPerUnitMass, gsoap_eml2_2::eml22__EnergyPerMassUom, gsoap_eml2_2::soap_new_eml22__EnergyPerMassMeasure)
+SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE_IMPL(StockTankOil, NetEnergyContentPerUnitMass, gsoap_eml2_2::eml22__EnergyPerMassUom, gsoap_eml2_2::soap_new_eml22__EnergyPerMassMeasure)
+SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE_IMPL(StockTankOil, GrossEnergyContentPerUnitVolume, gsoap_eml2_2::eml22__EnergyPerVolumeUom, gsoap_eml2_2::soap_new_eml22__EnergyPerVolumeMeasure)
+SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE_IMPL(StockTankOil, NetEnergyContentPerUnitVolume, gsoap_eml2_2::eml22__EnergyPerVolumeUom, gsoap_eml2_2::soap_new_eml22__EnergyPerVolumeMeasure)
+
+SETTER_FLUID_COMPONENT_COMMON_ATTRIBUTES_IMPL(NaturalGas)
+SETTER_FLUID_COMPONENT_OPTIONAL_ATTRIBUTE_IMPL(NaturalGas, GasGravity, double, soap_new_double)
+SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE_IMPL(NaturalGas, MolecularWeight, gsoap_eml2_2::eml22__MolecularWeightUom, gsoap_eml2_2::soap_new_eml22__MolecularWeightMeasure)
+SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE_IMPL(NaturalGas, GrossEnergyContentPerUnitMass, gsoap_eml2_2::eml22__EnergyPerMassUom, gsoap_eml2_2::soap_new_eml22__EnergyPerMassMeasure)
+SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE_IMPL(NaturalGas, NetEnergyContentPerUnitMass, gsoap_eml2_2::eml22__EnergyPerMassUom, gsoap_eml2_2::soap_new_eml22__EnergyPerMassMeasure)
+SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE_IMPL(NaturalGas, GrossEnergyContentPerUnitVolume, gsoap_eml2_2::eml22__EnergyPerVolumeUom, gsoap_eml2_2::soap_new_eml22__EnergyPerVolumeMeasure)
+SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE_IMPL(NaturalGas, NetEnergyContentPerUnitVolume, gsoap_eml2_2::eml22__EnergyPerVolumeUom, gsoap_eml2_2::soap_new_eml22__EnergyPerVolumeMeasure)
+
+void FluidSystem::setRockFluidOrganization(RESQML2_NS::RockFluidOrganizationInterpretation* rockFluidOrg)
+{
+	if (rockFluidOrg == nullptr) {
+		throw std::invalid_argument("Cannot set a null rockFluidOrg");
+	}
+	if (!static_cast<prodml21__FluidSystem*>(gsoapProxy2_2)->RockFluidUnitFeature.empty()) {
+		throw std::logic_error("A rock Fluid organization is already set for this fluid system.");
+	}
+	static_cast<prodml21__FluidSystem*>(gsoapProxy2_2)->RockFluidUnitFeature.push_back(rockFluidOrg->newEml22Reference());
+
+	getRepository()->addRelationship(this, rockFluidOrg);
+}
+
+COMMON_NS::DataObjectReference FluidSystem::getRockFluidOrganizationDor() const
+{
+	if (static_cast<prodml21__FluidSystem*>(gsoapProxy2_2)->RockFluidUnitFeature.empty()) {
+		return COMMON_NS::DataObjectReference();
+	}
+	else if (static_cast<prodml21__FluidSystem*>(gsoapProxy2_2)->RockFluidUnitFeature.size() > 1) {
+		throw std::logic_error("This fluid system is assocaited to more than one rock Fluid organization. This is not supported.");
 	}
 
-	return *result;
+	return COMMON_NS::DataObjectReference(static_cast<prodml21__FluidSystem*>(gsoapProxy2_2)->RockFluidUnitFeature[0]);
+}
+
+RESQML2_NS::RockFluidOrganizationInterpretation* FluidSystem::getRockFluidOrganization() const
+{
+	return getRepository()->getDataObjectByUuid<RESQML2_NS::RockFluidOrganizationInterpretation>(getRockFluidOrganizationDor().getUuid());
+}
+
+void FluidSystem::loadTargetRelationships()
+{
+	COMMON_NS::DataObjectReference dor = getRockFluidOrganizationDor();
+	if (!dor.isEmpty()) {
+		RESQML2_NS::RockFluidOrganizationInterpretation* rockFluidORg = getRepository()->getDataObjectByUuid<RESQML2_NS::RockFluidOrganizationInterpretation>(dor.getUuid());
+		if (rockFluidORg == nullptr) {
+			convertDorIntoRel<RESQML2_NS::RockFluidOrganizationInterpretation>(dor);
+		}
+		getRepository()->addRelationship(this, rockFluidORg);
+	}
 }

--- a/src/prodml2_1/FluidSystem.cpp
+++ b/src/prodml2_1/FluidSystem.cpp
@@ -61,3 +61,124 @@ FluidSystem::FluidSystem(COMMON_NS::DataObjectRepository * repo,
 
 	repo->addOrReplaceDataObject(this);
 }
+
+FluidSystem::FluidSystem(COMMON_NS::DataObjectRepository * repo,
+	const std::string & guid,
+	const std::string & title,
+	gsoap_eml2_2::eml22__ReferenceCondition referenceCondition,
+	gsoap_eml2_2::prodml21__ReservoirFluidKind reservoirFluidKind,
+	double gasOilRatio, gsoap_eml2_2::eml22__VolumePerVolumeUom gasOilRatioUom)
+{
+	if (repo == nullptr) {
+		throw invalid_argument("A repo must exist.");
+	}
+
+	gsoapProxy2_2 = soap_new_prodml21__FluidSystem(repo->getGsoapContext());
+
+	initMandatoryMetadata();
+	setMetadata(guid, title, "", -1, "", "", -1, "");
+
+	prodml21__FluidSystem* fs = static_cast<prodml21__FluidSystem*>(gsoapProxy2_2);
+
+	fs->StandardConditions = soap_new_eml22__ReferenceTemperaturePressure(repo->getGsoapContext());
+	static_cast<eml22__ReferenceTemperaturePressure*>(fs->StandardConditions)->__union_ReferenceTemperaturePressure_ = SOAP_UNION_gsoap_eml2_2__eml22__union_ReferenceTemperaturePressure__ReferenceTempPres;
+	static_cast<eml22__ReferenceTemperaturePressure*>(fs->StandardConditions)->union_ReferenceTemperaturePressure_.ReferenceTempPres = soap_new_std__string(repo->getGsoapContext());
+	static_cast<eml22__ReferenceTemperaturePressure*>(fs->StandardConditions)->union_ReferenceTemperaturePressure_.ReferenceTempPres->assign(soap_eml22__ReferenceCondition2s(repo->getGsoapContext(), referenceCondition));
+
+	fs->ReservoirFluidKind = reservoirFluidKind;
+
+	fs->SolutionGOR = soap_new_eml22__VolumePerVolumeMeasure(repo->getGsoapContext());
+	fs->SolutionGOR->__item = gasOilRatio;
+	fs->SolutionGOR->uom = gsoap_eml2_2::soap_eml22__VolumePerVolumeUom2s(repo->getGsoapContext(), gasOilRatioUom);
+
+	repo->addOrReplaceDataObject(this);
+}
+
+double FluidSystem::getStandardTemperatureValue() const
+{
+	prodml21__FluidSystem* fs = static_cast<prodml21__FluidSystem*>(gsoapProxy2_2);
+	if (fs->StandardConditions->soap_type() == SOAP_TYPE_gsoap_eml2_2_eml22__TemperaturePressure) {
+		return static_cast<eml22__TemperaturePressure*>(fs->StandardConditions)->Temperature->__item;
+	}
+	else if (fs->StandardConditions->soap_type() == SOAP_TYPE_gsoap_eml2_2_eml22__ReferenceTemperaturePressure) {
+		istringstream iss(*static_cast<eml22__ReferenceTemperaturePressure*>(fs->StandardConditions)->union_ReferenceTemperaturePressure_.ReferenceTempPres);
+		int result;
+		iss >> result;
+		return result;
+	}
+
+	throw logic_error("Unrecognized datatype for StandardConditions.");
+}
+
+gsoap_eml2_2::eml22__ThermodynamicTemperatureUom FluidSystem::getStandardTemperatureUom() const
+{
+	prodml21__FluidSystem* fs = static_cast<prodml21__FluidSystem*>(gsoapProxy2_2);
+	if (fs->StandardConditions->soap_type() == SOAP_TYPE_gsoap_eml2_2_eml22__TemperaturePressure) {
+		return static_cast<eml22__TemperaturePressure*>(fs->StandardConditions)->Temperature->uom;
+	}
+	else if (fs->StandardConditions->soap_type() == SOAP_TYPE_gsoap_eml2_2_eml22__ReferenceTemperaturePressure) {
+		const std::string str = *static_cast<eml22__ReferenceTemperaturePressure*>(fs->StandardConditions)->union_ReferenceTemperaturePressure_.ReferenceTempPres;
+		if (str.find("degC") != std::string::npos) return gsoap_eml2_2::eml22__ThermodynamicTemperatureUom__degC;
+		if (str.find("degF") != std::string::npos) return gsoap_eml2_2::eml22__ThermodynamicTemperatureUom__degF;
+		throw logic_error("Unrecognized temperature uom in " + str);
+	}
+
+	throw logic_error("Unrecognized datatype for StandardConditions.");
+}
+
+double FluidSystem::getStandardPressureValue() const
+{
+	prodml21__FluidSystem* fs = static_cast<prodml21__FluidSystem*>(gsoapProxy2_2);
+	if (fs->StandardConditions->soap_type() == SOAP_TYPE_gsoap_eml2_2_eml22__TemperaturePressure) {
+		return static_cast<eml22__TemperaturePressure*>(fs->StandardConditions)->Pressure->__item;
+	}
+	else if (fs->StandardConditions->soap_type() == SOAP_TYPE_gsoap_eml2_2_eml22__ReferenceTemperaturePressure) {
+		const std::string str = *static_cast<eml22__ReferenceTemperaturePressure*>(fs->StandardConditions)->union_ReferenceTemperaturePressure_.ReferenceTempPres;
+		istringstream iss(str);
+		int tempValue;
+		iss >> tempValue;
+		std::string  tempUom;
+		iss >> tempUom;
+		int pressureValue;
+		iss >> pressureValue;
+		return pressureValue;
+	}
+
+	throw logic_error("Unrecognized datatype for StandardConditions.");
+}
+
+gsoap_eml2_2::eml22__PressureUom FluidSystem::getStandardPressureUom() const
+{
+	prodml21__FluidSystem* fs = static_cast<prodml21__FluidSystem*>(gsoapProxy2_2);
+	if (fs->StandardConditions->soap_type() == SOAP_TYPE_gsoap_eml2_2_eml22__TemperaturePressure) {
+		gsoap_eml2_2::eml22__PressureUom result;
+		int conversion = soap_s2eml22__PressureUom(getGsoapContext(), static_cast<eml22__TemperaturePressure*>(fs->StandardConditions)->Pressure->uom.c_str(), &result);
+		if (conversion != SOAP_OK) {
+			throw invalid_argument("The pressure uom " + static_cast<eml22__TemperaturePressure*>(fs->StandardConditions)->Pressure->uom + " is not recognized yet");
+		}
+		return result;
+	}
+	else if (fs->StandardConditions->soap_type() == SOAP_TYPE_gsoap_eml2_2_eml22__ReferenceTemperaturePressure) {
+		const std::string str = *static_cast<eml22__ReferenceTemperaturePressure*>(fs->StandardConditions)->union_ReferenceTemperaturePressure_.ReferenceTempPres;
+		if (str.find("bar") != std::string::npos) return gsoap_eml2_2::eml22__PressureUom__bar;
+		if (str.find("atm") != std::string::npos) return gsoap_eml2_2::eml22__PressureUom__atm;
+		if (str.find("Hg") != std::string::npos) return gsoap_eml2_2::eml22__PressureUom__inHg_x005b60degF_x005d;
+		throw logic_error("Unrecognized pressure uom in " + str);
+	}
+
+	throw logic_error("Unrecognized datatype for StandardConditions.");
+}
+
+double FluidSystem::getSolutionGORValue() const {
+	return static_cast<prodml21__FluidSystem*>(gsoapProxy2_2)->SolutionGOR->__item;
+}
+
+gsoap_eml2_2::eml22__VolumePerVolumeUom FluidSystem::getSolutionGORUom() const {
+	gsoap_eml2_2::eml22__VolumePerVolumeUom* result;
+	gsoap_eml2_2::soap_s2eml22__VolumePerVolumeUom(getGsoapContext(), static_cast<prodml21__FluidSystem*>(gsoapProxy2_2)->SolutionGOR->uom.c_str(), result);
+	if (result == nullptr) {
+		throw logic_error("Cannot recognize the exotic volume per volume uom : " + static_cast<prodml21__FluidSystem*>(gsoapProxy2_2)->SolutionGOR->uom);
+	}
+
+	return *result;
+}

--- a/src/prodml2_1/FluidSystem.cpp
+++ b/src/prodml2_1/FluidSystem.cpp
@@ -20,6 +20,8 @@ under the License.
 
 #include <stdexcept>
 
+#include "FluidCharacterization.h"
+
 #include "../resqml2/RockFluidOrganizationInterpretation.h"
 
 using namespace std;
@@ -50,8 +52,10 @@ FluidSystem::FluidSystem(COMMON_NS::DataObjectRepository * repo,
 	prodml21__FluidSystem* fs = static_cast<prodml21__FluidSystem*>(gsoapProxy2_2);
 
 	fs->StandardConditions = soap_new_eml22__TemperaturePressure(repo->getGsoapContext());
+	static_cast<eml22__TemperaturePressure*>(fs->StandardConditions)->Temperature = soap_new_eml22__ThermodynamicTemperatureMeasure(repo->getGsoapContext());
 	static_cast<eml22__TemperaturePressure*>(fs->StandardConditions)->Temperature->__item = temperatureValue;
 	static_cast<eml22__TemperaturePressure*>(fs->StandardConditions)->Temperature->uom = temperatureUom;
+	static_cast<eml22__TemperaturePressure*>(fs->StandardConditions)->Pressure = soap_new_eml22__PressureMeasure(repo->getGsoapContext());
 	static_cast<eml22__TemperaturePressure*>(fs->StandardConditions)->Pressure->__item = pressureValue;
 	static_cast<eml22__TemperaturePressure*>(fs->StandardConditions)->Pressure->uom = gsoap_eml2_2::soap_eml22__PressureUom2s(repo->getGsoapContext(), pressureUom);
 
@@ -309,6 +313,27 @@ COMMON_NS::DataObjectReference FluidSystem::getRockFluidOrganizationDor() const
 RESQML2_NS::RockFluidOrganizationInterpretation* FluidSystem::getRockFluidOrganization() const
 {
 	return getRepository()->getDataObjectByUuid<RESQML2_NS::RockFluidOrganizationInterpretation>(getRockFluidOrganizationDor().getUuid());
+}
+
+std::vector<FluidCharacterization *> FluidSystem::getFluidCharacterizationSet() const
+{
+	return repository->getSourceObjects<FluidCharacterization>(this);
+}
+
+uint64_t FluidSystem::getFluidCharacterizationCount() const
+{
+	return repository->getSourceObjects<FluidCharacterization>(this).size();
+}
+
+FluidCharacterization * FluidSystem::getFluidCharacterization(uint64_t index) const
+{
+	const std::vector<FluidCharacterization*>& fluidCharacterizationSet = getFluidCharacterizationSet();
+
+	if (fluidCharacterizationSet.size() > index) {
+		return fluidCharacterizationSet[index];
+	}
+
+	throw out_of_range("The fluid Characterization index you are requesting is out of range.");
 }
 
 void FluidSystem::loadTargetRelationships()

--- a/src/prodml2_1/FluidSystem.h
+++ b/src/prodml2_1/FluidSystem.h
@@ -20,6 +20,82 @@ under the License.
 
 #include "../common/AbstractObject.h"
 
+#include "../MacroDefinitions.h"
+
+namespace RESQML2_NS
+{
+	/** A rock fluid unit feature. */
+	class RockFluidOrganizationInterpretation;
+}
+
+/**
+ * A macro that defines getter fluid component attribute
+ *
+ * @param 	componentName		Name of the component.
+ * @param 	attributeName	 	Name of the attribute.
+ * @param 	attributeDatatype	The attribute datatype.
+ */
+#define GETTER_FLUID_COMPONENT_ATTRIBUTE(componentName, attributeName, attributeDatatype)\
+	DLL_IMPORT_OR_EXPORT attributeDatatype get##componentName##attributeName() const {\
+		if (static_cast<gsoap_eml2_2::prodml21__FluidSystem*>(gsoapProxy2_2)->componentName == nullptr) { throw std::logic_error("The component does not exist"); }\
+		return static_cast<gsoap_eml2_2::prodml21__FluidSystem*>(gsoapProxy2_2)->componentName->attributeName;\
+	}
+
+ /**
+  * A macro that defines getter and setter fluid component optional attribute
+  *
+  * @param 	componentName		Name of the component.
+  * @param 	attributeName	 	Name of the attribute.
+  * @param 	attributeDatatype	The attribute datatype.
+  */
+#define GETTER_AND_SETTER_FLUID_COMPONENT_OPTIONAL_ATTRIBUTE(componentName, attributeName, attributeDatatype)\
+	DLL_IMPORT_OR_EXPORT void set##componentName##attributeName(const attributeDatatype& value);\
+	DLL_IMPORT_OR_EXPORT bool has##componentName##attributeName() const {\
+		return	static_cast<gsoap_eml2_2::prodml21__FluidSystem*>(gsoapProxy2_2)->componentName != nullptr &&\
+				static_cast<gsoap_eml2_2::prodml21__FluidSystem*>(gsoapProxy2_2)->componentName->attributeName != nullptr;\
+	}\
+	DLL_IMPORT_OR_EXPORT attributeDatatype get##componentName##attributeName() const {\
+		if (!has##componentName##attributeName()) { throw std::logic_error("This attribute in this component attribute does not exist"); }\
+		return *static_cast<gsoap_eml2_2::prodml21__FluidSystem*>(gsoapProxy2_2)->componentName->attributeName;\
+	}
+
+  /**
+   * A macro that defines getter and setter fluid component measure attribute
+   *
+   * @param 	componentName   Name of the component.
+   * @param 	attributeName	Name of the attribute.
+   * @param 	uomDatatype  	The uom datatype.
+   */
+#define GETTER_AND_SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE(componentName, attributeName, uomDatatype)\
+	DLL_IMPORT_OR_EXPORT void set##componentName##attributeName(double value, uomDatatype uom);\
+	DLL_IMPORT_OR_EXPORT bool has##componentName##attributeName() const {\
+		return	static_cast<gsoap_eml2_2::prodml21__FluidSystem*>(gsoapProxy2_2)->componentName != nullptr &&\
+				static_cast<gsoap_eml2_2::prodml21__FluidSystem*>(gsoapProxy2_2)->componentName->attributeName != nullptr;\
+	}\
+	DLL_IMPORT_OR_EXPORT double get##componentName##attributeName##Value() const {\
+		if (!has##componentName##attributeName()) { throw std::logic_error("This attribute in this component attribute does not exist"); }\
+		return static_cast<gsoap_eml2_2::prodml21__FluidSystem*>(gsoapProxy2_2)->componentName->attributeName->__item;\
+	}\
+	DLL_IMPORT_OR_EXPORT uomDatatype get##componentName##attributeName##Uom() const {\
+		if (!has##componentName##attributeName()) { throw std::logic_error("This attribute in this component attribute does not exist"); }\
+		return static_cast<gsoap_eml2_2::prodml21__FluidSystem*>(gsoapProxy2_2)->componentName->attributeName->uom;\
+	}
+
+   /**
+	* A macro that defines getter and setter fluid component common attributes
+	*
+	* @param 	componentName	Name of the component.
+	*/
+#define GETTER_AND_SETTER_FLUID_COMPONENT_COMMON_ATTRIBUTES(componentName)\
+	DLL_IMPORT_OR_EXPORT bool has##componentName() const {\
+		return	static_cast<gsoap_eml2_2::prodml21__FluidSystem*>(gsoapProxy2_2)->componentName != nullptr;\
+	}\
+	GETTER_FLUID_COMPONENT_ATTRIBUTE(componentName, uid, std::string)\
+	GETTER_AND_SETTER_FLUID_COMPONENT_OPTIONAL_ATTRIBUTE(componentName, Remark, std::string)\
+	GETTER_AND_SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE(componentName, MassFraction, gsoap_eml2_2::eml22__MassPerMassUom)\
+	GETTER_AND_SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE(componentName, MoleFraction, gsoap_eml2_2::eml22__AmountOfSubstancePerAmountOfSubstanceUom)
+
+
 namespace PRODML2_1_NS
 {
 	/** A fluid system. */
@@ -94,15 +170,11 @@ namespace PRODML2_1_NS
 		/** Destructor does nothing since the memory is managed by the gsoap context. */
 		~FluidSystem() = default;
 		
-		/**
-		* Get the kind of reservoir hydrocarbon fluid, in broad terms, by its phase behavior. 
-		*/
-		DLL_IMPORT_OR_EXPORT gsoap_eml2_2::prodml21__ReservoirFluidKind getReservoirFluidKind() const {
-			if (isPartial()) {
-				throw std::logic_error("Cannot get the Reservoir fluid kind of a partial Fluid System.");
-			}
-			return static_cast<gsoap_eml2_2::prodml21__FluidSystem*>(gsoapProxy2_2)->ReservoirFluidKind;
-		}
+		GETTER_SETTER_ATTRIBUTE(gsoap_eml2_2::prodml21__FluidSystem, gsoapProxy2_2, ReservoirFluidKind, gsoap_eml2_2::prodml21__ReservoirFluidKind)
+
+		GETTER_SETTER_OPTIONAL_ATTRIBUTE(gsoap_eml2_2::prodml21__FluidSystem, gsoapProxy2_2, PhasesPresent, gsoap_eml2_2::prodml21__PhasePresent)
+		GETTER_SETTER_OPTIONAL_ATTRIBUTE(gsoap_eml2_2::prodml21__FluidSystem, gsoapProxy2_2, ReservoirLifeCycleState, gsoap_eml2_2::prodml21__ReservoirLifeCycleState)
+		GETTER_SETTER_OPTIONAL_ATTRIBUTE(gsoap_eml2_2::prodml21__FluidSystem, gsoapProxy2_2, Remark, std::string)
 
 		/**
 		 * Gets standard temperature value
@@ -147,6 +219,89 @@ namespace PRODML2_1_NS
 		DLL_IMPORT_OR_EXPORT gsoap_eml2_2::eml22__VolumePerVolumeUom getSolutionGORUom() const;
 
 		/**
+		 * Sets the saturation pressure of this fluid system
+		 */
+		DLL_IMPORT_OR_EXPORT void setSaturationPressure(double value, gsoap_eml2_2::eml22__PressureUom pressureUom, gsoap_eml2_2::prodml21__SaturationPointKind saturationPointKind);
+
+		/**
+		 * Checks if this fluid system has a defined saturation pressure
+		 *
+		 * @returns	True if this fluid system has a defined saturation pressure else false.
+		 */
+		DLL_IMPORT_OR_EXPORT bool hasSaturationPressureValue() const;
+
+		/**
+		 * Gets the saturation pressure of this fluid system
+		 *
+		 * @returns	The saturation pressure of this fluid system.
+		 */
+		DLL_IMPORT_OR_EXPORT double getSaturationPressureValue() const;
+
+		/**
+		 * Gets the saturation pressure uom of this fluid system
+		 *
+		 * @returns	The saturation pressure uom of this fluid system.
+		 */
+		DLL_IMPORT_OR_EXPORT gsoap_eml2_2::eml22__PressureUom getSaturationPressureUom() const;
+
+		/**
+		 * Gets the saturation pressure point kind of this fluid system
+		 *
+		 * @returns	The saturation pressure point kind of this fluid system.
+		 */
+		DLL_IMPORT_OR_EXPORT gsoap_eml2_2::prodml21__SaturationPointKind getSaturationPressurePointKind() const;
+
+		/**
+		 * Formation water
+		 */
+		GETTER_AND_SETTER_FLUID_COMPONENT_COMMON_ATTRIBUTES(FormationWater)
+		GETTER_AND_SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE(FormationWater, Salinity, gsoap_eml2_2::eml22__MassPerMassUom)
+		GETTER_AND_SETTER_FLUID_COMPONENT_OPTIONAL_ATTRIBUTE(FormationWater, SpecificGravity, double)
+
+		/**
+		 * Stock tank oil
+		 */
+		GETTER_AND_SETTER_FLUID_COMPONENT_COMMON_ATTRIBUTES(StockTankOil)
+		GETTER_AND_SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE(StockTankOil, APIGravity, gsoap_eml2_2::eml22__APIGravityUom)
+		GETTER_AND_SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE(StockTankOil, MolecularWeight, gsoap_eml2_2::eml22__MolecularWeightUom)
+		GETTER_AND_SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE(StockTankOil, GrossEnergyContentPerUnitMass, gsoap_eml2_2::eml22__EnergyPerMassUom)
+		GETTER_AND_SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE(StockTankOil, NetEnergyContentPerUnitMass, gsoap_eml2_2::eml22__EnergyPerMassUom)
+		GETTER_AND_SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE(StockTankOil, GrossEnergyContentPerUnitVolume, gsoap_eml2_2::eml22__EnergyPerVolumeUom)
+		GETTER_AND_SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE(StockTankOil, NetEnergyContentPerUnitVolume, gsoap_eml2_2::eml22__EnergyPerVolumeUom)
+
+		/**
+		 * Natural gas
+		 */
+		GETTER_AND_SETTER_FLUID_COMPONENT_COMMON_ATTRIBUTES(NaturalGas)
+		GETTER_AND_SETTER_FLUID_COMPONENT_OPTIONAL_ATTRIBUTE(NaturalGas, GasGravity, double)
+		GETTER_AND_SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE(NaturalGas, MolecularWeight, gsoap_eml2_2::eml22__MolecularWeightUom)
+		GETTER_AND_SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE(NaturalGas, GrossEnergyContentPerUnitMass, gsoap_eml2_2::eml22__EnergyPerMassUom)
+		GETTER_AND_SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE(NaturalGas, NetEnergyContentPerUnitMass, gsoap_eml2_2::eml22__EnergyPerMassUom)
+		GETTER_AND_SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE(NaturalGas, GrossEnergyContentPerUnitVolume, gsoap_eml2_2::eml22__EnergyPerVolumeUom)
+		GETTER_AND_SETTER_FLUID_COMPONENT_MEASURE_ATTRIBUTE(NaturalGas, NetEnergyContentPerUnitVolume, gsoap_eml2_2::eml22__EnergyPerVolumeUom)
+
+		/**
+		* Sets the associated Rock fluid organization
+		*
+		* @param [in,out]	rockFluidUnit	If non-null, the rock fluid unit.
+		*/
+		DLL_IMPORT_OR_EXPORT void setRockFluidOrganization(RESQML2_NS::RockFluidOrganizationInterpretation* rockFluidOrg);
+
+		/**
+		 * Gets the associated Rock fluid organization dor
+		 *
+		 * @returns	Empty if it fails, else the associated Rock fluid organization dor.
+		 */
+		COMMON_NS::DataObjectReference getRockFluidOrganizationDor() const;
+
+		/**
+		 * Gets the associated Rock fluid organization
+		 *
+		 * @returns	Null if it fails, else the associated Rock fluid organization.
+		 */
+		DLL_IMPORT_OR_EXPORT RESQML2_NS::RockFluidOrganizationInterpretation* getRockFluidOrganization() const;
+
+		/**
 		 * The standard XML tag without XML namespace for serializing this data object.
 		 *
 		 * @returns	The XML tag.
@@ -171,6 +326,6 @@ namespace PRODML2_1_NS
 		DLL_IMPORT_OR_EXPORT std::string getXmlNamespace() const final { return XML_NS; }
 
 		/** Loads target relationships */
-		void loadTargetRelationships() {}
+		void loadTargetRelationships() final;
 	};
 }

--- a/src/prodml2_1/FluidSystem.h
+++ b/src/prodml2_1/FluidSystem.h
@@ -302,6 +302,32 @@ namespace PRODML2_1_NS
 		DLL_IMPORT_OR_EXPORT RESQML2_NS::RockFluidOrganizationInterpretation* getRockFluidOrganization() const;
 
 		/**
+		 * Gets all the fluid characterizations of this fluid system.
+		 *
+		 * @returns	A vector of all the fluid characterizations of this fluid system.
+		 */
+		DLL_IMPORT_OR_EXPORT std::vector<class FluidCharacterization *> getFluidCharacterizationSet() const;
+
+		/**
+		 * Get the fluid characterizations count of this fluid system.
+		 *
+		 * @returns	The fluid characterizations count of this fluid system.
+		 */
+		DLL_IMPORT_OR_EXPORT uint64_t getFluidCharacterizationCount() const;
+
+		/**
+		 * Gets a particular fluid characterization of this fluid system according to its position in the
+		 * fluid characterizations ordering.
+		 *
+		 * @exception	std::out_of_range	If @p index is out of the range of the representation set.
+		 *
+		 * @param 	index	Zero-based index of the fluid characterization we look for.
+		 *
+		 * @returns	A pointer to the fluid characterization at @p index.
+		 */
+		DLL_IMPORT_OR_EXPORT class FluidCharacterization * getFluidCharacterization(uint64_t index) const;
+
+		/**
 		 * The standard XML tag without XML namespace for serializing this data object.
 		 *
 		 * @returns	The XML tag.

--- a/src/prodml2_1/FluidSystem.h
+++ b/src/prodml2_1/FluidSystem.h
@@ -46,9 +46,9 @@ namespace PRODML2_1_NS
 		 * @param 		  	guid			  	The guid to set to this instance. If empty then a new
 		 * 										guid will be generated.
 		 * @param 		  	title			  	The title.
-		 * @param 		  	temperatureValue  	The temperature value.
+		 * @param 		  	temperatureValue  	The temperature value in standard conditions.
 		 * @param 		  	temperatureUom	  	The temperature uom.
-		 * @param 		  	pressureValue	  	The pressure value.
+		 * @param 		  	pressureValue	  	The pressure value in standard conditions.
 		 * @param 		  	pressureUom		  	The pressure uom.
 		 * @param 		  	reservoirFluidKind	The reservoir fluid kind.
 		 * @param 		  	gasOilRatio		  	The gas oil ratio.
@@ -59,6 +59,28 @@ namespace PRODML2_1_NS
 			const std::string & title,
 			double temperatureValue, gsoap_eml2_2::eml22__ThermodynamicTemperatureUom temperatureUom,
 			double pressureValue, gsoap_eml2_2::eml22__PressureUom pressureUom,
+			gsoap_eml2_2::prodml21__ReservoirFluidKind reservoirFluidKind,
+			double gasOilRatio, gsoap_eml2_2::eml22__VolumePerVolumeUom gasOilRatioUom);
+
+		/**
+		 * @brief	Creates an instance of this class in a gsoap context.
+		 *
+		 * @exception	std::invalid_argument	If <tt>repo == nullptr</tt>.
+		 *
+		 * @param [in,out]	repo			  	The dataobject repo where the underlying gsoap proxy is
+		 * 										going to be created.
+		 * @param 		  	guid			  	The guid to set to this instance. If empty then a new
+		 * 										guid will be generated.
+		 * @param 		  	title			  	The title.
+		 * @param 		  	referenceCondition	A wellknown couple of temperature-pressure in standard conditions.
+		 * @param 		  	reservoirFluidKind	The reservoir fluid kind.
+		 * @param 		  	gasOilRatio		  	The gas oil ratio.
+		 * @param 		  	gasOilRatioUom	  	The gas oil ratio uom.
+		 */
+		FluidSystem(COMMON_NS::DataObjectRepository * repo,
+			const std::string & guid,
+			const std::string & title,
+			gsoap_eml2_2::eml22__ReferenceCondition referenceCondition,
 			gsoap_eml2_2::prodml21__ReservoirFluidKind reservoirFluidKind,
 			double gasOilRatio, gsoap_eml2_2::eml22__VolumePerVolumeUom gasOilRatioUom);
 
@@ -81,6 +103,48 @@ namespace PRODML2_1_NS
 			}
 			return static_cast<gsoap_eml2_2::prodml21__FluidSystem*>(gsoapProxy2_2)->ReservoirFluidKind;
 		}
+
+		/**
+		 * Gets standard temperature value
+		 *
+		 * @returns	The standard temperature value.
+		 */
+		DLL_IMPORT_OR_EXPORT double getStandardTemperatureValue() const;
+
+		/**
+		 * Gets standard temperature uom
+		 *
+		 * @returns	The standard temperature uom.
+		 */
+		DLL_IMPORT_OR_EXPORT gsoap_eml2_2::eml22__ThermodynamicTemperatureUom getStandardTemperatureUom() const;
+
+		/**
+		 * Gets standard pressure value
+		 *
+		 * @returns	The standard pressure value.
+		 */
+		DLL_IMPORT_OR_EXPORT double getStandardPressureValue() const;
+
+		/**
+		 * Gets standard pressure uom
+		 *
+		 * @returns	The standard pressure uom.
+		 */
+		DLL_IMPORT_OR_EXPORT gsoap_eml2_2::eml22__PressureUom getStandardPressureUom() const;
+
+		/**
+		 * Gets solution gas-oil ratio value
+		 *
+		 * @returns	The solution gas-oil ratio value.
+		 */
+		DLL_IMPORT_OR_EXPORT double getSolutionGORValue() const;
+
+		/**
+		 * Gets solution gas-oil ratio uom
+		 *
+		 * @returns	The solution gas-oil ratio uom.
+		 */
+		DLL_IMPORT_OR_EXPORT gsoap_eml2_2::eml22__VolumePerVolumeUom getSolutionGORUom() const;
 
 		/**
 		 * The standard XML tag without XML namespace for serializing this data object.

--- a/swig/swigProdml2_1Include.i
+++ b/swig/swigProdml2_1Include.i
@@ -865,7 +865,7 @@ namespace PRODML2_1_NS
 		* @param 	uom					The uom associated to the values of this column
 		* @param	fluidProperty		The property that this column contains
 		*/
-		void pushBackTableFormatColumn(unsigned int tableFormatIndex, const std::string & uom, gsoap_eml2_2::prodml21__OutputFluidProperty fluidProperty);
+		void pushBackTableFormatColumn(unsigned int tableFormatIndex, gsoap_eml2_2::eml22__UnitOfMeasure uom, gsoap_eml2_2::prodml21__OutputFluidProperty fluidProperty);
 			
 		/**
 		* Pushes a table format colum
@@ -936,9 +936,9 @@ namespace PRODML2_1_NS
 		*
 		* @param	modelIndex		Zero-based index of the model in this fluid characterization.
 		* @param 	tableIndex		Zero-based index of the table in a model of this fluid characterization.
-		* @param 	rowContent		The string containing the content of the row in the table .
+		* @param 	rowContent		The values representing the content of the row in the table.
 		*/
-		void pushBackTableRow(unsigned int modelIndex, unsigned int tableIndex, const std::string & rowContent);
+		void pushBackTableRow(unsigned int modelIndex, unsigned int tableIndex, const std::vector<double> & rowContent);
 	};
 	
 	/** The time series data object is intended for use in transferring time series of data, e.g. from a historian. 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
* Allow to create a fluid System based on well known reference conditions
* Support for getting well known reference conditions in Fluid system and characterization
* Can now get and set FluidCharacterization type, intended usage and remark
* Full support for PRODML FluidSystem 
* Add link between FluidCharacterization and FluidSystem
* provide an example for FluidSystem serialization
* provide an example for tabular FluidCharacterization

Does this close any currently open issues?
-----------------------------------------
No

Where has this been tested?
---------------------------
**Operating System:** Win10 64

**Platform:** VS2017 64
