### PR TITLE
Fix reading of IJK grids geometry by using hyperslabbing

### DIFF
--- a/src/resqml2/AbstractIjkGridRepresentation.h
+++ b/src/resqml2/AbstractIjkGridRepresentation.h
@@ -241,7 +241,7 @@ namespace RESQML2_NS
 		* For each K Layer except the last one, indicate wether there is a layer or not after it.
 		*
 		* @param [out]	kGaps	An array for receiving the information about kGaps.
-		*						It must have a count of getKGapsCount(). It won't be free. A false value in
+		*						It must have a count of getKCellCount() - 1. It won't be free. A false value in
 		* 						@p kGaps means that the corresponding k layer has no gaps just after it.
 		*						A true value means that the corresponding k layer has a gap just after it.
 		*/
@@ -565,7 +565,7 @@ namespace RESQML2_NS
 		 * @exception	std::invalid_argument	If the split information is not loaded.
 		 * @exception	std::out_of_range	 	If @p iInterfaceEnd <tt>&gt;</tt> getICellCount(), @p
 		 * 										jInterfaceEnd <tt>&gt;</tt> getJCellCount() or @p
-		 * 										kInterfaceEnd <tt>&gt;</tt> getKCellCount().
+		 * 										kInterfaceEnd <tt>&gt;</tt> getKCellCount() + getKGapsCount().
 		 * @exception	std::range_error	 	If @p iInterfaceStart @c > @p iInterfaceEnd, @p
 		 * 										jInterfaceStart @c > @p jInterfaceEnd or @p
 		 * 										kInterfaceStart @c > @p kInterfaceEnd.
@@ -579,7 +579,7 @@ namespace RESQML2_NS
 		 * @param 	jInterfaceEnd  	The ending J interface index of the block taken from zero to
 		 * 							getJCellCount().
 		 * @param 	kInterfaceStart	The starting K interface index of the block taken from zero to
-		 * 							getKCellCount().
+		 * 							getKCellCount() + getKGapsCount().
 		 * @param 	kInterfaceEnd  	The ending K interface index of the block taken from zero to
 		 * 							getKCellCount().
 		 */
@@ -698,14 +698,14 @@ namespace RESQML2_NS
 		 * local CRS.
 		 *
 		 * @exception	std::out_of_range	 	If @p kInterfaceStart @c > getKCellCount() or @p
-		 * 										kInterfaceEnd @c > getKCellCount().
+		 * 										kInterfaceEnd @c > getKCellCount() + getKGapsCount().
 		 * @exception	std::range_error	 	If @p kInterfaceStart @c > @p kInterfaceEnd.
 		 * @exception	std::invalid_argument	If @p xyzPoints is @c nullptr.
 		 *
 		 * @param 	   	kInterfaceStart	The K index of the starting interface taken from zero to
 		 * 								getKCellCount().
 		 * @param 	   	kInterfaceEnd  	The K index of the ending interface taken from zero to
-		 * 								getKCellCount().
+		 * 								getKCellCount() + getKGapsCount().
 		 * @param [out]	xyzPoints	   	A linearized 2d array where the first (quickest) dimension is
 		 * 								coordinate dimension (XYZ) and second dimension is vertex
 		 * 								dimension. It must be preallocated with a size of

--- a/src/resqml2/IjkGridExplicitRepresentation.cpp
+++ b/src/resqml2/IjkGridExplicitRepresentation.cpp
@@ -30,7 +30,7 @@ using namespace RESQML2_NS;
 
 void IjkGridExplicitRepresentation::getXyzPointsOfKInterfaceSequence(unsigned int kInterfaceStart, unsigned int kInterfaceEnd, double * xyzPoints)
 {
-	if (kInterfaceStart > getKCellCount() || kInterfaceEnd > getKCellCount()) {
+	if (kInterfaceStart > getKCellCount() + getKGapsCount() || kInterfaceEnd > getKCellCount() + getKGapsCount()) {
 		throw out_of_range("kInterfaceStart and/or kInterfaceEnd is/are out of boundaries.");
 	}
 	if (kInterfaceStart > kInterfaceEnd) {

--- a/test/resqml2_test/FourSugarsParametricIjkGridWithGap.cpp
+++ b/test/resqml2_test/FourSugarsParametricIjkGridWithGap.cpp
@@ -77,26 +77,75 @@ void FourSugarsParametricIjkGridWithGap::readRepo() {
 	// read points by cell corner
 	ijkGrid->loadSplitInformation();
 
+	ijkGrid->loadBlockInformation(0, 1, 0, 1, 0, 3);	// using block hyperslabbing
+	unsigned int xyzPointCountOfBlock = ijkGrid->getXyzPointCountOfBlock();
+	std::unique_ptr<double[]> blockXyzPoints = std::unique_ptr<double[]>(new double[xyzPointCountOfBlock * 3]);
+	ijkGrid->getXyzPointsOfBlock(blockXyzPoints.get());
+
+	std::unique_ptr<double[]> interfaceXyzPoints(new double[ijkGrid->getXyzPointCountOfKInterface() * 3]); // using interface hyperslabbing
+	unsigned int kInterface = 0;
+	ijkGrid->getXyzPointsOfKInterfaceSequence(kInterface, kInterface, interfaceXyzPoints.get());
+	
 	auto ptIndex = ijkGrid->getXyzPointIndexFromCellCorner(0, 0, 0, 1);
 	REQUIRE(xyzPoints[ptIndex * 3] == 375);
 	REQUIRE(xyzPoints[ptIndex * 3 + 1] == .0);
 	REQUIRE(xyzPoints[ptIndex * 3 + 2] == 300);
+	REQUIRE(interfaceXyzPoints[ptIndex * 3] == 375);
+	REQUIRE(interfaceXyzPoints[ptIndex * 3 + 1] == .0);
+	REQUIRE(interfaceXyzPoints[ptIndex * 3 + 2] == 300);
+	double x, y, z;
+	ijkGrid->getXyzPointOfBlockFromCellCorner(0, 0, 0, 1, blockXyzPoints.get(), x, y, z);
+	REQUIRE(x == 375);
+	REQUIRE(y == .0);
+	REQUIRE(z == 300);
+
+	kInterface = 1;
+	ijkGrid->getXyzPointsOfKInterfaceSequence(kInterface, kInterface, interfaceXyzPoints.get());  // using interface hyperslabbing
+	uint64_t indexShift = kInterface * ijkGrid->getXyzPointCountOfKInterface() * 3;
 
 	ptIndex = ijkGrid->getXyzPointIndexFromCellCorner(0, 0, 0, 5);
 	REQUIRE(xyzPoints[ptIndex * 3] == 375);
 	REQUIRE(xyzPoints[ptIndex * 3 + 1] == .0);
 	REQUIRE(xyzPoints[ptIndex * 3 + 2] == 400);
+	REQUIRE(interfaceXyzPoints[ptIndex * 3 - indexShift] == 375);
+	REQUIRE(interfaceXyzPoints[ptIndex * 3 + 1 - indexShift] == .0);
+	REQUIRE(interfaceXyzPoints[ptIndex * 3 + 2 - indexShift] == 400);
+	ijkGrid->getXyzPointOfBlockFromCellCorner(0, 0, 0, 5, blockXyzPoints.get(), x, y, z);
+	REQUIRE(x == 375);
+	REQUIRE(y == .0);
+	REQUIRE(z == 400);
+
+	kInterface = 2;
+	ijkGrid->getXyzPointsOfKInterfaceSequence(kInterface, kInterface, interfaceXyzPoints.get());  // using interface hyperslabbing
+	indexShift = kInterface * ijkGrid->getXyzPointCountOfKInterface() * 3;
 
 	ptIndex = ijkGrid->getXyzPointIndexFromCellCorner(0, 0, 1, 1);
 	REQUIRE(xyzPoints[ptIndex * 3] == 375);
 	REQUIRE(xyzPoints[ptIndex * 3 + 1] == .0);
 	REQUIRE(xyzPoints[ptIndex * 3 + 2] == 425);
+	REQUIRE(interfaceXyzPoints[ptIndex * 3 - indexShift] == 375);
+	REQUIRE(interfaceXyzPoints[ptIndex * 3 + 1 - indexShift] == .0);
+	REQUIRE(interfaceXyzPoints[ptIndex * 3 + 2 - indexShift] == 425);
+	ijkGrid->getXyzPointOfBlockFromCellCorner(0, 0, 1, 1, blockXyzPoints.get(), x, y, z);
+	REQUIRE(x == 375);
+	REQUIRE(y == .0);
+	REQUIRE(z == 425);
 
+	kInterface = 3;
+	ijkGrid->getXyzPointsOfKInterfaceSequence(kInterface, kInterface, interfaceXyzPoints.get());  // using interface hyperslabbing
+	indexShift = kInterface * ijkGrid->getXyzPointCountOfKInterface() * 3;
+	
 	ptIndex = ijkGrid->getXyzPointIndexFromCellCorner(0, 0, 1, 5);
 	REQUIRE(xyzPoints[ptIndex * 3] == 375);
 	REQUIRE(xyzPoints[ptIndex * 3 + 1] == .0);
 	REQUIRE(xyzPoints[ptIndex * 3 + 2] == 500);
-
+	REQUIRE(interfaceXyzPoints[ptIndex * 3 - indexShift] == 375);
+	REQUIRE(interfaceXyzPoints[ptIndex * 3 + 1 - indexShift] == .0);
+	REQUIRE(interfaceXyzPoints[ptIndex * 3 + 2 - indexShift] == 500);
+	ijkGrid->getXyzPointOfBlockFromCellCorner(0, 0, 1, 5, blockXyzPoints.get(), x, y, z);
+	REQUIRE(x == 375);
+	REQUIRE(y == .0);
+	REQUIRE(z == 500);
+	
 	ijkGrid->unloadSplitInformation();
-
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- Fix issue that occurs when reading interfaces geometry in IJK grids with K gaps by using hyperslabbing.
- Fix geometry reading issue in IJK grids by using hyperslabbing by blocks.
- Update corresponding documentation
- Update corresponding examples
- Add corresponding unit tests.

Does this close any currently open issues?
------------------------------------------
No.

Any relevant logs, error output, etc?
-------------------------------------
No.

Any other comments?
-------------------
No.

Where has this been tested?
---------------------------
**Operating System:** Windows 10 64bits

**Platform:** Visual Studio Community 2019
