### PR TITLE
Prevent premature garbage collection of protocol handlers in C# and Java

### DIFF
--- a/cmake/swigJavaInclude.i
+++ b/cmake/swigJavaInclude.i
@@ -375,7 +375,7 @@ ${COMMENT_END}
 		return null;
 	}
 	
-	public static com.f2i.energisticsStandardsApi.${FESAPI_COMMON_NS}.AbstractOrganizationInterpretation resqml2_instantiateStratigraphicOccurrenceInterpretation(long cPtr, boolean owner)
+	public static com.f2i.energisticsStandardsApi.${FESAPI_RESQML2_NS}.AbstractOrganizationInterpretation resqml2_instantiateStratigraphicOccurrenceInterpretation(long cPtr, boolean owner)
 	{
 		String xmlNs = ${FESAPI_COMMON_NS}_AbstractObject_getXmlNamespace(cPtr, new com.f2i.energisticsStandardsApi.${FESAPI_COMMON_NS}.AbstractObject(cPtr, false));
 		if ("resqml20".equals(xmlNs)) {
@@ -922,7 +922,7 @@ ${COMMENT_END}
 		return null;
 	}
 	
-	public static com.f2i.energisticsStandardsApi.${FESAPI_RESQML2_NS}.StreamlinesFeature resqml2_instantiateStreamlinesFeature(long cPtr, bool owner)
+	public static com.f2i.energisticsStandardsApi.${FESAPI_RESQML2_NS}.StreamlinesFeature resqml2_instantiateStreamlinesFeature(long cPtr, boolean owner)
 	{
 		String xmlNs = ${FESAPI_COMMON_NS}_AbstractObject_getXmlNamespace(cPtr, new com.f2i.energisticsStandardsApi.${FESAPI_COMMON_NS}.AbstractObject(cPtr, false));
 		if ("resqml20".equals(xmlNs)) {
@@ -937,7 +937,7 @@ ${COMMENT_END}
 		return null;
 	}
 	
-	public static com.f2i.energisticsStandardsApi.${FESAPI_RESQML2_NS}.StreamlinesRepresentation resqml2_instantiateStreamlinesRepresentation(long cPtr, bool owner)
+	public static com.f2i.energisticsStandardsApi.${FESAPI_RESQML2_NS}.StreamlinesRepresentation resqml2_instantiateStreamlinesRepresentation(long cPtr, boolean owner)
 	{
 		String xmlNs = ${FESAPI_COMMON_NS}_AbstractObject_getXmlNamespace(cPtr, new com.f2i.energisticsStandardsApi.${FESAPI_COMMON_NS}.AbstractObject(cPtr, false));
 		if ("resqml20".equals(xmlNs)) {
@@ -994,7 +994,7 @@ ${COMMENT_END}
 		case FLUIDSYSTEM : return new com.f2i.energisticsStandardsApi.${FESAPI_PRODML2_1_NS}.FluidSystem(cPtr, owner);
 		case FRONTIERFEATURE : return new com.f2i.energisticsStandardsApi.${FESAPI_RESQML2_0_1_NS}.resqml20_FrontierFeature(cPtr, owner);
 		case GENETICBOUNDARYFEATURE :
-			com.f2i.energisticsStandardsApi.${FESAPI_RESQML2_0_1_NS}.resqml20_GeneticBoundaryFeature_resqml20 result = new com.f2i.energisticsStandardsApi.${FESAPI_RESQML2_0_1_NS}.GeneticBoundaryFeature(cPtr, owner);
+			com.f2i.energisticsStandardsApi.${FESAPI_RESQML2_0_1_NS}.resqml20_GeneticBoundaryFeature result = new com.f2i.energisticsStandardsApi.${FESAPI_RESQML2_0_1_NS}.resqml20_GeneticBoundaryFeature(cPtr, owner);
 			return result.isAnHorizon() ? new com.f2i.energisticsStandardsApi.${FESAPI_RESQML2_0_1_NS}.resqml20_Horizon(cPtr, owner) : result;
 		case GEOBODYFEATURE : return new com.f2i.energisticsStandardsApi.${FESAPI_RESQML2_0_1_NS}.resqml20_GeobodyFeature(cPtr, owner);
 		case GEOBODYBOUNDARYINTERPRETATION : return resqml2_instantiateGeobodyBoundaryInterpretation(cPtr, owner);

--- a/swig/swigEml2_3Include.i
+++ b/swig/swigEml2_3Include.i
@@ -41,7 +41,7 @@ namespace EML2_3_NS
 	%nodefaultctor; // Disable creation of default constructors
 
 #if defined(SWIGJAVA) || defined(SWIGPYTHON)
-	%rename(Activity_eml23) Activity;
+	%rename(eml23_Activity) Activity;
 #endif
 	class Activity : public EML2_NS::Activity
 	{
@@ -49,7 +49,7 @@ namespace EML2_3_NS
 	};	
 	
 #if defined(SWIGJAVA) || defined(SWIGPYTHON)
-	%rename(ActivityTemplate_eml23) ActivityTemplate;
+	%rename(eml23_ActivityTemplate) ActivityTemplate;
 #endif
 	class ActivityTemplate : public EML2_NS::ActivityTemplate
 	{
@@ -57,7 +57,7 @@ namespace EML2_3_NS
 	};
 
 #if defined(SWIGJAVA) || defined(SWIGPYTHON)
-	%rename(GraphicalInformationSet_eml23) GraphicalInformationSet;
+	%rename(eml23_GraphicalInformationSet) GraphicalInformationSet;
 #endif
 	class GraphicalInformationSet : public EML2_NS::GraphicalInformationSet
 	{
@@ -65,7 +65,7 @@ namespace EML2_3_NS
 	};
 
 #if defined(SWIGJAVA) || defined(SWIGPYTHON)
-	%rename(PropertyKind_eml23) PropertyKind;
+	%rename(eml23_PropertyKind) PropertyKind;
 #endif
 	class PropertyKind : public EML2_NS::PropertyKind
 	{
@@ -73,7 +73,7 @@ namespace EML2_3_NS
 	};
 
 #if defined(SWIGJAVA) || defined(SWIGPYTHON)
-	%rename(TimeSeries_eml23) TimeSeries;
+	%rename(eml23_TimeSeries) TimeSeries;
 #endif
 	class TimeSeries : public EML2_NS::TimeSeries
 	{

--- a/swig/swigEtp1_2Include.i
+++ b/swig/swigEtp1_2Include.i
@@ -28,6 +28,7 @@ under the License.
 	%nspace ETP_NS::CoreHandlers;
 	%nspace ETP_NS::DiscoveryHandlers;
 	%nspace ETP_NS::StoreHandlers;
+	%nspace ETP_NS::StoreNotificationHandlers;
 	%nspace ETP_NS::DataArrayHandlers;
 	%nspace ETP_NS::AbstractSession;
 	%nspace ETP_NS::PlainClientSession;
@@ -988,6 +989,7 @@ namespace Energistics {
 %shared_ptr(ETP_NS::CoreHandlers)
 %shared_ptr(ETP_NS::DiscoveryHandlers)
 %shared_ptr(ETP_NS::StoreHandlers)
+%shared_ptr(ETP_NS::StoreNotificationHandlers)
 %shared_ptr(ETP_NS::DataArrayHandlers)
 %shared_ptr(ETP_NS::AbstractSession)
 %shared_ptr(ETP_NS::PlainClientSession)
@@ -997,6 +999,7 @@ namespace Energistics {
 %feature("director") ETP_NS::CoreHandlers;
 %feature("director") ETP_NS::DiscoveryHandlers;
 %feature("director") ETP_NS::StoreHandlers;
+%feature("director") ETP_NS::StoreNotificationHandlers;
 %feature("director") ETP_NS::DataArrayHandlers;
 %feature("director") ETP_NS::ServerInitializationParameters;
 
@@ -1098,6 +1101,66 @@ namespace Energistics {
 	  PyObject_SetAttr($self, data_array_handler_reference(), args);
 	%}
 	}
+#endif 
+	
+#ifdef SWIGCSHARP
+%typemap(cscode) ETP_NS::AbstractSession %{
+  private CoreHandlers coreHandlersReference;
+  private DiscoveryHandlers discoveryHandlersReference;
+  private StoreHandlers storeHandlersReference;
+  private StoreNotificationHandlers storeNotificationHandlersReference;
+  private DataArrayHandlers dataArrayHandlersReference;
+%}
+
+%typemap(csin,
+         post="      coreHandlersReference = $csinput;"
+         ) std::shared_ptr<ETP_NS::CoreHandlers> coreHandlers "CoreHandlers.getCPtr($csinput)"
+		 
+%typemap(csin,
+         post="      discoveryHandlersReference = $csinput;"
+         ) std::shared_ptr<ETP_NS::DiscoveryHandlers> discoveryHandlers "DiscoveryHandlers.getCPtr($csinput)"
+
+%typemap(csin,
+         post="      storeHandlersReference = $csinput;"
+         ) std::shared_ptr<ETP_NS::StoreHandlers> storeHandlers "StoreHandlers.getCPtr($csinput)"
+		 
+%typemap(csin,
+         post="      storeNotificationHandlersReference = $csinput;"
+         ) std::shared_ptr<ETP_NS::StoreNotificationHandlers> storeNotificationHandlers "StoreNotificationHandlers.getCPtr($csinput)"
+		 
+%typemap(csin,
+         post="      dataArrayHandlersReference = $csinput;"
+         ) std::shared_ptr<ETP_NS::DataArrayHandlers> dataArrayHandlers "DataArrayHandlers.getCPtr($csinput)"
+#endif	  
+	  
+#ifdef SWIGJAVA
+%typemap(javacode) ETP_NS::AbstractSession %{
+  private CoreHandlers coreHandlersReference;
+  private DiscoveryHandlers discoveryHandlersReference;
+  private StoreHandlers storeHandlersReference;
+  private StoreNotificationHandlers storeNotificationHandlersReference;
+  private DataArrayHandlers dataArrayHandlersReference;
+%}
+
+%typemap(javain, 
+         post="      coreHandlersReference = $javainput;"
+         ) std::shared_ptr<ETP_NS::CoreHandlers> coreHandlers "CoreHandlers.getCPtr($javainput)"
+		 
+%typemap(javain, 
+         post="      discoveryHandlersReference = $javainput;"
+         ) std::shared_ptr<ETP_NS::DiscoveryHandlers> discoveryHandlers "DiscoveryHandlers.getCPtr($javainput)"
+		 
+%typemap(javain, 
+         post="      storeHandlersReference = $javainput;"
+         ) std::shared_ptr<ETP_NS::StoreHandlers> storeHandlers "StoreHandlers.getCPtr($javainput)"
+		 
+%typemap(javain, 
+         post="      storeNotificationHandlersReference = $javainput;"
+         ) std::shared_ptr<ETP_NS::StoreNotificationHandlers> storeNotificationHandlers "StoreNotificationHandlers.getCPtr($javainput)"
+		 
+%typemap(javain, 
+         post="      dataArrayHandlersReference = $javainput;"
+         ) std::shared_ptr<ETP_NS::DataArrayHandlers> dataArrayHandlers "DataArrayHandlers.getCPtr($javainput)"
 #endif
 
 namespace ETP_NS
@@ -1146,6 +1209,21 @@ namespace ETP_NS
 		virtual void on_PutDataObjectsResponse(const Energistics::Etp::v12::Protocol::Store::PutDataObjectsResponse & msg, int64_t correlationId);
 	    virtual void on_DeleteDataObjects(const Energistics::Etp::v12::Protocol::Store::DeleteDataObjects & msg, int64_t correlationId);
 		virtual void on_DeleteDataObjectsResponse(const Energistics::Etp::v12::Protocol::Store::DeleteDataObjectsResponse & msg, int64_t correlationId);
+	};
+	
+	class StoreNotificationHandlers : public ProtocolHandlers
+	{
+	public:
+		StoreNotificationHandlers(AbstractSession* mySession): ProtocolHandlers(mySession) {}
+		virtual ~StoreNotificationHandlers() {}
+
+	    virtual void on_SubscribeNotifications(const Energistics::Etp::v12::Protocol::StoreNotification::SubscribeNotifications & msg, int64_t messageId);
+	    virtual void on_UnsubscribeNotifications(const Energistics::Etp::v12::Protocol::StoreNotification::UnsubscribeNotifications & msg, int64_t messageId, int64_t correlationId);
+		virtual void on_UnsolicitedStoreNotifications(const Energistics::Etp::v12::Protocol::StoreNotification::UnsolicitedStoreNotifications & msg, int64_t correlationId);
+		virtual void on_SubscriptionEnded(const Energistics::Etp::v12::Protocol::StoreNotification::SubscriptionEnded & msg, int64_t correlationId);
+	    virtual void on_ObjectChanged(const Energistics::Etp::v12::Protocol::StoreNotification::ObjectChanged & msg, int64_t correlationId);
+	    virtual void on_ObjectDeleted(const Energistics::Etp::v12::Protocol::StoreNotification::ObjectDeleted & msg, int64_t correlationId);
+		virtual void on_ObjectAccessRevoked(const Energistics::Etp::v12::Protocol::StoreNotification::ObjectAccessRevoked & msg, int64_t correlationId);
 	};
 	
 	class DataArrayHandlers : public ProtocolHandlers

--- a/swig/swigResqml2_2Include.i
+++ b/swig/swigResqml2_2Include.i
@@ -609,7 +609,7 @@ namespace RESQML2_2_NS
 	public:
 	};
 	
-#ifdef SWIGPYTHON
+#if defined(SWIGJAVA) || defined(SWIGPYTHON)
 	%rename(resqml22_StreamlinesFeature) StreamlinesFeature;
 #endif	
 	class StreamlinesFeature : public RESQML2_NS::StreamlinesFeature
@@ -617,7 +617,7 @@ namespace RESQML2_2_NS
 	public:
 	};
 	
-#ifdef SWIGPYTHON
+#if defined(SWIGJAVA) || defined(SWIGPYTHON)
 	%rename(resqml22_StreamlinesRepresentation) StreamlinesRepresentation;
 #endif	
 	class StreamlinesRepresentation : public RESQML2_NS::StreamlinesRepresentation


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Prevent premature garbage collection of protocol handlers in C# and Java.
Also fix some renamings regarding Java and Python wrappers.

Does this close any currently open issues?
------------------------------------------
No.

Any relevant logs, error output, etc?
-------------------------------------
No.

Any other comments?
-------------------
No.

Where has this been tested?
---------------------------
**Operating System:** Windows 10 64bits

**Platform:** Visual Studio Community 2019
