### PR TITLE
Bug fix: ChannelMetaDataObject may lead to unresolved ref at link

### DIFF
--- a/src/common/AbstractObject.h
+++ b/src/common/AbstractObject.h
@@ -840,7 +840,7 @@ namespace COMMON_NS
 		 *
 		 * @returns	A pointer to the new EML2.1 data object reference.
 		 */
-		gsoap_eml2_1::eml21__DataObjectReference* newEmlReference() const;
+		DLL_IMPORT_OR_EXPORT gsoap_eml2_1::eml21__DataObjectReference* newEmlReference() const;
 
 		/**
 		 * Creates an returns an EML2.2 data object reference which targets this data object

--- a/src/witsml2_0/ChannelMetaDataObject.h
+++ b/src/witsml2_0/ChannelMetaDataObject.h
@@ -104,7 +104,7 @@ namespace WITSML2_0_NS
 		 *
 		 * @returns	Null if it fails, else the property kind.
 		 */
-		DLL_IMPORT_OR_EXPORT EML2_NS::PropertyKind* getPropertyKind() const
+		EML2_NS::PropertyKind* getPropertyKind() const
 		{
 			return getRepository()->template getDataObjectByUuid<EML2_NS::PropertyKind>(getPropertyKindDor().getUuid());
 		}
@@ -116,7 +116,7 @@ namespace WITSML2_0_NS
 		 *
 		 * @param [in,out]	propKind	If non-null, the property kind.
 		 */
-		DLL_IMPORT_OR_EXPORT void setPropertyKind(EML2_NS::PropertyKind* propKind)
+		void setPropertyKind(EML2_NS::PropertyKind* propKind)
 		{
 			if (propKind == nullptr) {
 				throw std::invalid_argument("Cannot set a null witsml propKind to a witsml log/channelset/channel");

--- a/swig/swigWitsml2_0Include.i
+++ b/swig/swigWitsml2_0Include.i
@@ -2168,15 +2168,9 @@ namespace WITSML2_0_NS
 		void setPropertyKind(EML2_NS::PropertyKind* propKind);
 	};
 
-/*
-Following %template definitions lead to some linkage errors when building the
-Python extension.
-*/
-#ifndef SWIGPYTHON
 	%template(ChannelMetaDataLog) ChannelMetaDataObject<gsoap_eml2_1::witsml20__Log>;
 	%template(ChannelMetaDataChannelSet) ChannelMetaDataObject<gsoap_eml2_1::witsml20__ChannelSet>;
 	%template(ChannelMetaDataChannel) ChannelMetaDataObject<gsoap_eml2_1::witsml20__Channel>;
-#endif
 	
 	template <class T>
 	class ChannelIndexDataObject : public ChannelMetaDataObject<T>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Bug fix: ChannelMetaDataObject may lead to unresolved reference at link.

Does this close any currently open issues?
------------------------------------------
No.

Any relevant logs, error output, etc?
-------------------------------------
No.

Any other comments?
-------------------
No.

Where has this been tested?
---------------------------
**Operating System:** Windows 10 64bits

**Platform:** Visual Studio Community 2019
