### PR TITLE
Support Boost > 1.69 with ETP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,9 +135,6 @@ if (WITH_ETP)
 
 	# Boost DEPENDENCY
 	find_package(Boost 1.66.0 REQUIRED system)
-	if (Boost_MINOR_VERSION GREATER 69)
-		message(ERROR ": The Boost library cannot be superior to 1.69.0.")
-	endif ()
 	
 	add_subdirectory (etpClientExample)
 	add_subdirectory (etpServerExample)

--- a/src/etp/AbstractSession.h
+++ b/src/etp/AbstractSession.h
@@ -31,6 +31,8 @@ under the License.
 #include "ProtocolHandlers/StoreNotificationHandlers.h"
 #include "ProtocolHandlers/DataArrayHandlers.h"
 
+#include <unordered_map>
+
 #if defined(_WIN32) && !defined(FESAPI_STATIC)
 	#ifndef DLL_IMPORT_OR_EXPORT
 		#if defined(FesapiCpp_EXPORTS) || defined(FesapiCppUnderDev_EXPORTS)

--- a/src/etp/DataArrayBlockingSession.cpp
+++ b/src/etp/DataArrayBlockingSession.cpp
@@ -76,12 +76,23 @@ bool DataArrayBlockingSession::run()
 		results.end());
 
 	websocket::response_type responseType;
+#if BOOST_VERSION < 107000
 	ws.handshake_ex(responseType,
 		host + ":" + port, target,
 		[](websocket::request_type& m)
 		{
 			m.insert(boost::beast::http::field::sec_websocket_protocol, "etp12.energistics.org");
 		});
+#else
+	ws.set_option(websocket::stream_base::decorator(
+		[](websocket::request_type& m)
+		{
+			m.insert(boost::beast::http::field::sec_websocket_protocol, "etp12.energistics.org");
+		})
+	);
+
+	ws.handshake(responseType, host + ":" + port, target);
+#endif
 
 	if (!responseType.count(boost::beast::http::field::sec_websocket_protocol) ||
 		responseType[boost::beast::http::field::sec_websocket_protocol] != "etp12.energistics.org") {

--- a/src/etp/DataArrayBlockingSession.h
+++ b/src/etp/DataArrayBlockingSession.h
@@ -48,7 +48,7 @@ namespace ETP_NS
 		virtual ~DataArrayBlockingSession() = default;
 
 		boost::asio::io_context& getIoContext() {
-			return ws.get_executor().context();
+			return static_cast<boost::asio::io_context&> (ws.get_executor().context());
 		}
 
 		bool run();

--- a/src/etp/PlainServerSession.cpp
+++ b/src/etp/PlainServerSession.cpp
@@ -22,7 +22,7 @@ under the License.
 using namespace ETP_NS;
 
 PlainServerSession::PlainServerSession(tcp::socket socket)
-	: AbstractPlainOrSslServerSession<PlainServerSession>(socket.get_executor().context()),
+	: AbstractPlainOrSslServerSession<PlainServerSession>(static_cast<boost::asio::io_context&>(socket.get_executor().context())),
 	ws_(std::move(socket))
 {
 	ws_.binary(true);

--- a/src/etp/Server.h
+++ b/src/etp/Server.h
@@ -570,9 +570,15 @@ namespace ETP_NS
 					std::vector< std::shared_ptr<T> >& sessions,
 					ServerInitializationParameters* serverInitializationParams)
 				: socket_(std::move(socket))
+#if BOOST_VERSION < 107000
 				, strand_(socket_.get_executor())
 				, timer_(socket_.get_executor().context(),
-				(std::chrono::steady_clock::time_point::max)())
+			        (std::chrono::steady_clock::time_point::max)())
+#else
+				, strand_(static_cast<boost::asio::io_context&>(socket_.get_executor().context()).get_executor())
+				, timer_(socket_.get_executor(),
+					(std::chrono::steady_clock::time_point::max)())
+#endif
 				, doc_root_(doc_root)
 				, queue_(*this)
 				, sessions_(sessions)


### PR DESCRIPTION
Issue #278

(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------
Allow Fesapi ETP code to build with boost version greater than 1.69 

Does this close any currently open issues?
------------------------------------------
Yes, Issue #278

Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Operating System:** Windows

**Platform:** VisualStudio 19 with Boost 1.74
