### PR TITLE
Filter server session on sec-websocket-protocol

### DIFF
--- a/etpClientExample/main.cpp
+++ b/etpClientExample/main.cpp
@@ -43,7 +43,11 @@ int main(int argc, char **argv)
 {
 	if (argc < 3) {
 		std::cerr << "The command must be : etpClientExample ipAddress port [target]" << std::endl;
+		return 1;
+	}
 
+	if (argc == 4 && (argv[3][0] != '/' || argv[3][strlen(argv[3]) - 1] != '/')) {
+		std::cerr << "Please put a slash at the start and at the end of the target " << argv[3] << std::endl;
 		return 1;
 	}
 
@@ -109,10 +113,7 @@ int main(int argc, char **argv)
 		}
 
 		auto httpsClientSession = std::make_shared<HttpsClientSession>(ioc, ctx);
-		std::string etpServerCapTarget = "/";
-		if (argc >= 4) {
-			etpServerCapTarget += std::string(argv[3]) + "/";
-		}
+		std::string etpServerCapTarget = argc >= 4 ? argv[3] : "/";
 		etpServerCapTarget += ".well-known/etp-server-capabilities?GetVersion=etp12.energistics.org";
 		std::cout << "Requesting " << etpServerCapTarget << " to " << argv[1] << " on port " << argv[2] << std::endl;
 		httpsClientSession->run(argv[1], argv[2], etpServerCapTarget.c_str(), 11, authorization);
@@ -123,10 +124,7 @@ int main(int argc, char **argv)
 	else {
 #endif
 		auto httpClientSession = std::make_shared<HttpClientSession>(ioc);
-		std::string etpServerCapTarget = "/";
-		if (argc >= 4) {
-			etpServerCapTarget += std::string(argv[3]) + "/";
-		}
+		std::string etpServerCapTarget = argc >= 4 ? argv[3] : "/";
 		etpServerCapTarget += ".well-known/etp-server-capabilities?GetVersion=etp12.energistics.org";
 		std::cout << "Requesting " << etpServerCapTarget << " to " << argv[1] << " on port " << argv[2] << std::endl;
 		httpClientSession->run(argv[1], argv[2], etpServerCapTarget.c_str(), 11, authorization);

--- a/etpServerExample/CMakeLists.txt
+++ b/etpServerExample/CMakeLists.txt
@@ -9,7 +9,7 @@ target_compile_options(etpServerExample	PRIVATE
 	$<$<CXX_COMPILER_ID:MSVC>:/bigobj>
 )
 
-find_package(Boost 1.66.0 REQUIRED filesystem)
+find_package(Boost 1.66.0 REQUIRED log filesystem)
 
 # ============================================================================
 # include directories
@@ -59,16 +59,20 @@ endif ()
 target_sources(etpServerExample PRIVATE ${ALL_CPP_FILES} ${ALL_H_FILES})
 
 target_compile_definitions(etpServerExample PRIVATE BOOST_ALL_NO_LIB)
-	
+
 add_dependencies (etpServerExample ${CPP_LIBRARY_NAME})
-target_link_libraries (etpServerExample PRIVATE ${CPP_LIBRARY_NAME} ${Boost_FILESYSTEM_LIBRARY} ${CMAKE_THREAD_LIBS_INIT} ${AVRO_LIBRARY_RELEASE})
 if (WIN32)
 	target_link_libraries (etpServerExample PRIVATE bcrypt.lib)
 	
 	set_target_properties (etpServerExample PROPERTIES
 		LINK_FLAGS "/INCREMENTAL:NO"
-		RUNTIME_OUTPUT_DIRECTORY ${FESAPI_BINARY_DIR})
+		RUNTIME_OUTPUT_DIRECTORY ${FESAPI_BINARY_DIR})	
+	
+	# https://www.boost.org/doc/libs/1_75_0/libs/log/doc/html/log/rationale/namespace_mangling.html
+	target_compile_definitions(etpServerExample PRIVATE BOOST_LOG_DYN_LINK)
 endif (WIN32)
+target_link_libraries (etpServerExample PRIVATE ${CPP_LIBRARY_NAME} ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${AVRO_LIBRARY_RELEASE})
+
 
 install (
 	TARGETS etpServerExample

--- a/etpServerExample/MyOwnCoreProtocolHandlers.h
+++ b/etpServerExample/MyOwnCoreProtocolHandlers.h
@@ -22,11 +22,16 @@ under the License.
 
 #include "etp/AbstractSession.h"
 
+class MyServerInitializationParameters;
+
 class MyOwnCoreProtocolHandlers : public ETP_NS::CoreHandlers
 {
+private:
+	MyServerInitializationParameters const * serverInitializationParams_;
 public:
-	MyOwnCoreProtocolHandlers(ETP_NS::AbstractSession* mySession): ETP_NS::CoreHandlers(mySession) {}
-	~MyOwnCoreProtocolHandlers() {}
+	MyOwnCoreProtocolHandlers(ETP_NS::AbstractSession* mySession, MyServerInitializationParameters const * serverInitializationParams):
+		ETP_NS::CoreHandlers(mySession), serverInitializationParams_(serverInitializationParams) {}
+	~MyOwnCoreProtocolHandlers() = default;
 
 	void on_RequestSession(const Energistics::Etp::v12::Protocol::Core::RequestSession & rs, int64_t correlationId);
 };

--- a/etpServerExample/MyOwnDataArrayProtocolHandlers.cpp
+++ b/etpServerExample/MyOwnDataArrayProtocolHandlers.cpp
@@ -18,6 +18,8 @@ under the License.
 -----------------------------------------------------------------------*/
 #include "MyOwnDataArrayProtocolHandlers.h"
 
+#include <boost/log/trivial.hpp>
+
 #include "etp/AbstractSession.h"
 #include "etp/EtpException.h"
 #include "etp/EtpHelpers.h"
@@ -33,7 +35,7 @@ void MyOwnDataArrayProtocolHandlers::on_GetDataArrays(const Energistics::Etp::v1
 	Energistics::Etp::v12::Protocol::Core::ProtocolException pe;
 	for (std::pair < std::string, Energistics::Etp::v12::Datatypes::DataArrayTypes::DataArrayIdentifier > element : gda.dataArrays) {
 		Energistics::Etp::v12::Datatypes::DataArrayTypes::DataArrayIdentifier& dai = element.second;
-		std::cout << "Data array received uri : " << dai.uri << std::endl;
+		BOOST_LOG_TRIVIAL(trace) << "Data array received uri : " << dai.uri;
 
 		try
 		{
@@ -45,7 +47,7 @@ void MyOwnDataArrayProtocolHandlers::on_GetDataArrays(const Energistics::Etp::v1
 				continue;
 			}
 
-			std::cout << "Received pathInResource : " << dai.pathInResource << std::endl;
+			BOOST_LOG_TRIVIAL(trace) << "Received pathInResource : " << dai.pathInResource;
 			auto elemCountPerDim = hdfProxy->getElementCountPerDimension(dai.pathInResource);
 			Energistics::Etp::v12::Datatypes::DataArrayTypes::DataArray da;
 			da.dimensions.reserve(elemCountPerDim.size());
@@ -115,9 +117,9 @@ void MyOwnDataArrayProtocolHandlers::on_PutDataArrays(const Energistics::Etp::v1
 {
 	Energistics::Etp::v12::Protocol::Core::ProtocolException pe;
 	for (std::pair < std::string, Energistics::Etp::v12::Datatypes::DataArrayTypes::PutDataArraysType > pdat : pda.dataArrays) {
-		std::cout << "PutDataArray in resource " << pdat.second.uid.uri << " at path " << pdat.second.uid.pathInResource << std::endl;;
+		BOOST_LOG_TRIVIAL(trace) << "PutDataArray in resource " << pdat.second.uid.uri << " at path " << pdat.second.uid.pathInResource;
 		for (size_t i = 0; i < pdat.second.array.dimensions.size(); ++i) {
-			std::cout << "Dimension " << i << " with count : " << pdat.second.array.dimensions[i] << std::endl;
+			BOOST_LOG_TRIVIAL(trace) << "Dimension " << i << " with count : " << pdat.second.array.dimensions[i];
 		}
 
 		try {
@@ -126,7 +128,7 @@ void MyOwnDataArrayProtocolHandlers::on_PutDataArrays(const Energistics::Etp::v1
 
 			EML2_NS::AbstractHdfProxy* hdfProxy = repo->getDataObjectByUuidAndVersion<EML2_NS::AbstractHdfProxy>(uuidAndVersion.first, uuidAndVersion.second);
 			if (hdfProxy == nullptr) {
-				std::cout << "Creating file " << uuidAndVersion.first << ".h5 in " << repo->hdf5Folder << std::endl;
+				BOOST_LOG_TRIVIAL(trace) << "Creating file " << uuidAndVersion.first << ".h5 in " << repo->hdf5Folder;
 				hdfProxy = repo->createHdfProxy(uuidAndVersion.first, uuidAndVersion.first, repo->hdf5Folder, uuidAndVersion.first + ".h5", COMMON_NS::DataObjectRepository::openingMode::READ_WRITE);
 			}
 
@@ -207,7 +209,7 @@ void MyOwnDataArrayProtocolHandlers::on_GetDataArrayMetadata(const Energistics::
 	Energistics::Etp::v12::Protocol::Core::ProtocolException pe;
 	for (std::pair < std::string, Energistics::Etp::v12::Datatypes::DataArrayTypes::DataArrayIdentifier > element : gdam.dataArrays) {
 		Energistics::Etp::v12::Datatypes::DataArrayTypes::DataArrayIdentifier& dai = element.second;
-		std::cout << "GetDataArrayMetadata received uri : " << dai.uri << std::endl;
+		BOOST_LOG_TRIVIAL(trace) << "GetDataArrayMetadata received uri : " << dai.uri;
 
 		try {
 			COMMON_NS::AbstractObject* obj = repo->getObjectFromUri(dai.uri);
@@ -218,7 +220,7 @@ void MyOwnDataArrayProtocolHandlers::on_GetDataArrayMetadata(const Energistics::
 				continue;
 			}
 
-			std::cout << "Received pathInResource : " << dai.pathInResource << std::endl;
+			BOOST_LOG_TRIVIAL(trace) << "Received pathInResource : " << dai.pathInResource;
 			Energistics::Etp::v12::Datatypes::DataArrayTypes::DataArrayMetadata dam;
 			auto elemCountPerDim = hdfProxy->getElementCountPerDimension(dai.pathInResource);
 			dam.dimensions.reserve(elemCountPerDim.size());

--- a/etpServerExample/MyOwnDiscoveryProtocolHandlers.cpp
+++ b/etpServerExample/MyOwnDiscoveryProtocolHandlers.cpp
@@ -18,6 +18,8 @@ under the License.
 -----------------------------------------------------------------------*/
 #include "MyOwnDiscoveryProtocolHandlers.h"
 
+#include <boost/log/trivial.hpp>
+
 #include "common/AbstractObject.h"
 #include "etp/EtpHelpers.h"
 
@@ -97,7 +99,7 @@ void MyOwnDiscoveryProtocolHandlers::getDataObjectResource(const Energistics::Et
 
 void MyOwnDiscoveryProtocolHandlers::on_GetResources(const Energistics::Etp::v12::Protocol::Discovery::GetResources & msg, int64_t correlationId)
 {
-	std::cout << "Discovery graph resource received uri : " << msg.context.uri << std::endl;
+	BOOST_LOG_TRIVIAL(trace) << "Discovery graph resource received uri : " << msg.context.uri;
 
 	if (msg.context.depth < 0) {
 		session->send(ETP_NS::EtpHelpers::buildSingleMessageProtocolException(5, "The requested depth cannot be inferior to zero."), correlationId, 0x02);

--- a/etpServerExample/MyOwnStoreProtocolHandlers.cpp
+++ b/etpServerExample/MyOwnStoreProtocolHandlers.cpp
@@ -18,6 +18,8 @@ under the License.
 -----------------------------------------------------------------------*/
 #include "MyOwnStoreProtocolHandlers.h"
 
+#include <boost/log/trivial.hpp>
+
 #include "etp/AbstractSession.h"
 #include "etp/EtpHelpers.h"
 #include "etp/EtpException.h"
@@ -36,7 +38,7 @@ void MyOwnStoreProtocolHandlers::on_GetDataObjects(const Energistics::Etp::v12::
 
 	Energistics::Etp::v12::Protocol::Core::ProtocolException pe;
 	for (const auto & pair : msg.uris) {
-		std::cout << "Store received URI : " << pair.second << std::endl;
+		BOOST_LOG_TRIVIAL(trace) << "Store received URI : " << pair.second;
 
 		try
 		{
@@ -71,7 +73,7 @@ void MyOwnStoreProtocolHandlers::on_PutDataObjects(const Energistics::Etp::v12::
 
 	Energistics::Etp::v12::Protocol::Core::ProtocolException pe;
 	for (const auto & pair : msg.dataObjects) {
-		std::cout << "Store received data object : " << pair.second.resource.dataObjectType << " (" << pair.second.resource.uri << ")" << std::endl;
+		BOOST_LOG_TRIVIAL(trace) << "Store received data object : " << pair.second.resource.dataObjectType << " (" << pair.second.resource.uri << ")";
 
 		COMMON_NS::AbstractObject* importedObj = repo->addOrReplaceGsoapProxy(pair.second.data, pair.second.resource.dataObjectType);
 		if (importedObj == nullptr) {

--- a/etpServerExample/MyServerInitializationParameters.h
+++ b/etpServerExample/MyServerInitializationParameters.h
@@ -22,6 +22,8 @@ under the License.
 
 #include <vector>
 
+#include <boost/uuid/random_generator.hpp>
+
 #include "MyDataObjectRepository.h"
 #include "MyOwnCoreProtocolHandlers.h"
 #include "MyOwnDiscoveryProtocolHandlers.h"
@@ -35,11 +37,14 @@ private:
 	MyDataObjectRepository* repo_;
 
 public:
-	MyServerInitializationParameters(MyDataObjectRepository* repo): repo_(repo) {}
-	~MyServerInitializationParameters() {}
+	MyServerInitializationParameters(MyDataObjectRepository* repo): repo_(repo) {
+		boost::uuids::random_generator gen;
+		identifier = gen();
+	}
+	~MyServerInitializationParameters() = default;
 
-	void postSessionCreationOperation(ETP_NS::AbstractSession* session) final {
-		session->setCoreProtocolHandlers(std::make_shared<MyOwnCoreProtocolHandlers>(session));
+	void postSessionCreationOperation(ETP_NS::AbstractSession* session) const final {
+		session->setCoreProtocolHandlers(std::make_shared<MyOwnCoreProtocolHandlers>(session, this));
 		session->setDiscoveryProtocolHandlers(std::make_shared<MyOwnDiscoveryProtocolHandlers>(session, repo_));
 		session->setStoreProtocolHandlers(std::make_shared<MyOwnStoreProtocolHandlers>(session, repo_));
 		session->setStoreNotificationProtocolHandlers(std::make_shared<MyOwnStoreNotificationProtocolHandlers>(session, repo_));

--- a/etpServerExample/main.cpp
+++ b/etpServerExample/main.cpp
@@ -17,6 +17,8 @@ specific language governing permissions and limitations
 under the License.
 -----------------------------------------------------------------------*/
 
+#include <boost/log/trivial.hpp>
+
 #ifdef WITH_ETP_SSL
 #include "etp/ssl/SslServerSession.h"
 #endif
@@ -81,7 +83,7 @@ int main(int argc, char **argv)
 	MyServerInitializationParameters serverInitializationParams(&repo);
 
 	const int threadCount = 2;
-	std::cout << "Start listening on " << argv[1] << ":" << argv[2] << " with " << threadCount << " threads..." << std::endl;
+	BOOST_LOG_TRIVIAL(trace) << "Start listening on " << argv[1] << ":" << argv[2] << " with " << threadCount << " threads...";
 
 #ifdef WITH_ETP_SSL
 	if (std::stoi(argv[2]) == 443) {

--- a/src/etp/AbstractClientSession.h
+++ b/src/etp/AbstractClientSession.h
@@ -140,6 +140,7 @@ namespace ETP_NS
 				{
 					m.insert(boost::beast::http::field::sec_websocket_protocol, "etp12.energistics.org");
 					m.insert(boost::beast::http::field::authorization, authorization);
+					m.insert("etp-encoding", "binary");
 				},
 				std::bind(
 					&AbstractClientSession::on_handshake,
@@ -211,14 +212,14 @@ namespace ETP_NS
 
 		void on_handshake(boost::system::error_code ec)
 		{
+#ifndef NDEBUG
+			std::cout << responseType << std::endl;
+#endif
+
 			if (ec) {
 				std::cerr << "on_handshake : " << ec.message() << std::endl;
 				return;
 			}
-
-#ifndef NDEBUG
-			std::cout << responseType << std::endl;
-#endif
 
 			if (!responseType.count(boost::beast::http::field::sec_websocket_protocol) ||
 				responseType[boost::beast::http::field::sec_websocket_protocol] != "etp12.energistics.org")

--- a/src/etp/AbstractPlainOrSslServerSession.h
+++ b/src/etp/AbstractPlainOrSslServerSession.h
@@ -24,6 +24,7 @@ under the License.
 
 #include <boost/asio/strand.hpp>
 #include <boost/asio/bind_executor.hpp>
+#include <boost/uuid/random_generator.hpp>
 
 #include "../common/AbstractObject.h"
 
@@ -45,6 +46,8 @@ namespace ETP_NS
 		AbstractPlainOrSslServerSession(boost::asio::io_context& ioc) : strand(ioc.get_executor())
 		{
 			messageId = 1; // The client side of the connection MUST use ONLY non-zero even-numbered messageIds.
+			boost::uuids::random_generator gen;
+			identifier = gen();
 		}
 
 		virtual ~AbstractPlainOrSslServerSession() = default;

--- a/src/etp/AbstractSession.h
+++ b/src/etp/AbstractSession.h
@@ -21,6 +21,7 @@ under the License.
 #include <boost/beast/core.hpp>
 #include <boost/beast/websocket.hpp>
 #include <boost/asio/ip/tcp.hpp>
+#include <boost/uuid/uuid_io.hpp>
 
 #include "../nsDefinitions.h"
 
@@ -73,6 +74,7 @@ namespace ETP_NS
 		bool etpSessionClosed; // open with the requestSession and openSession message
 		std::vector<std::vector<uint8_t> > sendingQueue;
 		int64_t messageId;
+		boost::uuids::uuid identifier;
 
 	    AbstractSession() : receivedBuffer(), protocolHandlers(), specificProtocolHandlers(),
 			webSocketSessionClosed(true), etpSessionClosed(true),
@@ -133,6 +135,11 @@ namespace ETP_NS
 	public:
 
 		virtual ~AbstractSession() = default;
+
+		/**
+		* Return the identifier of the session which is an UUID.
+		*/
+		const boost::uuids::uuid& getIdentifier() const { return identifier; }
 
 		/**
 		* The list of subscriptions recorded by customers on this session.

--- a/src/etp/ProtocolHandlers/CoreHandlers.h
+++ b/src/etp/ProtocolHandlers/CoreHandlers.h
@@ -25,8 +25,9 @@ namespace ETP_NS
 	class DLL_IMPORT_OR_EXPORT CoreHandlers : public ProtocolHandlers
 	{
 	public:
-		CoreHandlers(AbstractSession* mySession): ProtocolHandlers(mySession) {}
-		virtual ~CoreHandlers() {}
+		CoreHandlers(AbstractSession* mySession):
+			ProtocolHandlers(mySession) {}
+		virtual ~CoreHandlers() = default;
 
 	    void decodeMessageBody(const Energistics::Etp::v12::Datatypes::MessageHeader & mh, avro::DecoderPtr d) override;
 

--- a/src/etp/ServerInitializationParameters.cpp
+++ b/src/etp/ServerInitializationParameters.cpp
@@ -20,7 +20,7 @@ under the License.
 
 using namespace ETP_NS;
 
-std::map<std::string, Energistics::Etp::v12::Datatypes::DataValue> ServerInitializationParameters::makeEndpointCapabilities()
+std::map<std::string, Energistics::Etp::v12::Datatypes::DataValue> ServerInitializationParameters::makeEndpointCapabilities() const
 {
 	std::map<std::string, Energistics::Etp::v12::Datatypes::DataValue> result;
 
@@ -35,12 +35,12 @@ std::map<std::string, Energistics::Etp::v12::Datatypes::DataValue> ServerInitial
 	return result;
 }
 
-std::vector<std::string> ServerInitializationParameters::makeSupportedEncodings()
+std::vector<std::string> ServerInitializationParameters::makeSupportedEncodings() const
 {
 	return std::vector<std::string>(1, "binary");
 }
 
-std::vector<Energistics::Etp::v12::Datatypes::SupportedDataObject> ServerInitializationParameters::makeSupportedDataObjects()
+std::vector<Energistics::Etp::v12::Datatypes::SupportedDataObject> ServerInitializationParameters::makeSupportedDataObjects() const
 {
 	std::vector<Energistics::Etp::v12::Datatypes::SupportedDataObject> result;
 
@@ -91,7 +91,7 @@ std::vector<Energistics::Etp::v12::Datatypes::SupportedDataObject> ServerInitial
 	return result;
 }
 
-std::vector<Energistics::Etp::v12::Datatypes::SupportedProtocol> ServerInitializationParameters::makeSupportedProtocols()
+std::vector<Energistics::Etp::v12::Datatypes::SupportedProtocol> ServerInitializationParameters::makeSupportedProtocols() const
 {
 	std::vector<Energistics::Etp::v12::Datatypes::SupportedProtocol> result;
 	Energistics::Etp::v12::Datatypes::Version protocolVersion;

--- a/src/etp/ServerInitializationParameters.h
+++ b/src/etp/ServerInitializationParameters.h
@@ -24,22 +24,40 @@ namespace ETP_NS
 {
 	class ServerInitializationParameters
 	{
+	protected:
+		boost::uuids::uuid identifier;
+
 	public:
+		/**
+		* Set the identifier of the server a default value.
+		* You should set the identifer as wanted in your own derived class.
+		*/
 		ServerInitializationParameters() {}
-		virtual ~ServerInitializationParameters() {}
+		/**
+		* Mainly for use with SWIG i.e. boost uuid structure is not easily portable whereas strings are.
+		*/
+		ServerInitializationParameters(const std::string & serverUuid) {
+			std::stringstream ss(serverUuid);
+			ss >> identifier;
+		}
+		virtual ~ServerInitializationParameters() = default;
 
-		DLL_IMPORT_OR_EXPORT virtual std::string getApplicationName() { return "F2I-CONSULTING ETP SERVER"; }
-		DLL_IMPORT_OR_EXPORT virtual std::string getApplicationVersion() { return "0.0"; }
-		DLL_IMPORT_OR_EXPORT virtual std::string getContactEmail() { return "name@f2i-consulting.com"; }
-		DLL_IMPORT_OR_EXPORT virtual std::string getContactName() { return "Philippe Verney"; }
-		DLL_IMPORT_OR_EXPORT virtual std::string getContactPhone() { return "Please use Zoom or Slack"; }
-		DLL_IMPORT_OR_EXPORT virtual std::string getOrganizationName() { return "F2I-CONSULTING"; }
+		DLL_IMPORT_OR_EXPORT virtual const boost::uuids::uuid& getServerInstanceId() const { return identifier; }
+		DLL_IMPORT_OR_EXPORT virtual std::string getApplicationName() const { return "F2I-CONSULTING ETP SERVER"; }
+		DLL_IMPORT_OR_EXPORT virtual std::string getApplicationVersion() const { return "0.0"; }
+		DLL_IMPORT_OR_EXPORT virtual std::string getContactEmail() const { return "philippe.verney@f2i-consulting.com"; }
+		DLL_IMPORT_OR_EXPORT virtual std::string getContactName() const { return "Philippe Verney"; }
+		DLL_IMPORT_OR_EXPORT virtual std::string getContactPhone() const { return "Please use Zoom or Slack"; }
+		DLL_IMPORT_OR_EXPORT virtual std::string getOrganizationName() const { return "F2I-CONSULTING"; }
 
-		DLL_IMPORT_OR_EXPORT virtual std::vector<std::string> makeSupportedEncodings();
-		DLL_IMPORT_OR_EXPORT virtual std::map<std::string, Energistics::Etp::v12::Datatypes::DataValue> makeEndpointCapabilities();
-		DLL_IMPORT_OR_EXPORT virtual std::vector<Energistics::Etp::v12::Datatypes::SupportedDataObject> makeSupportedDataObjects();
-		DLL_IMPORT_OR_EXPORT virtual std::vector<Energistics::Etp::v12::Datatypes::SupportedProtocol> makeSupportedProtocols();
+		DLL_IMPORT_OR_EXPORT virtual std::vector<std::string> makeSupportedEncodings() const;
+		DLL_IMPORT_OR_EXPORT virtual std::map<std::string, Energistics::Etp::v12::Datatypes::DataValue> makeEndpointCapabilities() const;
+		DLL_IMPORT_OR_EXPORT virtual std::vector<Energistics::Etp::v12::Datatypes::SupportedDataObject> makeSupportedDataObjects() const;
+		DLL_IMPORT_OR_EXPORT virtual std::vector<Energistics::Etp::v12::Datatypes::SupportedProtocol> makeSupportedProtocols() const;
 
-		DLL_IMPORT_OR_EXPORT virtual void postSessionCreationOperation(AbstractSession*) {}
+		/**
+		* Override this method in order to register some dedicated protocol handlers for a session.
+		*/
+		DLL_IMPORT_OR_EXPORT virtual void postSessionCreationOperation (AbstractSession*) const {}
 	};
 }

--- a/swig/swigEtp1_2Include.i
+++ b/swig/swigEtp1_2Include.i
@@ -1326,8 +1326,9 @@ namespace ETP_NS
 	class ServerInitializationParameters
 	{
 	public:
-		ServerInitializationParameters() {}
-		virtual ~ServerInitializationParameters() {}
+		ServerInitializationParameters();
+		ServerInitializationParameters(const std::string & serverUuid);
+		virtual ~ServerInitializationParameters();
 
 		virtual std::string getApplicationName();
 		virtual std::string getApplicationVersion();


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Filter server session on sec-websocket-protocol
Use Boost log in EtpServerExample
Support for Server UUID and session UUID
Warn about target syntax in EtpServerExample

Does this close any currently open issues?
------------------------------------------
No

Where has this been tested?
---------------------------
**Operating System:** Win10 64

**Platform:** VS 2017 64
