### PR TITLE
Small ETP-related refactoring

### DIFF
--- a/etpServerExample/MyOwnDiscoveryProtocolHandlers.cpp
+++ b/etpServerExample/MyOwnDiscoveryProtocolHandlers.cpp
@@ -161,7 +161,7 @@ void MyOwnDiscoveryProtocolHandlers::on_GetResources(const Energistics::Etp::v12
 
 		for (const auto & pair : groupedDataObj) {
 			for (const auto* obj : pair.second) {
-				nextGr.context.uri = obj->buildUri();
+				nextGr.context.uri = obj->buildEtp12Uri();
 				getDataObjectResource(nextGr, correlationId, mb.resources);
 			}
 		}

--- a/etpServerExample/MyOwnDiscoveryProtocolHandlers.cpp
+++ b/etpServerExample/MyOwnDiscoveryProtocolHandlers.cpp
@@ -161,7 +161,7 @@ void MyOwnDiscoveryProtocolHandlers::on_GetResources(const Energistics::Etp::v12
 
 		for (const auto & pair : groupedDataObj) {
 			for (const auto* obj : pair.second) {
-				nextGr.context.uri = ETP_NS::EtpHelpers::buildUriFromEnergisticsObject(obj);
+				nextGr.context.uri = obj->buildUri();
 				getDataObjectResource(nextGr, correlationId, mb.resources);
 			}
 		}

--- a/src/common/AbstractObject.cpp
+++ b/src/common/AbstractObject.cpp
@@ -1197,7 +1197,7 @@ std::string AbstractObject::getExtraMetadataStringValueAtIndex(unsigned int inde
 	throw logic_error("Not implemented yet.");
 }
 
-std::string AbstractObject::buildUri() const
+std::string AbstractObject::buildEtp12Uri() const
 {
 	return "eml:///" + getQualifiedType() + "(" + getUuid() + ")";
 }

--- a/src/common/AbstractObject.cpp
+++ b/src/common/AbstractObject.cpp
@@ -1197,6 +1197,11 @@ std::string AbstractObject::getExtraMetadataStringValueAtIndex(unsigned int inde
 	throw logic_error("Not implemented yet.");
 }
 
+std::string AbstractObject::buildUri() const
+{
+	return "eml:///" + getQualifiedType() + "(" + getUuid() + ")";
+}
+
 void AbstractObject::readArrayNdOfDoubleValues(gsoap_resqml2_0_1::resqml20__AbstractDoubleArray * arrayInput, double * arrayOutput) const
 {
 	long soapType = arrayInput->soap_type();

--- a/src/common/AbstractObject.h
+++ b/src/common/AbstractObject.h
@@ -1069,6 +1069,12 @@ namespace COMMON_NS
 		DLL_IMPORT_OR_EXPORT std::string getExtraMetadataStringValueAtIndex(unsigned int index) const;
 		
 		/**
+		* Build and return an URI from an Energistics object.
+		* @return	The URI built from the Energistics object
+		*/
+		DLL_IMPORT_OR_EXPORT std::string buildUri() const;
+
+		/**
 		 * Reads the forward relationships of this data object and update the <tt>.rels</tt> of the
 		 * associated data repository.
 		 */

--- a/src/common/AbstractObject.h
+++ b/src/common/AbstractObject.h
@@ -1069,10 +1069,10 @@ namespace COMMON_NS
 		DLL_IMPORT_OR_EXPORT std::string getExtraMetadataStringValueAtIndex(unsigned int index) const;
 		
 		/**
-		* Build and return an URI from an Energistics object.
-		* @return	The URI built from the Energistics object
+		* Build and return an ETP1.2 URI from an Energistics dataobject.
+		* @return	The ETP1.2 URI built from the Energistics dataobject
 		*/
-		DLL_IMPORT_OR_EXPORT std::string buildUri() const;
+		DLL_IMPORT_OR_EXPORT std::string buildEtp12Uri() const;
 
 		/**
 		 * Reads the forward relationships of this data object and update the <tt>.rels</tt> of the

--- a/src/etp/AbstractPlainOrSslServerSession.h
+++ b/src/etp/AbstractPlainOrSslServerSession.h
@@ -26,8 +26,6 @@ under the License.
 #include <boost/asio/bind_executor.hpp>
 #include <boost/uuid/random_generator.hpp>
 
-#include "../common/AbstractObject.h"
-
 namespace ETP_NS
 {
 	// Echoes back all received WebSocket messages.

--- a/src/etp/EtpHelpers.cpp
+++ b/src/etp/EtpHelpers.cpp
@@ -95,11 +95,6 @@ Energistics::Etp::v12::Datatypes::ErrorInfo ETP_NS::EtpHelpers::validateDataObje
 	return errorInfo;
 }
 
-std::string ETP_NS::EtpHelpers::buildUriFromEnergisticsObject(const COMMON_NS::AbstractObject * const obj)
-{
-	return "eml:///" + obj->getQualifiedType() + "(" + obj->getUuid() + ")";
-}
-
 Energistics::Etp::v12::Datatypes::Object::Resource ETP_NS::EtpHelpers::buildEtpResourceFromEnergisticsObject(const COMMON_NS::AbstractObject * const obj, bool countRels)
 {
 	if (obj == nullptr) {
@@ -109,7 +104,7 @@ Energistics::Etp::v12::Datatypes::Object::Resource ETP_NS::EtpHelpers::buildEtpR
 	Energistics::Etp::v12::Datatypes::Object::Resource result;
 
 	result.dataObjectType = obj->getQualifiedType();
-	result.uri = buildUriFromEnergisticsObject(obj);
+	result.uri = obj->buildUri();
 	result.name = obj->getTitle();
 	if (obj->isPartial()) {
 		result.lastChanged = -1;

--- a/src/etp/EtpHelpers.cpp
+++ b/src/etp/EtpHelpers.cpp
@@ -104,7 +104,7 @@ Energistics::Etp::v12::Datatypes::Object::Resource ETP_NS::EtpHelpers::buildEtpR
 	Energistics::Etp::v12::Datatypes::Object::Resource result;
 
 	result.dataObjectType = obj->getQualifiedType();
-	result.uri = obj->buildUri();
+	result.uri = obj->buildEtp12Uri();
 	result.name = obj->getTitle();
 	if (obj->isPartial()) {
 		result.lastChanged = -1;

--- a/src/etp/EtpHelpers.h
+++ b/src/etp/EtpHelpers.h
@@ -55,13 +55,6 @@ namespace ETP_NS
 		DLL_IMPORT_OR_EXPORT Energistics::Etp::v12::Datatypes::ErrorInfo validateDataObjectUri(const std::string & uri, AbstractSession* session = nullptr);
 
 		/**
-		* Build and return an URI from an Energistics object.
-		* @param obj		The input Energistics obj
-		* @return			The URI built from the Energistics object
-		*/
-		DLL_IMPORT_OR_EXPORT std::string buildUriFromEnergisticsObject(const COMMON_NS::AbstractObject * const obj);
-
-		/**
 		* Build and return an ETP resource from an Energistics object.
 		* @param obj		The input Energistics obj
 		* @param countRels	Indicate if the returned resource contain the count of source or target relationships.

--- a/swig/swigEtp1_2Include.i
+++ b/swig/swigEtp1_2Include.i
@@ -1301,7 +1301,6 @@ namespace ETP_NS
 	namespace EtpHelpers {
 		Energistics::Etp::v12::Datatypes::ErrorInfo validateUri(const std::string & uri, ETP_NS::AbstractSession* session = nullptr);
 		Energistics::Etp::v12::Datatypes::ErrorInfo validateDataObjectUri(const std::string & uri, ETP_NS::AbstractSession* session = nullptr);
-		std::string buildUriFromEnergisticsObject(const COMMON_NS::AbstractObject * const obj);
 		Energistics::Etp::v12::Datatypes::Object::Resource buildEtpResourceFromEnergisticsObject(const COMMON_NS::AbstractObject * const obj, bool countRels = true);
 		Energistics::Etp::v12::Datatypes::Object::DataObject buildEtpDataObjectFromEnergisticsObject(COMMON_NS::AbstractObject * obj, bool includeSerialization = true);	
 		Energistics::Etp::v12::Protocol::Core::ProtocolException buildSingleMessageProtocolException(int32_t m_code, const std::string & m_message);

--- a/swig/swigModule.i
+++ b/swig/swigModule.i
@@ -294,9 +294,11 @@ namespace COMMON_NS
 		std::string getExtraMetadataKeyAtIndex(unsigned int index) const;
 		std::string getExtraMetadataStringValueAtIndex(unsigned int index) const;
 
+		std::string buildUri() const;
+
 		unsigned int getActivityCount() const;
 
-		EML2_NS::Activity * getActivity (unsigned int index) const;
+		EML2_NS::Activity * getActivity (unsigned int index) const;		
 	};
 
 %warnfilter(473) HdfProxyFactory::make;

--- a/swig/swigModule.i
+++ b/swig/swigModule.i
@@ -294,7 +294,7 @@ namespace COMMON_NS
 		std::string getExtraMetadataKeyAtIndex(unsigned int index) const;
 		std::string getExtraMetadataStringValueAtIndex(unsigned int index) const;
 
-		std::string buildUri() const;
+		std::string buildEtp12Uri() const;
 
 		unsigned int getActivityCount() const;
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- Remove buildUriFromEnergisticsObject from EtpHelpers
- Add corresponding buildUri method in AbstractObject
- Remove unused include directive from AbstractPlainOrSslServerSession

Does this close any currently open issues?
------------------------------------------
No.

Any relevant logs, error output, etc?
-------------------------------------
No.

Any other comments?
-------------------
No.

Where has this been tested?
---------------------------
**Operating System:** Windows 10 64bits

**Platform:** Visual Studio Community 2019
