### PR TITLE
Flush AVRO message before to send them

### DIFF
--- a/etpClientExample/MyOwnCoreProtocolHandlers.cpp
+++ b/etpClientExample/MyOwnCoreProtocolHandlers.cpp
@@ -88,6 +88,7 @@ void askUser(ETP_NS::AbstractSession* session, COMMON_NS::DataObjectRepository* 
 			mb.context.uri = commandTokens[1];
 			mb.scope = Energistics::Etp::v12::Datatypes::Object::ContextScopeKind::self;
 			mb.context.depth = 1;
+			mb.context.navigableEdges = Energistics::Etp::v12::Datatypes::Object::RelationshipKind::Primary;
 			mb.countObjects = true;
 
 			if (commandTokens.size() > 2) {
@@ -278,6 +279,8 @@ void askUser(ETP_NS::AbstractSession* session, COMMON_NS::DataObjectRepository* 
 				mb.context.uri = commandTokens[1];
 				mb.scope = Energistics::Etp::v12::Datatypes::Object::ContextScopeKind::sources;
 				mb.context.depth = 1;
+				mb.context.navigableEdges = Energistics::Etp::v12::Datatypes::Object::RelationshipKind::Primary;
+				mb.countObjects = true;
 
 				std::static_pointer_cast<MyOwnDiscoveryProtocolHandlers>(session->getDiscoveryProtocolHandlers())->getObjectWhenDiscovered.push_back(session->send(mb, 0, 0x02));
 			}
@@ -286,6 +289,8 @@ void askUser(ETP_NS::AbstractSession* session, COMMON_NS::DataObjectRepository* 
 				mb.context.uri = commandTokens[1];
 				mb.scope = Energistics::Etp::v12::Datatypes::Object::ContextScopeKind::targets;
 				mb.context.depth = 1;
+				mb.context.navigableEdges = Energistics::Etp::v12::Datatypes::Object::RelationshipKind::Primary;
+				mb.countObjects = true;
 
 				std::static_pointer_cast<MyOwnDiscoveryProtocolHandlers>(session->getDiscoveryProtocolHandlers())->getObjectWhenDiscovered.push_back(session->send(mb, 0, 0x02));
 			}
@@ -294,6 +299,8 @@ void askUser(ETP_NS::AbstractSession* session, COMMON_NS::DataObjectRepository* 
 				mb.context.uri = commandTokens[1];
 				mb.scope = Energistics::Etp::v12::Datatypes::Object::ContextScopeKind::targetsOrSelf;
 				mb.context.depth = 1;
+				mb.context.navigableEdges = Energistics::Etp::v12::Datatypes::Object::RelationshipKind::Primary;
+				mb.countObjects = true;
 				std::static_pointer_cast<MyOwnDiscoveryProtocolHandlers>(session->getDiscoveryProtocolHandlers())->getObjectWhenDiscovered.push_back(session->send(mb, 0, 0x02));
 
 				mb.scope = Energistics::Etp::v12::Datatypes::Object::ContextScopeKind::sources;

--- a/etpClientExample/MyOwnDiscoveryProtocolHandlers.cpp
+++ b/etpClientExample/MyOwnDiscoveryProtocolHandlers.cpp
@@ -55,6 +55,6 @@ void MyOwnDiscoveryProtocolHandlers::on_GetResourcesResponse(const Energistics::
 	}
 
 	if (!getO.uris.empty()) {
-		session->send(getO);
+		session->send(getO, 0, 0x02);
 	}
 }

--- a/etpClientExample/main.cpp
+++ b/etpClientExample/main.cpp
@@ -46,8 +46,8 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	if (argc == 4 && (argv[3][0] != '/' || argv[3][strlen(argv[3]) - 1] != '/')) {
-		std::cerr << "Please put a slash at the start and at the end of the target " << argv[3] << std::endl;
+	if (argc == 4 && (argv[3][0] != '/')) {
+		std::cerr << "Please put a slash at the start of the target " << argv[3] << std::endl;
 		return 1;
 	}
 
@@ -114,6 +114,9 @@ int main(int argc, char **argv)
 
 		auto httpsClientSession = std::make_shared<HttpsClientSession>(ioc, ctx);
 		std::string etpServerCapTarget = argc >= 4 ? argv[3] : "/";
+		if (etpServerCapTarget[etpServerCapTarget.size() - 1] != '/') {
+			etpServerCapTarget += '/';
+		}
 		etpServerCapTarget += ".well-known/etp-server-capabilities?GetVersion=etp12.energistics.org";
 		std::cout << "Requesting " << etpServerCapTarget << " to " << argv[1] << " on port " << argv[2] << std::endl;
 		httpsClientSession->run(argv[1], argv[2], etpServerCapTarget.c_str(), 11, authorization);
@@ -125,6 +128,9 @@ int main(int argc, char **argv)
 #endif
 		auto httpClientSession = std::make_shared<HttpClientSession>(ioc);
 		std::string etpServerCapTarget = argc >= 4 ? argv[3] : "/";
+		if (etpServerCapTarget[etpServerCapTarget.size() - 1] != '/') {
+			etpServerCapTarget += '/';
+		}
 		etpServerCapTarget += ".well-known/etp-server-capabilities?GetVersion=etp12.energistics.org";
 		std::cout << "Requesting " << etpServerCapTarget << " to " << argv[1] << " on port " << argv[2] << std::endl;
 		httpClientSession->run(argv[1], argv[2], etpServerCapTarget.c_str(), 11, authorization);

--- a/src/etp/AbstractClientSession.h
+++ b/src/etp/AbstractClientSession.h
@@ -21,6 +21,8 @@ under the License.
 #include "AbstractSession.h"
 
 #include <boost/asio/connect.hpp>
+#include <boost/uuid/random_generator.hpp>
+#include <boost/uuid/uuid_io.hpp>
 
 #include "DataArrayBlockingSession.h"
 
@@ -84,6 +86,12 @@ namespace ETP_NS
 			requestSession.applicationVersion = "0.0";
 			requestSession.requestedProtocols = requestedProtocols;
 			requestSession.supportedDataObjects = supportedDataObjects;
+			requestSession.currentDateTime = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+			requestSession.supportedFormats.push_back("xml");
+
+			boost::uuids::random_generator gen;
+			auto instanceUuid = gen();
+			std::copy(std::begin(instanceUuid.data), std::end(instanceUuid.data), requestSession.clientInstanceId.array.begin());
 		}
 
 		virtual ~AbstractClientSession() = default;
@@ -228,7 +236,7 @@ namespace ETP_NS
 			successfulConnection = true;
 			webSocketSessionClosed = false;
 
-			send(requestSession);
+			send(requestSession, 0, 0x02);
 			do_read();
 		}
 	};

--- a/src/etp/AbstractSession.cpp
+++ b/src/etp/AbstractSession.cpp
@@ -70,7 +70,7 @@ void AbstractSession::on_read(boost::system::error_code ec, std::size_t bytes_tr
 	if ((receivedMh.messageFlags & 0x10) != 0) {
 		Energistics::Etp::v12::Protocol::Core::Acknowledge acknowledge;
 		acknowledge.protocolId = receivedMh.protocol;
-		send(acknowledge, receivedMh.messageId);
+		send(acknowledge, receivedMh.messageId, 0x02);
 	}
 
 	auto specificProtocolHandlerIt = specificProtocolHandlers.find(receivedMh.correlationId);
@@ -89,7 +89,7 @@ void AbstractSession::on_read(boost::system::error_code ec, std::size_t bytes_tr
 	}
 	else {
 		flushReceivingBuffer();
-		send(ETP_NS::EtpHelpers::buildSingleMessageProtocolException(4, "The agent does not support the protocol " + std::to_string(receivedMh.protocol) + " identified in a message header."));
+		send(ETP_NS::EtpHelpers::buildSingleMessageProtocolException(4, "The agent does not support the protocol " + std::to_string(receivedMh.protocol) + " identified in a message header."), receivedMh.messageId, 0x02);
 	}
 
 	do_read();
@@ -100,5 +100,5 @@ void AbstractSession::close()
 	// Build Open Session message
 	Energistics::Etp::v12::Protocol::Core::CloseSession closeSession;
 
-	send(closeSession);
+	send(closeSession, 0, 0x02);
 }

--- a/src/etp/AbstractSession.h
+++ b/src/etp/AbstractSession.h
@@ -126,8 +126,8 @@ namespace ETP_NS
 			e->init(*out);
 			avro::encode(*e, mh);
 			avro::encode(*e, mb);
-			sendingQueue.push_back(*avro::snapshot(*out).get());
 			e->flush();
+			sendingQueue.push_back(*avro::snapshot(*out).get());
 
 			return mh.messageId;
 		}

--- a/src/etp/DataArrayBlockingSession.h
+++ b/src/etp/DataArrayBlockingSession.h
@@ -85,7 +85,7 @@ namespace ETP_NS
 			dai.uri = uri;
 			dai.pathInResource = datasetName;
 			gda.dataArrays["0"] = dai;
-			send(gda);
+			send(gda, 0, 0x02);
 
 			// Read a message into our buffer
 			// For now hoping that this message is the response for the above sent message

--- a/src/etp/Server.h
+++ b/src/etp/Server.h
@@ -18,6 +18,12 @@ under the License.
 -----------------------------------------------------------------------*/
 #pragma once
 
+#include <regex>
+#include <thread>
+#include <stdexcept>
+#include <vector>
+#include <fstream>
+
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/signal_set.hpp>
 #include <boost/asio/strand.hpp>
@@ -25,11 +31,6 @@ under the License.
 #include <boost/asio/ssl.hpp>
 #endif
 #include <boost/beast/http/file_body.hpp>
-
-#include <thread>
-#include <stdexcept>
-#include <vector>
-#include <fstream>
 
 #include "avro/Compiler.hh"
 
@@ -198,6 +199,14 @@ namespace ETP_NS
 		if (ec == boost::system::errc::no_such_file_or_directory)
 			return send(not_found(req.target()));
 			*/
+
+		while (path.find("//") != std::string::npos) {
+			path = std::regex_replace(path, std::regex("//"), "/");
+		}
+		while (path.find("\\\\") != std::string::npos) {
+			// See https://stackoverflow.com/questions/4025482/cant-escape-the-backslash-with-regex
+			path = std::regex_replace(path, std::regex("\\\\\\\\"), "\\");
+		}
 
 		if (path == "./.well-known/etp-server-capabilities" ||
 			path == ".\\.well-known\\etp-server-capabilities") {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- Add FIN flag to some messages
- Add correlation id when receiving a message belonging to an unsupported protocol
- Better support of trailing slash and multiple forward slashes
- Initialize correctly RequestSession

Does this close any currently open issues?
------------------------------------------
No

Any other comments?
-------------------
Mostly coming from ETP1.2 second testing ilab : https://3.basecamp.com/3247751/buckets/838608/messages/3496781542

Where has this been tested?
---------------------------
**Operating System:** WIN10 64

**Platform:** VS 2017 64
