### PR TITLE
Small ETP-related fixes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,7 +91,7 @@ jobs:
             -DZLIB_INCLUDE_DIR=C:/hdf5-1.10.6-win64-vs2017/include
             -DZLIB_LIBRARY_RELEASE=C:/hdf5-1.10.6-win64-vs2017/lib/zlib.lib
             -DSZIP_LIBRARY_RELEASE=C:/hdf5-1.10.6-win64-vs2017/lib/szip.lib
-            -DBoost_INCLUDE_DIR=C:/hostedtoolcache/windows/Boost/1.75.0/x86_64/include
+            -DBoost_INCLUDE_DIR=C:/hostedtoolcache/windows/Boost/1.75.0/x86_64
             -DWITH_EXAMPLE=TRUE
             -DWITH_RESQML2_2=TRUE
             -DWITH_DOTNET_WRAPPING=TRUE
@@ -210,7 +210,7 @@ jobs:
             $(Build.SourcesDirectory)/avro-cpp-1.10.1
             $(Generator)
             -Wno-dev -Wno-deprecated
-            -DBoost_INCLUDE_DIR=C:/hostedtoolcache/windows/Boost/1.75.0/x86_64/include
+            -DBoost_INCLUDE_DIR=C:/hostedtoolcache/windows/Boost/1.75.0/x86_64
             -DCMAKE_INSTALL_PREFIX=$(Agent.TempDirectory)/avro-cpp-1.10.1-install
       - task: CMake@1
         displayName: "CMake build AVRO --config $(BuildType)"
@@ -243,7 +243,7 @@ jobs:
             -DZLIB_INCLUDE_DIR=C:/hdf5-1.12.0-win64-vs2019/include
             -DZLIB_LIBRARY_RELEASE=C:/hdf5-1.12.0-win64-vs2019/lib/zlib.lib
             -DSZIP_LIBRARY_RELEASE=C:/hdf5-1.12.0-win64-vs2019/lib/szip.lib
-            -DBoost_INCLUDE_DIR=C:/hostedtoolcache/windows/Boost/1.75.0/x86_64/include
+            -DBoost_INCLUDE_DIR=C:/hostedtoolcache/windows/Boost/1.75.0/x86_64
             -DAVRO_INCLUDE_DIR=$(Agent.TempDirectory)/avro-cpp-1.10.1-install/include
             -DAVRO_LIBRARY_RELEASE=$(Agent.TempDirectory)/avro-cpp-1.10.1-install/lib/avrocpp_s.lib
             -DWITH_EXAMPLE=TRUE
@@ -274,6 +274,17 @@ jobs:
           sudo apt install -y libhdf5-dev libminizip-dev valgrind
         displayName: 'APT install'
 
+      # Boost
+      # Use the boost-1.73.0-linux-16.04-gcc-x64.tar.gz for Ubuntu 16.04
+      - powershell: |
+          $url = "https://github.com/actions/boost-versions/releases/download/1.73.0-20200608.5/boost-1.73.0-linux-16.04-gcc-x64.tar.gz"
+          (New-Object System.Net.WebClient).DownloadFile($url, "/tmp/boost.tar.gz")
+          mkdir "/tmp/boost"
+          tar -xzf "/tmp/boost.tar.gz" -C "/tmp/boost"
+          Push-Location -Path "/tmp/boost"
+          Invoke-Expression "bash ./setup.sh"
+        displayName: 'Install Boost 1.73'
+
       - task: CMake@1
         displayName: 'Configure FESAPI build'
         inputs:
@@ -286,7 +297,7 @@ jobs:
             -DMINIZIP_LIBRARY_RELEASE=/usr/lib/x86_64-linux-gnu/libminizip.so
             -DZLIB_INCLUDE_DIR=/usr/include
             -DZLIB_LIBRARY_RELEASE=/usr/lib/x86_64-linux-gnu/libz.so
-            -DBoost_INCLUDE_DIR=$(BOOST_ROOT_1_72_0)/include
+            -DBoost_INCLUDE_DIR=/opt/hostedtoolcache/boost/1.73.0/x64
             -DWITH_EXAMPLE=TRUE
             -DWITH_RESQML2_2=TRUE
             -DWITH_TEST=TRUE
@@ -322,14 +333,12 @@ jobs:
         inputs:
           cmakeArgs:
             -Wno-dev -Wno-deprecated
-            -DHDF5_1_8=TRUE
             -DHDF5_C_INCLUDE_DIR=/usr/include/hdf5/serial/
             -DHDF5_C_LIBRARY_RELEASE=/usr/lib/x86_64-linux-gnu/hdf5/serial/libhdf5.so
             -DMINIZIP_INCLUDE_DIR=/usr/include/minizip
             -DMINIZIP_LIBRARY_RELEASE=/usr/lib/x86_64-linux-gnu/libminizip.so
             -DZLIB_INCLUDE_DIR=/usr/include
             -DZLIB_LIBRARY_RELEASE=/usr/lib/x86_64-linux-gnu/libz.so
-            -DBoost_INCLUDE_DIR=$(BOOST_ROOT_1_72_0)/include
             -DWITH_EXAMPLE=TRUE
             -DWITH_RESQML2_2=TRUE
             -DWITH_PYTHON_WRAPPING=TRUE

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -222,11 +222,6 @@ jobs:
         inputs:
           workingDirectory: $(Agent.TempDirectory)/build-avro-cpp-1.10.1
           cmakeArgs: --install .
-
-      # Patch about https://github.com/boostorg/beast/issues/1980
-      - powershell: |
-          ((Get-Content -path $(BOOST_ROOT_1_72_0)/include/boost/beast/core/impl/file_stdio.ipp -Raw) -replace 'std::numeric_limits<long>::max','(std::numeric_limits<long>::max)') | Set-Content -Path $(BOOST_ROOT_1_72_0)/include/boost/beast/core/impl/file_stdio.ipp
-        displayName: 'Patching Beast 1.72 for MSVC'
           
       - task: CMake@1
         displayName: 'CMake .. $(Generator)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -266,19 +266,8 @@ jobs:
     timeoutInMinutes: 120
     steps:
       - script: |
-          sudo apt install -y libhdf5-dev libminizip-dev valgrind
+          sudo apt install -y libhdf5-dev libminizip-dev libboost-all-dev valgrind
         displayName: 'APT install'
-
-      # Boost
-      # Use the boost-1.73.0-linux-16.04-gcc-x64.tar.gz for Ubuntu 16.04
-      - powershell: |
-          $url = "https://github.com/actions/boost-versions/releases/download/1.73.0-20200608.5/boost-1.73.0-linux-16.04-gcc-x64.tar.gz"
-          (New-Object System.Net.WebClient).DownloadFile($url, "/tmp/boost.tar.gz")
-          mkdir "/tmp/boost"
-          tar -xzf "/tmp/boost.tar.gz" -C "/tmp/boost"
-          Push-Location -Path "/tmp/boost"
-          Invoke-Expression "bash ./setup.sh"
-        displayName: 'Install Boost 1.73'
 
       - task: CMake@1
         displayName: 'Configure FESAPI build'
@@ -292,7 +281,6 @@ jobs:
             -DMINIZIP_LIBRARY_RELEASE=/usr/lib/x86_64-linux-gnu/libminizip.so
             -DZLIB_INCLUDE_DIR=/usr/include
             -DZLIB_LIBRARY_RELEASE=/usr/lib/x86_64-linux-gnu/libz.so
-            -DBoost_INCLUDE_DIR=/opt/hostedtoolcache/boost/1.73.0/x64
             -DWITH_EXAMPLE=TRUE
             -DWITH_RESQML2_2=TRUE
             -DWITH_TEST=TRUE

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,6 +49,14 @@ jobs:
           workingDirectory: C:/Minizip-build
           cmakeArgs: --build . --config $(BuildType) --target INSTALL -- /verbosity:minimal
 
+      # Boost
+      # Use the boost_1_75_0-msvc-14.1-64.exe for Windows 2016
+      - powershell: |
+          $Url = "https://sourceforge.net/projects/boost/files/boost-binaries/1.75.0/boost_1_75_0-msvc-14.1-64.exe"
+          (New-Object System.Net.WebClient).DownloadFile($Url, "$env:TEMP\boost.exe")
+          Start-Process -Wait -FilePath "$env:TEMP\boost.exe" "/SILENT","/SP-","/SUPPRESSMSGBOXES","/DIR=C:\hostedtoolcache\windows\Boost\1.75.0\x86_64"  
+        displayName: 'Install Boost 1.75'
+
       # sourceforge and WebRequest incompatible
       - task: PowerShell@2
         inputs:
@@ -83,7 +91,7 @@ jobs:
             -DZLIB_INCLUDE_DIR=C:/hdf5-1.10.6-win64-vs2017/include
             -DZLIB_LIBRARY_RELEASE=C:/hdf5-1.10.6-win64-vs2017/lib/zlib.lib
             -DSZIP_LIBRARY_RELEASE=C:/hdf5-1.10.6-win64-vs2017/lib/szip.lib
-            -DBoost_INCLUDE_DIR=$(BOOST_ROOT_1_72_0)/include
+            -DBoost_INCLUDE_DIR=C:/hostedtoolcache/windows/Boost/1.75.0/x86_64/include
             -DWITH_EXAMPLE=TRUE
             -DWITH_RESQML2_2=TRUE
             -DWITH_DOTNET_WRAPPING=TRUE
@@ -175,6 +183,14 @@ jobs:
           workingDirectory: C:/Minizip-build
           cmakeArgs: --build . --config $(BuildType) --target INSTALL -- /verbosity:minimal
         
+      # Boost
+      # Use the boost_1_75_0-msvc-14.2-64.exe for Windows 2019
+      - powershell: |
+          $Url = "https://sourceforge.net/projects/boost/files/boost-binaries/1.75.0/boost_1_75_0-msvc-14.2-64.exe"
+          (New-Object System.Net.WebClient).DownloadFile($Url, "$env:TEMP\boost.exe")
+          Start-Process -Wait -FilePath "$env:TEMP\boost.exe" "/SILENT","/SP-","/SUPPRESSMSGBOXES","/DIR=C:\hostedtoolcache\windows\Boost\1.75.0\x86_64"  
+        displayName: 'Install Boost 1.75'
+        
       # AVRO
       - powershell: |
           Invoke-WebRequest https://mirroir.wptheme.fr/apache/avro/avro-1.10.1/cpp/avro-cpp-1.10.1.tar.gz -OutFile $(Agent.TempDirectory)/avro-cpp-1.10.1.tar.gz
@@ -194,7 +210,7 @@ jobs:
             $(Build.SourcesDirectory)/avro-cpp-1.10.1
             $(Generator)
             -Wno-dev -Wno-deprecated
-            -DBoost_INCLUDE_DIR=$(BOOST_ROOT_1_72_0)/include
+            -DBoost_INCLUDE_DIR=C:/hostedtoolcache/windows/Boost/1.75.0/x86_64/include
             -DCMAKE_INSTALL_PREFIX=$(Agent.TempDirectory)/avro-cpp-1.10.1-install
       - task: CMake@1
         displayName: "CMake build AVRO --config $(BuildType)"
@@ -227,7 +243,7 @@ jobs:
             -DZLIB_INCLUDE_DIR=C:/hdf5-1.12.0-win64-vs2019/include
             -DZLIB_LIBRARY_RELEASE=C:/hdf5-1.12.0-win64-vs2019/lib/zlib.lib
             -DSZIP_LIBRARY_RELEASE=C:/hdf5-1.12.0-win64-vs2019/lib/szip.lib
-            -DBoost_INCLUDE_DIR=$(BOOST_ROOT_1_72_0)/include
+            -DBoost_INCLUDE_DIR=C:/hostedtoolcache/windows/Boost/1.75.0/x86_64/include
             -DAVRO_INCLUDE_DIR=$(Agent.TempDirectory)/avro-cpp-1.10.1-install/include
             -DAVRO_LIBRARY_RELEASE=$(Agent.TempDirectory)/avro-cpp-1.10.1-install/lib/avrocpp_s.lib
             -DWITH_EXAMPLE=TRUE
@@ -292,13 +308,13 @@ jobs:
         displayName: 'Unit test'
 
   - job:
-    displayName: Ubuntu 16.04 with Python3 wrappers
+    displayName: Ubuntu 20.04 with Python3 wrappers
     pool:
-      vmImage: 'ubuntu-16.04'
+      vmImage: 'ubuntu-20.04'
     timeoutInMinutes: 120
     steps:
       - script: |
-          sudo apt install -y libhdf5-dev libminizip-dev
+          sudo apt install -y libhdf5-dev libminizip-dev libboost-all-dev
         displayName: 'APT install'
 
       - task: CMake@1

--- a/etpClientExample/CMakeLists.txt
+++ b/etpClientExample/CMakeLists.txt
@@ -32,23 +32,6 @@ if (WIN32)
 	source_group ("src" FILES ${ALL_CPP_FILES} ${ALL_H_FILES})
 endif (WIN32)
 
-if (WITH_ETP_SSL)
-	file (GLOB SSL_CPP_FILES ${CMAKE_CURRENT_SOURCE_DIR}/ssl/*.cpp)
-	set (ALL_CPP_FILES
-		${ALL_CPP_FILES}
-		${SSL_CPP_FILES}
-	)
-	if (WIN32)
-		file (GLOB SSL_H_FILES ${CMAKE_CURRENT_SOURCE_DIR}/ssl/*.h)
-		
-		set (ALL_H_FILES
-			${ALL_H_FILES}
-			${SSL_H_FILES}
-		)
-		source_group ("src\\ssl" FILES ${SSL_CPP_FILES} ${SSL_H_FILES})
-	endif (WIN32)
-endif ()
-
 target_sources(etpClientExample PRIVATE ${ALL_CPP_FILES} ${ALL_H_FILES})
 
 target_compile_definitions(etpClientExample PRIVATE BOOST_ALL_NO_LIB)

--- a/python/src/etp_client_example.py
+++ b/python/src/etp_client_example.py
@@ -16,7 +16,7 @@ import my_own_client_core_handlers
 import my_own_discovery_protocol_handlers
 import my_own_store_protocol_handlers
 
-session = fesapi.createClientSession("127.0.0.1", "8080", "/", "")
+session = fesapi.createWsClientSession("127.0.0.1", "8080", "/", "")
 session.setCoreProtocolHandlers(my_own_client_core_handlers.MyOwnClientCoreHandlers(session))
 session.setDiscoveryProtocolHandlers(my_own_discovery_protocol_handlers.MyOwnDiscoveryProtocolHandlers(session))
 session.setStoreProtocolHandlers(my_own_store_protocol_handlers.MyOwnStoreProtocolHandlers(session))

--- a/src/common/DataObjectReference.cpp
+++ b/src/common/DataObjectReference.cpp
@@ -39,3 +39,34 @@ DataObjectReference::DataObjectReference(AbstractObject const * dataObj)
 		dor23 = dataObj->newEml23Reference();
 	}
 }
+
+gsoap_resqml2_0_1::eml20__DataObjectReference* DataObjectReference::toDor20() const {
+	if (dor20 != nullptr) {
+		return dor20;
+	}
+
+	gsoap_resqml2_0_1::eml20__DataObjectReference* result = nullptr;
+	if (dor21 != nullptr) {
+		result = gsoap_resqml2_0_1::soap_new_eml20__DataObjectReference(dor21->soap);
+	}
+	else if (dor22 != nullptr) {
+		result = gsoap_resqml2_0_1::soap_new_eml20__DataObjectReference(dor22->soap);
+	}
+	else if (dor23 != nullptr) {
+		result = gsoap_resqml2_0_1::soap_new_eml20__DataObjectReference(dor23->soap);
+	}
+	else {
+		throw std::logic_error("The instance is in an inconsistent state.");
+	}
+
+	result->ContentType = getContentType();
+	result->Title = getTitle();
+	result->UUID = getUuid();
+	const std::string version = getVersion();
+	if (!version.empty()) {
+		result->VersionString = gsoap_resqml2_0_1::soap_new_std__string(result->soap);
+		result->VersionString->assign(version);
+	}
+
+	return result;
+}

--- a/src/common/DataObjectReference.h
+++ b/src/common/DataObjectReference.h
@@ -191,36 +191,7 @@ namespace COMMON_NS
 		*
 		* @returns A potentially new EML2.0 DataObjectReference corresponding to this instance. Do not delete it.
 		*/
-		gsoap_resqml2_0_1::eml20__DataObjectReference* toDor20() const {
-			if (dor20 != nullptr) {
-				return dor20;
-			}
-
-			gsoap_resqml2_0_1::eml20__DataObjectReference* result = nullptr;
-			if (dor21 != nullptr) {
-				result = gsoap_resqml2_0_1::soap_new_eml20__DataObjectReference(dor21->soap);
-			}
-			else if (dor22 != nullptr) {
-				result = gsoap_resqml2_0_1::soap_new_eml20__DataObjectReference(dor22->soap);
-			}
-			else if (dor23 != nullptr) {
-				result = gsoap_resqml2_0_1::soap_new_eml20__DataObjectReference(dor23->soap);
-			}
-			else {
-				throw std::logic_error("The instance is in an inconsistent state.");
-			}
-			
-			result->ContentType = getContentType();
-			result->Title = getTitle();
-			result->UUID = getUuid();
-			const std::string version = getVersion();
-			if (!version.empty()) {
-				result->VersionString = gsoap_resqml2_0_1::soap_new_std__string(result->soap);
-				result->VersionString->assign(version);
-			}
-
-			return result;
-		}
+		DLL_IMPORT_OR_EXPORT gsoap_resqml2_0_1::eml20__DataObjectReference* toDor20() const;
 
 	private :
 		gsoap_resqml2_0_1::eml20__DataObjectReference* dor20;

--- a/src/etp/Server.h
+++ b/src/etp/Server.h
@@ -27,6 +27,7 @@ under the License.
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/signal_set.hpp>
 #include <boost/asio/strand.hpp>
+#include <boost/asio/bind_executor.hpp>
 #ifdef WITH_ETP_SSL
 #include <boost/asio/ssl.hpp>
 #endif

--- a/src/etp/Server.h
+++ b/src/etp/Server.h
@@ -201,11 +201,11 @@ namespace ETP_NS
 			*/
 
 		while (path.find("//") != std::string::npos) {
-			path = std::regex_replace(path, std::regex("//"), "/");
+			path = std::regex_replace(path, std::regex("//"), std::string("/"));
 		}
 		while (path.find("\\\\") != std::string::npos) {
 			// See https://stackoverflow.com/questions/4025482/cant-escape-the-backslash-with-regex
-			path = std::regex_replace(path, std::regex("\\\\\\\\"), "\\");
+			path = std::regex_replace(path, std::regex("\\\\\\\\"), std::string("\\"));
 		}
 
 		if (path == "./.well-known/etp-server-capabilities" ||

--- a/swig/swigEtp1_2Include.i
+++ b/swig/swigEtp1_2Include.i
@@ -1317,7 +1317,7 @@ namespace ETP_NS
 
 	namespace ClientSessionLaunchers
 	{
-		std::shared_ptr<ETP_NS::PlainClientSession> createClientSession(const std::string & host, const std::string & port, const std::string & target, const std::string & authorization);
+		std::shared_ptr<ETP_NS::PlainClientSession> createWsClientSession(const std::string & host, const std::string & port, const std::string & target, const std::string & authorization);
 	}
 	
 	/******************* SERVER ***************************/
@@ -1350,12 +1350,11 @@ namespace ETP_NS
 	public:
 	};
 
-	template <class T>
 	class Server
 	{
 	public:
 		Server(ServerInitializationParameters* serverInitializationParams) : serverInitializationParams_(serverInitializationParams) {}
-		std::vector< std::shared_ptr<T> >& getSessions() { return sessions_; }
+		std::vector< std::shared_ptr<AbstractSession> >& getSessions() { return sessions_; }
 		void listen(const std::string & host, unsigned short port, int threadCount);
 	};
 	%template(PlainServer) ETP_NS::Server<ETP_NS::PlainServerSession>;

--- a/swig/swigEtp1_2Include.i
+++ b/swig/swigEtp1_2Include.i
@@ -1357,6 +1357,5 @@ namespace ETP_NS
 		std::vector< std::shared_ptr<AbstractSession> >& getSessions() { return sessions_; }
 		void listen(const std::string & host, unsigned short port, int threadCount);
 	};
-	%template(PlainServer) ETP_NS::Server<ETP_NS::PlainServerSession>;
 
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- Moving DataObjectReference::toDor20() definition in .cpp
- Fix regex_replace call and missing include directive in etp\Server.h
- Fix createWsClientSession method naming issue in both Python ETP client example and SWIG interface
- Remove template from Server class in Swig interface
- Removing unused ETP (ssl)-related CMake directives 

Does this close any currently open issues?
------------------------------------------
No.

Any relevant logs, error output, etc?
-------------------------------------
No.

Any other comments?
-------------------
No.

Where has this been tested?
---------------------------
**Operating System:** Windows 10 64bits

**Platform:** Visual Studio Community 2019
