### PR TITLE
Remove untested support of zip/epc password

### DIFF
--- a/src/epc/Package.h
+++ b/src/epc/Package.h
@@ -234,7 +234,7 @@ namespace epc
 		 *
 		 * @returns	The extracted file.
 		 */
-		std::string extractFile(const std::string & filename, const std::string & password = "");
+		std::string extractFile(const std::string & filename);
 
 		/** Writes the package */
 		void writePackage();


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
EPC package allows to unzip EPC protected with a password but it is never used and never tested.
This PR removes this capability for now.

Does this close any currently open issues?
------------------------------------------
No

Where has this been tested?
---------------------------
**Operating System:** Win10 64

**Platform:** VS2017 64
