### PR TITLE
Use Boost for UUID regular expression check when needed

### DIFF
--- a/src/common/AbstractObject.cpp
+++ b/src/common/AbstractObject.cpp
@@ -25,6 +25,8 @@ under the License.
 #include <sstream>
 #if (defined(_WIN32) || (defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 9))))
 #include <regex>
+#else
+#include <boost/regex.hpp>
 #endif
 #include <algorithm>
 
@@ -357,7 +359,11 @@ void AbstractObject::setUuid(const std::string & uuid)
 #if (defined(_WIN32) || (defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 9))))
 		if (!regex_match(uuid, regex("[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"))) {
 			throw invalid_argument("The uuid does not match the official uuid regular expression : " + uuid);
-	}
+		}
+#else // https://stackoverflow.com/questions/12530406/is-gcc-4-8-or-earlier-buggy-about-regular-expressions
+		if (!boost::regex_match(uuid, regex("[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"))) {
+			throw invalid_argument("The uuid does not match the official uuid regular expression : " + uuid);
+		}
 #endif
 		if (gsoapProxy2_0_1 != nullptr) { gsoapProxy2_0_1->uuid = uuid; }
 		else if (gsoapProxy2_1 != nullptr) { gsoapProxy2_1->uuid = uuid; }

--- a/test/unitTest.cpp
+++ b/test/unitTest.cpp
@@ -134,6 +134,12 @@ TEST_CASE("Export and import an empty EPC document", "[epc]")
 	testOut.deserialize();	
 }
 
+TEST_CASE("Set a wrong UUID", "[UUID]")
+{
+	COMMON_NS::DataObjectRepository repo;
+	REQUIRE_THROWS(repo.createBoundaryFeature("My non standard UUID", "MyTitle"));
+}
+
 TEST_CASE("Test hdf5 opening mode", "[hdf]")
 {
 	std::remove("../../testingFile.h5");


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
CentOS 7 comes with a GCC which does not support std regex : https://stackoverflow.com/questions/12530406/is-gcc-4-8-or-earlier-buggy-about-regular-expressions
The idea is to use Boost regex instead in such cases.

Does this close any currently open issues?
------------------------------------------
Fix #174 

Where has this been tested?
---------------------------
**Operating System:** Win10 64

**Platform:** VS2017 64
