### PR TITLE
add flag to set MPI IO collective or back to default (independent)

### DIFF
--- a/src/eml2/HdfProxy.cpp
+++ b/src/eml2/HdfProxy.cpp
@@ -235,8 +235,8 @@ void HdfProxy::close()
 
 	if (hdfFile > -1) {
 
-		if(dsetPlistId != H5P_DEFAULT)
-			H5Pclose(dsetPlistId);
+		if(dsetPlistId)
+			H5Pclose(*dsetPlistId);
 		H5Fclose(hdfFile);
 		hdfFile = -1;
 	}
@@ -750,7 +750,7 @@ void HdfProxy::writeArrayNdSlab(
 	if (H5Tequal(hdf5Datatype, datatypeOfDataset) <= 0) {
 		throw invalid_argument("The given datatype for the slab is not compatible with the datatype of the dataset.");
 	}
-	errorCode = H5Dwrite(dataset, hdf5Datatype, memspace, filespace, dsetPlistId, values);
+	errorCode = H5Dwrite(dataset, hdf5Datatype, memspace, filespace, dsetPlistId ? *dsetPlistId : H5P_DEFAULT, values);
 
 	H5Sclose(memspace);
 	H5Sclose(filespace);

--- a/src/eml2/HdfProxy.cpp
+++ b/src/eml2/HdfProxy.cpp
@@ -234,6 +234,9 @@ void HdfProxy::close()
 	openedGroups.clear();
 
 	if (hdfFile > -1) {
+
+		if(dsetPlistId != H5P_DEFAULT)
+			H5Pclose(dsetPlistId);
 		H5Fclose(hdfFile);
 		hdfFile = -1;
 	}
@@ -747,7 +750,7 @@ void HdfProxy::writeArrayNdSlab(
 	if (H5Tequal(hdf5Datatype, datatypeOfDataset) <= 0) {
 		throw invalid_argument("The given datatype for the slab is not compatible with the datatype of the dataset.");
 	}
-	errorCode = H5Dwrite(dataset, hdf5Datatype, memspace, filespace, H5P_DEFAULT, values);
+	errorCode = H5Dwrite(dataset, hdf5Datatype, memspace, filespace, dsetPlistId, values);
 
 	H5Sclose(memspace);
 	H5Sclose(filespace);

--- a/src/eml2/HdfProxy.cpp
+++ b/src/eml2/HdfProxy.cpp
@@ -236,7 +236,10 @@ void HdfProxy::close()
 	if (hdfFile > -1) {
 
 		if(dsetPlistId)
+		{
 			H5Pclose(*dsetPlistId);
+			dsetPlistId.reset();
+		}
 		H5Fclose(hdfFile);
 		hdfFile = -1;
 	}

--- a/src/eml2/HdfProxy.h
+++ b/src/eml2/HdfProxy.h
@@ -362,6 +362,9 @@ namespace EML2_NS
 		/** The compression level used for writing data */
 		unsigned int compressionLevel = 0;
 
+		/** The dataset property list Id */
+		hdf5_hid_t dsetPlistId = 0; //properly should be H5P_DEFAULT
+
 		/** Groups which are currently opened where key is their path and value is their identifier */
 		std::unordered_map< std::string, hdf5_hid_t > openedGroups;
 	};

--- a/src/eml2/HdfProxy.h
+++ b/src/eml2/HdfProxy.h
@@ -363,7 +363,7 @@ namespace EML2_NS
 		unsigned int compressionLevel = 0;
 
 		/** The dataset property list Id */
-		hdf5_hid_t dsetPlistId = 0; //properly should be H5P_DEFAULT
+		std::unique_ptr<hdf5_hid_t> dsetPlistId;
 
 		/** Groups which are currently opened where key is their path and value is their identifier */
 		std::unordered_map< std::string, hdf5_hid_t > openedGroups;

--- a/src/eml2_0/HdfProxyMPI.cpp
+++ b/src/eml2_0/HdfProxyMPI.cpp
@@ -89,10 +89,7 @@ void HdfProxyMPI::open()
 	else {
 		throw invalid_argument("The HDF5 permission access is unknown.");
 	}
-
-	dsetPlistId.reset(new hid_t);
-	*dsetPlistId = H5Pcreate(H5P_DATASET_XFER);
-
+	
 	/* Release file-access template */
 	if (H5Pclose(fapl_id)) {
 		throw invalid_argument("Cannot release the parallel file-access template");
@@ -101,6 +98,12 @@ void HdfProxyMPI::open()
 
 void HdfProxyMPI::setCollectiveIO()
 {
+	if(!dsetPlistId)
+	{
+		dsetPlistId.reset(new hid_t);
+		*dsetPlistId = H5Pcreate(H5P_DATASET_XFER);
+	}
+	
 	if( H5Pset_dxpl_mpio( *dsetPlistId, H5FD_MPIO_COLLECTIVE) < 0)
 	{
 		throw invalid_argument("Can not set the collective IO flag");
@@ -108,7 +111,13 @@ void HdfProxyMPI::setCollectiveIO()
 }
 
 void HdfProxyMPI::setIndependentIO()
-{
+{	
+	if(!dsetPlistId)
+	{
+		dsetPlistId.reset(new hid_t);
+		*dsetPlistId = H5Pcreate(H5P_DATASET_XFER);
+	}
+
 	if( H5Pset_dxpl_mpio( *dsetPlistId, H5FD_MPIO_INDEPENDENT) < 0)
 	{
 		throw invalid_argument("Can not set the independent IO flag");

--- a/src/eml2_0/HdfProxyMPI.cpp
+++ b/src/eml2_0/HdfProxyMPI.cpp
@@ -90,7 +90,8 @@ void HdfProxyMPI::open()
 		throw invalid_argument("The HDF5 permission access is unknown.");
 	}
 
-	dsetPlistId = H5Pcreate(H5P_DATASET_XFER);
+	dsetPlistId.reset(new hid_t);
+	*dsetPlistId = H5Pcreate(H5P_DATASET_XFER);
 
 	/* Release file-access template */
 	if (H5Pclose(fapl_id)) {
@@ -100,7 +101,7 @@ void HdfProxyMPI::open()
 
 void HdfProxyMPI::setCollectiveIO()
 {
-	if( H5Pset_dxpl_mpio( dsetPlistId, H5FD_MPIO_COLLECTIVE) < 0)
+	if( H5Pset_dxpl_mpio( *dsetPlistId, H5FD_MPIO_COLLECTIVE) < 0)
 	{
 		throw invalid_argument("Can not set the collective IO flag");
 	}
@@ -108,7 +109,7 @@ void HdfProxyMPI::setCollectiveIO()
 
 void HdfProxyMPI::setIndependentIO()
 {
-	if( H5Pset_dxpl_mpio( dsetPlistId, H5FD_MPIO_INDEPENDENT) < 0)
+	if( H5Pset_dxpl_mpio( *dsetPlistId, H5FD_MPIO_INDEPENDENT) < 0)
 	{
 		throw invalid_argument("Can not set the independent IO flag");
 	}

--- a/src/eml2_0/HdfProxyMPI.cpp
+++ b/src/eml2_0/HdfProxyMPI.cpp
@@ -90,8 +90,26 @@ void HdfProxyMPI::open()
 		throw invalid_argument("The HDF5 permission access is unknown.");
 	}
 
+	dsetPlistId = H5Pcreate(H5P_DATASET_XFER);
+
 	/* Release file-access template */
 	if (H5Pclose(fapl_id)) {
 		throw invalid_argument("Cannot release the parallel file-access template");
+	}
+}
+
+void HdfProxyMPI::setCollectiveIO()
+{
+	if( H5Pset_dxpl_mpio( dsetPlistId, H5FD_MPIO_COLLECTIVE) < 0)
+	{
+		throw invalid_argument("Can not set the collective IO flag");
+	}
+}
+
+void HdfProxyMPI::setIndependentIO()
+{
+	if( H5Pset_dxpl_mpio( dsetPlistId, H5FD_MPIO_INDEPENDENT) < 0)
+	{
+		throw invalid_argument("Can not set the independent IO flag");
 	}
 }

--- a/src/eml2_0/HdfProxyMPI.h
+++ b/src/eml2_0/HdfProxyMPI.h
@@ -87,6 +87,17 @@ namespace EML2_0_NS
 		void setMPICommunicator(MPI_Comm communicator) { mpi_comm = communicator; }
 
 		/**
+		 * @brief Set IO to collective
+		 * @details necessary to write with compression enabled
+		 */
+		void setCollectiveIO();
+
+		/**
+		 * @brief Set IO to independent (default)
+		 */
+		void setIndependentIO();
+
+		/**
 		* The standard XML namespace for serializing this data object.
 		*/
 		DLL_IMPORT_OR_EXPORT static constexpr char const* XML_NS = "eml20";


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------
The collective flag allows to use compression with MPI IO

Does this close any currently open issues?
------------------------------------------
should close #332 

Any relevant logs, error output, etc?
-------------------------------------
n.a.

Any other comments?
-------------------
n.a.

Where has this been tested?
---------------------------
**Operating System:** …

**Platform:** …
