### PR TITLE
Compatibility fixed for zlib and minizip

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -12,7 +12,7 @@ jobs:
         shell: pwsh
         run: |
           # Download and extract
-          curl -L "https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz" -o "${{ runner.temp }}\zlib.tar.gz"
+          curl -L "https://github.com/madler/zlib/releases/download/v1.3.2/zlib-1.3.2.tar.gz" -o "${{ runner.temp }}\zlib.tar.gz"
           cd ${{ runner.temp }}
           tar -xzf zlib.tar.gz
           # Detect extracted folder (handles zlib-1.3.1 or future versions)
@@ -22,16 +22,7 @@ jobs:
           mkdir zlib-build
           cd zlib-build
           # Configure and install
-          cmake -G"Visual Studio 17 2022" -A x64 -T host=x64 -Wno-dev -Wno-deprecated -DCMAKE_INSTALL_PREFIX=${{ runner.temp }}/zlib-install $zlibSrc.FullName
-          cmake --build . --config Release -j2
-          cmake --build . --config Release --target INSTALL
-      - name: Minizip static lib install
-        run: |
-          git clone https://github.com/F2I-Consulting/Minizip.git ${{ runner.temp }}/Minizip
-          cd ${{ runner.temp }}
-          mkdir minizip-build
-          cd minizip-build
-          cmake -G"Visual Studio 17 2022" -A x64 -T host=x64 -Wno-dev -Wno-deprecated -DBUILD_SHARED_LIBS=FALSE -DZLIB_ROOT=${{ runner.temp }}/zlib-install -DZLIB_USE_STATIC_LIBS=TRUE -DCMAKE_INSTALL_PREFIX=${{ runner.temp }}/minizip-install ${{ runner.temp }}/Minizip
+          cmake -G"Visual Studio 17 2022" -A x64 -T host=x64 -Wno-dev -Wno-deprecated -DZLIB_BUILD_MINIZIP=ON -DZLIB_BUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=${{ runner.temp }}/zlib-install $zlibSrc.FullName
           cmake --build . --config Release -j2
           cmake --build . --config Release --target INSTALL
       - name: HDF5 install
@@ -41,7 +32,7 @@ jobs:
           Expand-Archive ${{ runner.temp }}\hdf5-2.0.0.zip -DestinationPath ${{ runner.temp }}
           mkdir hdf5-build
           cd hdf5-build
-          cmake -G"Visual Studio 17 2022" -A x64 -T host=x64 -Wno-dev -Wno-deprecated -DHDF5_ENABLE_ZLIB_SUPPORT:BOOL=ON -DZLIB_ROOT:PATH=${{ runner.temp }}/zlib-install -DZLIB_INCLUDE_DIR:PATH=${{ runner.temp }}/zlib-install/include -DZLIB_LIBRARY:PATH=${{ runner.temp }}/zlib-install/lib/zlibstatic.lib -DBUILD_SHARED_LIBS:BOOL=OFF -DHDF5_BUILD_FORTRAN:BOOL=OFF -DHDF5_BUILD_JAVA:BOOL=OFF -DHDF5_ENABLE_PARALLEL:BOOL=OFF -DHDF5_BUILD_CPP_LIB:BOOL=OFF -DHDF5_BUILD_HL_LIB:BOOL=OFF -DHDF5_BUILD_EXAMPLES:BOOL=OFF -DHDF5_BUILD_GENERATORS:BOOL=OFF -DHDF5_BUILD_TOOLS:BOOL=OFF -DHDF5_BUILD_UTILS:BOOL=OFF -DBUILD_TESTING:BOOL=OFF -DCMAKE_INSTALL_PREFIX=${{ runner.temp }}/hdf5-install ${{ runner.temp }}/hdf5-2.0.0
+          cmake -G"Visual Studio 17 2022" -A x64 -T host=x64 -Wno-dev -Wno-deprecated -DHDF5_ENABLE_ZLIB_SUPPORT:BOOL=ON -DZLIB_ROOT:PATH=${{ runner.temp }}/zlib-install -DZLIB_INCLUDE_DIR:PATH=${{ runner.temp }}/zlib-install/include -DZLIB_LIBRARY:PATH=${{ runner.temp }}/zlib-install/lib/zs.lib -DBUILD_SHARED_LIBS:BOOL=OFF -DHDF5_BUILD_FORTRAN:BOOL=OFF -DHDF5_BUILD_JAVA:BOOL=OFF -DHDF5_ENABLE_PARALLEL:BOOL=OFF -DHDF5_BUILD_CPP_LIB:BOOL=OFF -DHDF5_BUILD_HL_LIB:BOOL=OFF -DHDF5_BUILD_EXAMPLES:BOOL=OFF -DHDF5_BUILD_GENERATORS:BOOL=OFF -DHDF5_BUILD_TOOLS:BOOL=OFF -DHDF5_BUILD_UTILS:BOOL=OFF -DBUILD_TESTING:BOOL=OFF -DCMAKE_INSTALL_PREFIX=${{ runner.temp }}/hdf5-install ${{ runner.temp }}/hdf5-2.0.0
           cmake --build . --config Release -j2
           cmake --build . --config Release --target INSTALL
       - name: Boost install
@@ -57,7 +48,7 @@ jobs:
           cd ${{ github.workspace }}/..
           mkdir build
           cd build
-          cmake -G"Visual Studio 17 2022" -A x64 -T host=x64 -Wno-dev -Wno-deprecated -DHDF5_ROOT=${{ runner.temp }}/hdf5-install -DHDF5_USE_STATIC_LIBRARIES=TRUE -DMINIZIP_ROOT=${{ runner.temp }}/minizip-install -DZLIB_ROOT=${{ runner.temp }}/zlib-install -DZLIB_USE_STATIC_LIBS=TRUE -DBoost_INCLUDE_DIR=${{ runner.temp }}/boost-install -DWITH_EXAMPLE=TRUE -DWITH_RESQML2_2=TRUE -DWITH_DOTNET_WRAPPING=TRUE -DSWIG_EXECUTABLE=${{ runner.temp }}/swigwin-4.4.1/swig.exe -DCMAKE_INSTALL_PREFIX=${{ runner.temp }}/fesapi-install ${{ github.workspace }}
+          cmake -G"Visual Studio 17 2022" -A x64 -T host=x64 -Wno-dev -Wno-deprecated -DHDF5_ROOT=${{ runner.temp }}/hdf5-install -DHDF5_USE_STATIC_LIBRARIES=TRUE -DMINIZIP_ROOT=${{ runner.temp }}/zlib-install -DMINIZIP_USE_STATIC_LIBS=TRUE -DZLIB_ROOT=${{ runner.temp }}/zlib-install -DZLIB_USE_STATIC_LIBS=TRUE -DBoost_INCLUDE_DIR=${{ runner.temp }}/boost-install -DWITH_EXAMPLE=TRUE -DWITH_RESQML2_2=TRUE -DWITH_DOTNET_WRAPPING=TRUE -DSWIG_EXECUTABLE=${{ runner.temp }}/swigwin-4.4.1/swig.exe -DCMAKE_INSTALL_PREFIX=${{ runner.temp }}/fesapi-install ${{ github.workspace }}
           cmake --build . --config Release -j2
           cmake --build . --config Release --target INSTALL
       - name: Add msbuild to PATH
@@ -179,27 +170,33 @@ jobs:
           CIBW_BUILD: cp38-manylinux_* cp39-manylinux_* cp310-manylinux_* cp311-manylinux_* cp312-manylinux_* cp313-manylinux_*
           CIBW_ARCHS: auto64
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
-          CIBW_BEFORE_ALL: >
-            yum install -y wget gcc-c++ boost-devel &&
-            yum search epel-release &&
-            yum info epel-release &&
-            yum install -y epel-release &&
-            yum --enablerepo=epel install -y minizip1.2-devel cmake3 &&
-            wget --no-verbose https://support.hdfgroup.org/releases/hdf5/v2_0/v2_0_0/downloads/hdf5-2.0.0.tar.gz && 
-            tar -xzf hdf5-2.0.0.tar.gz &&
-            cd hdf5-2.0.0 &&
-            mkdir build &&
-            cd build &&
-            cmake -G "Unix Makefiles" -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DHDF5_ENABLE_ZLIB_SUPPORT:BOOL=ON -DBUILD_SHARED_LIBS:BOOL=OFF -DHDF5_BUILD_FORTRAN:BOOL=OFF -DHDF5_BUILD_JAVA:BOOL=OFF -DHDF5_ENABLE_PARALLEL:BOOL=OFF -DHDF5_BUILD_CPP_LIB:BOOL=OFF -DHDF5_BUILD_HL_LIB:BOOL=OFF -DHDF5_BUILD_EXAMPLES:BOOL=OFF -DHDF5_BUILD_GENERATORS:BOOL=OFF -DHDF5_BUILD_TOOLS:BOOL=OFF -DHDF5_BUILD_UTILS:BOOL=OFF -DBUILD_TESTING:BOOL=OFF -DCMAKE_INSTALL_PREFIX:STRING=${{ github.workspace }}/../hdf5-install .. &&
-            cmake --build . --config Release &&
-            make -j4 &&
-            make install &&
-            cd ../.. &&
-            mkdir build &&
-            cd build &&
-            cmake3 -DCMAKE_BUILD_TYPE=Release -DHDF5_ROOT=${{ github.workspace }}/../hdf5-install -DHDF5_USE_STATIC_LIBRARIES=TRUE -DWITH_PYTHON_WRAPPING=TRUE -DCMAKE_INSTALL_PREFIX:STRING=/fesapi-install {project} &&
-            cmake3 --build . -j2 --config Release &&
-            cmake3 --install .
+          CIBW_BEFORE_ALL: |
+            yum remove cmake
+            yum install -y wget gcc-c++ boost-devel
+            yum search epel-release
+            yum info epel-release
+            yum install -y epel-release
+            yum --enablerepo=epel install -y minizip1.2-devel
+            cd ${{ github.workspace }}/..
+            wget --no-verbose https://github.com/Kitware/CMake/releases/download/v4.3.2/cmake-4.3.2-linux-x86_64.tar.gz
+            tar -xzf cmake-4.3.2-linux-x86_64.tar.gz
+            export PATH=${{ github.workspace }}/../cmake-4.3.2-linux-x86_64/bin:$PATH
+            cmake --version  # Should cmake version
+            wget --no-verbose https://support.hdfgroup.org/releases/hdf5/v2_0/v2_0_0/downloads/hdf5-2.0.0.tar.gz 
+            tar -xzf hdf5-2.0.0.tar.gz
+            cd hdf5-2.0.0
+            mkdir build
+            cd build
+            cmake -G "Unix Makefiles" -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DHDF5_ENABLE_ZLIB_SUPPORT:BOOL=ON -DBUILD_SHARED_LIBS:BOOL=OFF -DHDF5_BUILD_FORTRAN:BOOL=OFF -DHDF5_BUILD_JAVA:BOOL=OFF -DHDF5_ENABLE_PARALLEL:BOOL=OFF -DHDF5_BUILD_CPP_LIB:BOOL=OFF -DHDF5_BUILD_HL_LIB:BOOL=OFF -DHDF5_BUILD_EXAMPLES:BOOL=OFF -DHDF5_BUILD_GENERATORS:BOOL=OFF -DHDF5_BUILD_TOOLS:BOOL=OFF -DHDF5_BUILD_UTILS:BOOL=OFF -DBUILD_TESTING:BOOL=OFF -DCMAKE_INSTALL_PREFIX:STRING=${{ github.workspace }}/../hdf5-install ..
+            cmake --build . --config Release
+            make -j4
+            make install
+            cd ../..
+            mkdir build
+            cd build
+            cmake -DCMAKE_BUILD_TYPE=Release -DHDF5_ROOT=${{ github.workspace }}/../hdf5-install -DHDF5_USE_STATIC_LIBRARIES=TRUE -DWITH_PYTHON_WRAPPING=TRUE -DCMAKE_INSTALL_PREFIX:STRING=/fesapi-install {project}
+            cmake --build . -j2 --config Release
+            cmake --install .
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: >
             export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/fesapi-install/lib64 &&
             auditwheel repair -w {dest_dir} {wheel}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
-cmake_minimum_required (VERSION 3.12)
+# The cmake/modules/FindZLIB.cmake relies on CMP0159 which is only available from CMAKE 3.29
+cmake_minimum_required (VERSION 3.29)
 
 project (Fesapi)
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ FESAPI uses cmake as its build tool. A 3.12 version or later of cmake is require
 		- ONLY IF YOU WANT TO LINK TO PARALLEL HDF5, set a cmake variable called HDF5_PREFER_PARALLEL to ON (and give a look to [example/exampleMPI.cpp](./example/exampleMPI.cpp))
 	- MINIZIP (using [our own cmake find module](./cmake/modules/FindMINIZIP.cmake))
 		- (ONLY IF NOT AUTOMATICALLY FOUND) MINIZIP_ROOT : The path to the folder containing include and lib folders of MINIZIP
+		- ONLY IF YOU WANT TO STATICALLY LINK TO MINIZIP, set a cmake variable called MINIZIP_USE_STATIC_LIBS to ON
 	- ZLIB (using [cmake find module](https://cmake.org/cmake/help/latest/module/FindZLIB.html))
 		- (ONLY IF NOT AUTOMATICALLY FOUND) ZLIB_ROOT : The path to the folder containing include and lib folders of ZLIB
 		- ONLY IF YOU WANT TO STATICALLY LINK TO ZLIB, set a cmake variable called ZLIB_USE_STATIC_LIBS to ON

--- a/cmake/modules/FindMINIZIP.cmake
+++ b/cmake/modules/FindMINIZIP.cmake
@@ -48,8 +48,13 @@ set(_MINIZIP_SEARCH_NORMAL
 unset(_MINIZIP_x86)
 list(APPEND _MINIZIP_SEARCHES _MINIZIP_SEARCH_NORMAL)
 
-set(MINIZIP_NAMES minizip minizips)
-set(MINIZIP_NAMES_DEBUG minizipd minizipsd minizip_d)
+if(MINIZIP_USE_STATIC_LIBS)
+	set(MINIZIP_NAMES minizips minizip)
+	set(MINIZIP_NAMES_DEBUG minizipsd minizipd minizip_d)
+else()
+	set(MINIZIP_NAMES minizip)
+	set(MINIZIP_NAMES_DEBUG minizipd minizip_d)
+endif()
 
 # Try each search configuration.
 foreach(search ${_MINIZIP_SEARCHES})

--- a/cmake/modules/FindMINIZIP.cmake
+++ b/cmake/modules/FindMINIZIP.cmake
@@ -48,8 +48,8 @@ set(_MINIZIP_SEARCH_NORMAL
 unset(_MINIZIP_x86)
 list(APPEND _MINIZIP_SEARCHES _MINIZIP_SEARCH_NORMAL)
 
-set(MINIZIP_NAMES minizip)
-set(MINIZIP_NAMES_DEBUG minizipd minizip_d)
+set(MINIZIP_NAMES minizip minizips)
+set(MINIZIP_NAMES_DEBUG minizipd minizipsd minizip_d)
 
 # Try each search configuration.
 foreach(search ${_MINIZIP_SEARCHES})

--- a/cmake/modules/FindZLIB.cmake
+++ b/cmake/modules/FindZLIB.cmake
@@ -1,0 +1,279 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file LICENSE.rst or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+FindZLIB
+--------
+
+Finds the native zlib data compression library:
+
+.. code-block:: cmake
+
+  find_package(ZLIB [<version>] [...])
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+This module provides the following :ref:`Imported Targets`:
+
+``ZLIB::ZLIB``
+  .. versionadded:: 3.1
+
+  Target that encapsulates the zlib usage requirements.  It is available only
+  when zlib is found.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This module defines the following variables:
+
+``ZLIB_FOUND``
+  Boolean indicating whether (the requested version of) zlib was found.
+
+``ZLIB_VERSION``
+  .. versionadded:: 3.26
+
+  The version of zlib found.
+
+``ZLIB_INCLUDE_DIRS``
+  Include directories containing ``zlib.h`` and other headers needed to use
+  zlib.
+
+``ZLIB_LIBRARIES``
+  List of libraries needed to link to zlib.
+
+  .. versionchanged:: 3.4
+    Debug and Release library variants can be now found separately.
+
+Hints
+^^^^^
+
+This module accepts the following variables:
+
+``ZLIB_ROOT``
+  A user may set this variable to a zlib installation root to help locate zlib
+  in custom installation paths.
+
+``ZLIB_USE_STATIC_LIBS``
+  .. versionadded:: 3.24
+
+  Set this variable to ``ON`` before calling ``find_package(ZLIB)`` to look for
+  static libraries.  Default is ``OFF``.
+
+Deprecated Variables
+^^^^^^^^^^^^^^^^^^^^
+
+The following variables are provided for backward compatibility:
+
+``ZLIB_VERSION_MAJOR``
+  .. deprecated:: 3.26
+    Superseded by ``ZLIB_VERSION``.
+
+  The major version of zlib.
+
+``ZLIB_VERSION_MINOR``
+  .. deprecated:: 3.26
+    Superseded by ``ZLIB_VERSION``.
+
+  The minor version of zlib.
+
+``ZLIB_VERSION_PATCH``
+  .. deprecated:: 3.26
+    Superseded by ``ZLIB_VERSION``.
+
+  The patch version of zlib.
+
+``ZLIB_VERSION_TWEAK``
+  .. deprecated:: 3.26
+    Superseded by ``ZLIB_VERSION``.
+
+  The tweak version of zlib.
+
+``ZLIB_VERSION_STRING``
+  .. deprecated:: 3.26
+    Superseded by ``ZLIB_VERSION``.
+
+  The version of zlib found (x.y.z).
+
+``ZLIB_MAJOR_VERSION``
+  .. deprecated:: 3.26
+    Superseded by ``ZLIB_VERSION``.
+
+  The major version of zlib.
+
+``ZLIB_MINOR_VERSION``
+  .. deprecated:: 3.26
+    Superseded by ``ZLIB_VERSION``.
+
+  The minor version of zlib.
+
+``ZLIB_PATCH_VERSION``
+  .. deprecated:: 3.26
+    Superseded by ``ZLIB_VERSION``.
+
+  The patch version of zlib.
+
+Examples
+^^^^^^^^
+
+Finding zlib and linking it to a project target:
+
+.. code-block:: cmake
+
+  find_package(ZLIB)
+  target_link_libraries(project_target PRIVATE ZLIB::ZLIB)
+#]=======================================================================]
+
+cmake_policy(PUSH)
+cmake_policy(SET CMP0159 NEW) # file(STRINGS) with REGEX updates CMAKE_MATCH_<n>
+
+if(ZLIB_FIND_COMPONENTS AND NOT ZLIB_FIND_QUIETLY)
+  message(AUTHOR_WARNING
+    "ZLIB does not provide any COMPONENTS.  Calling\n"
+    "  find_package(ZLIB COMPONENTS ...)\n"
+    "will always fail."
+    )
+endif()
+
+set(_ZLIB_SEARCHES)
+
+# Search ZLIB_ROOT first if it is set.
+if(ZLIB_ROOT)
+  set(_ZLIB_SEARCH_ROOT PATHS ${ZLIB_ROOT} NO_DEFAULT_PATH)
+  list(APPEND _ZLIB_SEARCHES _ZLIB_SEARCH_ROOT)
+endif()
+
+# Normal search.
+set(_ZLIB_x86 "(x86)")
+set(_ZLIB_SEARCH_NORMAL
+    PATHS "[HKEY_LOCAL_MACHINE\\SOFTWARE\\GnuWin32\\Zlib;InstallPath]"
+          "$ENV{ProgramFiles}/zlib"
+          "$ENV{ProgramFiles${_ZLIB_x86}}/zlib")
+unset(_ZLIB_x86)
+list(APPEND _ZLIB_SEARCHES _ZLIB_SEARCH_NORMAL)
+
+if(ZLIB_USE_STATIC_LIBS)
+  set(ZLIB_NAMES zs zlibstatic zlibstat zlib z)
+  set(ZLIB_NAMES_DEBUG zsd zlibstaticd zlibstatd zlibd zd)
+else()
+  set(ZLIB_NAMES z zlib zdll zlib1 zlibstatic zlibwapi zlibvc zlibstat)
+  set(ZLIB_NAMES_DEBUG zd zlibd zdlld zlibd1 zlib1d zlibstaticd zlibwapid zlibvcd zlibstatd)
+endif()
+
+# Try each search configuration.
+foreach(search ${_ZLIB_SEARCHES})
+  find_path(ZLIB_INCLUDE_DIR NAMES zlib.h ${${search}} PATH_SUFFIXES include)
+endforeach()
+
+# Allow ZLIB_LIBRARY to be set manually, as the location of the zlib library
+if(NOT ZLIB_LIBRARY)
+  if(DEFINED CMAKE_FIND_LIBRARY_PREFIXES)
+    set(_zlib_ORIG_CMAKE_FIND_LIBRARY_PREFIXES "${CMAKE_FIND_LIBRARY_PREFIXES}")
+  else()
+    set(_zlib_ORIG_CMAKE_FIND_LIBRARY_PREFIXES)
+  endif()
+  if(DEFINED CMAKE_FIND_LIBRARY_SUFFIXES)
+    set(_zlib_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES "${CMAKE_FIND_LIBRARY_SUFFIXES}")
+  else()
+    set(_zlib_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES)
+  endif()
+  # Prefix/suffix of the win32/Makefile.gcc build
+  if(WIN32)
+    list(APPEND CMAKE_FIND_LIBRARY_PREFIXES "" "lib")
+    list(APPEND CMAKE_FIND_LIBRARY_SUFFIXES ".dll.a")
+  endif()
+  # Support preference of static libs by adjusting CMAKE_FIND_LIBRARY_SUFFIXES
+  if(ZLIB_USE_STATIC_LIBS)
+    if(WIN32)
+      set(CMAKE_FIND_LIBRARY_SUFFIXES .lib .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
+    else()
+      set(CMAKE_FIND_LIBRARY_SUFFIXES .a)
+    endif()
+  endif()
+
+  foreach(search ${_ZLIB_SEARCHES})
+    find_library(ZLIB_LIBRARY_RELEASE NAMES ${ZLIB_NAMES} NAMES_PER_DIR ${${search}} PATH_SUFFIXES lib)
+    find_library(ZLIB_LIBRARY_DEBUG NAMES ${ZLIB_NAMES_DEBUG} NAMES_PER_DIR ${${search}} PATH_SUFFIXES lib)
+  endforeach()
+
+  # Restore the original find library ordering
+  if(DEFINED _zlib_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES "${_zlib_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES}")
+  else()
+    set(CMAKE_FIND_LIBRARY_SUFFIXES)
+  endif()
+  if(DEFINED _zlib_ORIG_CMAKE_FIND_LIBRARY_PREFIXES)
+    set(CMAKE_FIND_LIBRARY_PREFIXES "${_zlib_ORIG_CMAKE_FIND_LIBRARY_PREFIXES}")
+  else()
+    set(CMAKE_FIND_LIBRARY_PREFIXES)
+  endif()
+
+  include(${CMAKE_ROOT}/Modules/SelectLibraryConfigurations.cmake)
+  select_library_configurations(ZLIB)
+endif()
+
+unset(ZLIB_NAMES)
+unset(ZLIB_NAMES_DEBUG)
+
+mark_as_advanced(ZLIB_INCLUDE_DIR)
+
+if(ZLIB_INCLUDE_DIR AND EXISTS "${ZLIB_INCLUDE_DIR}/zlib.h")
+  file(STRINGS "${ZLIB_INCLUDE_DIR}/zlib.h" ZLIB_H REGEX "^#define ZLIB_VERSION \"[^\"]*\"$")
+  if(ZLIB_H MATCHES "ZLIB_VERSION \"(([0-9]+)\\.([0-9]+)(\\.([0-9]+)(\\.([0-9]+))?)?)")
+    set(ZLIB_VERSION_STRING "${CMAKE_MATCH_1}")
+    set(ZLIB_VERSION_MAJOR "${CMAKE_MATCH_2}")
+    set(ZLIB_VERSION_MINOR "${CMAKE_MATCH_3}")
+    set(ZLIB_VERSION_PATCH "${CMAKE_MATCH_5}")
+    set(ZLIB_VERSION_TWEAK "${CMAKE_MATCH_7}")
+  else()
+    set(ZLIB_VERSION_STRING "")
+    set(ZLIB_VERSION_MAJOR "")
+    set(ZLIB_VERSION_MINOR "")
+    set(ZLIB_VERSION_PATCH "")
+    set(ZLIB_VERSION_TWEAK "")
+  endif()
+  set(ZLIB_MAJOR_VERSION "${ZLIB_VERSION_MAJOR}")
+  set(ZLIB_MINOR_VERSION "${ZLIB_VERSION_MINOR}")
+  set(ZLIB_PATCH_VERSION "${ZLIB_VERSION_PATCH}")
+  set(ZLIB_VERSION "${ZLIB_VERSION_STRING}")
+endif()
+
+include("${CMAKE_ROOT}/Modules/FindPackageHandleStandardArgs.cmake")
+find_package_handle_standard_args(ZLIB REQUIRED_VARS ZLIB_LIBRARY ZLIB_INCLUDE_DIR
+                                       VERSION_VAR ZLIB_VERSION
+                                       HANDLE_COMPONENTS)
+
+if(ZLIB_FOUND)
+    set(ZLIB_INCLUDE_DIRS ${ZLIB_INCLUDE_DIR})
+
+    if(NOT ZLIB_LIBRARIES)
+      set(ZLIB_LIBRARIES ${ZLIB_LIBRARY})
+    endif()
+
+    if(NOT TARGET ZLIB::ZLIB)
+      add_library(ZLIB::ZLIB UNKNOWN IMPORTED)
+      set_target_properties(ZLIB::ZLIB PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${ZLIB_INCLUDE_DIRS}")
+
+      if(ZLIB_LIBRARY_RELEASE)
+        set_property(TARGET ZLIB::ZLIB APPEND PROPERTY
+          IMPORTED_CONFIGURATIONS RELEASE)
+        set_target_properties(ZLIB::ZLIB PROPERTIES
+          IMPORTED_LOCATION_RELEASE "${ZLIB_LIBRARY_RELEASE}")
+      endif()
+
+      if(ZLIB_LIBRARY_DEBUG)
+        set_property(TARGET ZLIB::ZLIB APPEND PROPERTY
+          IMPORTED_CONFIGURATIONS DEBUG)
+        set_target_properties(ZLIB::ZLIB PROPERTIES
+          IMPORTED_LOCATION_DEBUG "${ZLIB_LIBRARY_DEBUG}")
+      endif()
+
+      if(NOT ZLIB_LIBRARY_RELEASE AND NOT ZLIB_LIBRARY_DEBUG)
+        set_property(TARGET ZLIB::ZLIB APPEND PROPERTY
+          IMPORTED_LOCATION "${ZLIB_LIBRARY}")
+      endif()
+    endif()
+endif()
+
+cmake_policy(POP)

--- a/src/epc/Package.cpp
+++ b/src/epc/Package.cpp
@@ -37,7 +37,7 @@ under the License.
 #include <zip.h>
 #include <unzip.h>
 #ifdef _WIN32
-#include <iowin32.h>
+#include "../tools/iowin32.h"
 #endif
 
 #include "FilePart.h"

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -1,6 +1,8 @@
 
-set(FESAPI_TOOLS_SOURCES 	${CMAKE_CURRENT_SOURCE_DIR}/tools/TimeTools.cpp )
+set(FESAPI_TOOLS_SOURCES 	${CMAKE_CURRENT_SOURCE_DIR}/tools/TimeTools.cpp
+							$<$<BOOL:${WIN32}>:${CMAKE_CURRENT_SOURCE_DIR}/tools/iowin32.c> )
 set(FESAPI_TOOLS_HEADERS 	${CMAKE_CURRENT_SOURCE_DIR}/tools/date.h
 							${CMAKE_CURRENT_SOURCE_DIR}/tools/Statistics.h
 							${CMAKE_CURRENT_SOURCE_DIR}/tools/TimeTools.h
-							${CMAKE_CURRENT_SOURCE_DIR}/tools/Trigonometry.h )
+							${CMAKE_CURRENT_SOURCE_DIR}/tools/Trigonometry.h
+							$<$<BOOL:${WIN32}>:${CMAKE_CURRENT_SOURCE_DIR}/tools/iowin32.h> )

--- a/src/tools/MiniZip64_info.txt
+++ b/src/tools/MiniZip64_info.txt
@@ -1,0 +1,69 @@
+MiniZip - Copyright (c) 1998-2026 - by Gilles Vollant - version 1.1 64 bits from Mathias Svensson
+
+Introduction
+---------------------
+MiniZip 1.1 is built from MiniZip 1.0 by Gilles Vollant ( https://www.winimage.com/zLibDll/minizip.html )
+
+When adding ZIP64 support into minizip it would result into risk of breaking compatibility with minizip 1.0.
+All possible work was done for compatibility.
+
+
+Background
+---------------------
+When adding ZIP64 support Mathias Svensson found that Even Rouault have added ZIP64 
+support for unzip.c into minizip for a open source project called gdal ( https://www.gdal.org/ )
+
+That was used as a starting point. And after that ZIP64 support was added to zip.c
+some refactoring and code cleanup was also done.
+
+
+Changed from MiniZip 1.0 to MiniZip 1.1
+---------------------------------------
+* Added ZIP64 support for unzip ( by Even Rouault )
+* Added ZIP64 support for zip ( by Mathias Svensson )
+* Reverted some changed that Even Rouault did.
+* Bunch of patches received from Gulles Vollant that he received for MiniZip from various users.
+* Added unzip patch for BZIP Compression method (patch create by Daniel Borca)
+* Added BZIP Compress method for zip
+* Did some refactoring and code cleanup
+
+
+Credits
+
+ Gilles Vollant    - Original MiniZip author
+ Even Rouault      - ZIP64 unzip Support
+ Daniel Borca      - BZip Compression method support in unzip
+ Mathias Svensson  - ZIP64 zip support
+ Mathias Svensson  - BZip Compression method support in zip
+
+ Resource
+
+ ZIP App Note  https://www.pkware.com/documents/casestudies/APPNOTE.TXT
+               Zip File specification
+
+
+Notes.
+ * To be able to use BZip compression method in zip64.c or unzip64.c the BZIP2 lib is needed and HAVE_BZIP2 need to be defined.
+
+License
+----------------------------------------------------------
+   Condition of use and distribution are the same than zlib :
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+----------------------------------------------------------
+

--- a/src/tools/iowin32.c
+++ b/src/tools/iowin32.c
@@ -1,0 +1,447 @@
+/* iowin32.c -- IO base function header for compress/uncompress .zip
+     part of the MiniZip project - ( https://www.winimage.com/zLibDll/minizip.html )
+
+         Copyright (C) 1998-2026 Gilles Vollant (minizip) ( https://www.winimage.com/zLibDll/minizip.html )
+
+         Modifications for Zip64 support
+         Copyright (C) 2009-2010 Mathias Svensson ( https://result42.com )
+
+     For more info read MiniZip_info.txt
+
+*/
+
+#include <stdlib.h>
+
+#include "zlib.h"
+#include "ioapi.h"
+#include "iowin32.h"
+
+#ifndef INVALID_HANDLE_VALUE
+#define INVALID_HANDLE_VALUE (0xFFFFFFFF)
+#endif
+
+#ifndef INVALID_SET_FILE_POINTER
+#define INVALID_SET_FILE_POINTER ((DWORD)-1)
+#endif
+
+
+/* see Include/shared/winapifamily.h in the Windows Kit */
+#if defined(WINAPI_FAMILY_PARTITION) && (!(defined(IOWIN32_USING_WINRT_API)))
+
+#if !defined(WINAPI_FAMILY_ONE_PARTITION)
+#define WINAPI_FAMILY_ONE_PARTITION(PartitionSet, Partition) ((WINAPI_FAMILY & PartitionSet) == Partition)
+#endif
+
+#if WINAPI_FAMILY_ONE_PARTITION(WINAPI_FAMILY, WINAPI_PARTITION_APP)
+#define IOWIN32_USING_WINRT_API 1
+#endif
+#endif
+
+typedef struct
+{
+    HANDLE hf;
+    int error;
+} WIN32FILE_IOWIN;
+
+
+static void win32_translate_open_mode(int mode,
+                                      DWORD* lpdwDesiredAccess,
+                                      DWORD* lpdwCreationDisposition,
+                                      DWORD* lpdwShareMode,
+                                      DWORD* lpdwFlagsAndAttributes) {
+    *lpdwDesiredAccess = *lpdwShareMode = *lpdwFlagsAndAttributes = *lpdwCreationDisposition = 0;
+
+    if ((mode & ZLIB_FILEFUNC_MODE_READWRITEFILTER)==ZLIB_FILEFUNC_MODE_READ)
+    {
+        *lpdwDesiredAccess = GENERIC_READ;
+        *lpdwCreationDisposition = OPEN_EXISTING;
+        *lpdwShareMode = FILE_SHARE_READ;
+    }
+    else if (mode & ZLIB_FILEFUNC_MODE_EXISTING)
+    {
+        *lpdwDesiredAccess = GENERIC_WRITE | GENERIC_READ;
+        *lpdwCreationDisposition = OPEN_EXISTING;
+    }
+    else if (mode & ZLIB_FILEFUNC_MODE_CREATE)
+    {
+        *lpdwDesiredAccess = GENERIC_WRITE | GENERIC_READ;
+        *lpdwCreationDisposition = CREATE_ALWAYS;
+    }
+}
+
+static voidpf win32_build_iowin(HANDLE hFile) {
+    voidpf ret=NULL;
+
+    if ((hFile != NULL) && (hFile != INVALID_HANDLE_VALUE))
+    {
+        WIN32FILE_IOWIN w32fiow;
+        w32fiow.hf = hFile;
+        w32fiow.error = 0;
+        ret = malloc(sizeof(WIN32FILE_IOWIN));
+
+        if (ret==NULL)
+            CloseHandle(hFile);
+        else
+            *((WIN32FILE_IOWIN*)ret) = w32fiow;
+    }
+    return ret;
+}
+
+voidpf ZCALLBACK win32_open64_file_func(voidpf opaque, const void* filename, int mode) {
+    (void)opaque;
+    DWORD dwDesiredAccess,dwCreationDisposition,dwShareMode,dwFlagsAndAttributes ;
+    HANDLE hFile = NULL;
+
+    win32_translate_open_mode(mode,&dwDesiredAccess,&dwCreationDisposition,&dwShareMode,&dwFlagsAndAttributes);
+
+#ifdef IOWIN32_USING_WINRT_API
+#ifdef UNICODE
+    if ((filename!=NULL) && (dwDesiredAccess != 0))
+        hFile = CreateFile2((LPCTSTR)filename, dwDesiredAccess, dwShareMode, dwCreationDisposition, NULL);
+#else
+    if ((filename!=NULL) && (dwDesiredAccess != 0))
+    {
+        WCHAR filenameW[FILENAME_MAX + 0x200 + 1];
+        MultiByteToWideChar(CP_ACP,0,(const char*)filename,-1,filenameW,FILENAME_MAX + 0x200);
+        hFile = CreateFile2(filenameW, dwDesiredAccess, dwShareMode, dwCreationDisposition, NULL);
+    }
+#endif
+#else
+    if ((filename!=NULL) && (dwDesiredAccess != 0))
+        hFile = CreateFile((LPCTSTR)filename, dwDesiredAccess, dwShareMode, NULL, dwCreationDisposition, dwFlagsAndAttributes, NULL);
+#endif
+
+    return win32_build_iowin(hFile);
+}
+
+
+voidpf ZCALLBACK win32_open64_file_funcA(voidpf opaque, const void* filename, int mode) {
+    (void)opaque;
+    DWORD dwDesiredAccess,dwCreationDisposition,dwShareMode,dwFlagsAndAttributes ;
+    HANDLE hFile = NULL;
+
+    win32_translate_open_mode(mode,&dwDesiredAccess,&dwCreationDisposition,&dwShareMode,&dwFlagsAndAttributes);
+
+#ifdef IOWIN32_USING_WINRT_API
+    if ((filename!=NULL) && (dwDesiredAccess != 0))
+    {
+        WCHAR filenameW[FILENAME_MAX + 0x200 + 1];
+        MultiByteToWideChar(CP_ACP,0,(const char*)filename,-1,filenameW,FILENAME_MAX + 0x200);
+        hFile = CreateFile2(filenameW, dwDesiredAccess, dwShareMode, dwCreationDisposition, NULL);
+    }
+#else
+    if ((filename!=NULL) && (dwDesiredAccess != 0))
+        hFile = CreateFileA((LPCSTR)filename, dwDesiredAccess, dwShareMode, NULL, dwCreationDisposition, dwFlagsAndAttributes, NULL);
+#endif
+
+    return win32_build_iowin(hFile);
+}
+
+
+voidpf ZCALLBACK win32_open64_file_funcW(voidpf opaque, const void* filename, int mode) {
+    (void)opaque;
+    DWORD dwDesiredAccess,dwCreationDisposition,dwShareMode,dwFlagsAndAttributes ;
+    HANDLE hFile = NULL;
+
+    win32_translate_open_mode(mode,&dwDesiredAccess,&dwCreationDisposition,&dwShareMode,&dwFlagsAndAttributes);
+
+#ifdef IOWIN32_USING_WINRT_API
+    if ((filename!=NULL) && (dwDesiredAccess != 0))
+        hFile = CreateFile2((LPCWSTR)filename, dwDesiredAccess, dwShareMode, dwCreationDisposition,NULL);
+#else
+    if ((filename!=NULL) && (dwDesiredAccess != 0))
+        hFile = CreateFileW((LPCWSTR)filename, dwDesiredAccess, dwShareMode, NULL, dwCreationDisposition, dwFlagsAndAttributes, NULL);
+#endif
+
+    return win32_build_iowin(hFile);
+}
+
+
+voidpf ZCALLBACK win32_open_file_func(voidpf opaque, const char* filename, int mode) {
+    (void)opaque;
+    DWORD dwDesiredAccess,dwCreationDisposition,dwShareMode,dwFlagsAndAttributes ;
+    HANDLE hFile = NULL;
+
+    win32_translate_open_mode(mode,&dwDesiredAccess,&dwCreationDisposition,&dwShareMode,&dwFlagsAndAttributes);
+
+#ifdef IOWIN32_USING_WINRT_API
+#ifdef UNICODE
+    if ((filename!=NULL) && (dwDesiredAccess != 0))
+        hFile = CreateFile2((LPCTSTR)filename, dwDesiredAccess, dwShareMode, dwCreationDisposition, NULL);
+#else
+    if ((filename!=NULL) && (dwDesiredAccess != 0))
+    {
+        WCHAR filenameW[FILENAME_MAX + 0x200 + 1];
+        MultiByteToWideChar(CP_ACP,0,(const char*)filename,-1,filenameW,FILENAME_MAX + 0x200);
+        hFile = CreateFile2(filenameW, dwDesiredAccess, dwShareMode, dwCreationDisposition, NULL);
+    }
+#endif
+#else
+    if ((filename!=NULL) && (dwDesiredAccess != 0))
+        hFile = CreateFile((LPCTSTR)filename, dwDesiredAccess, dwShareMode, NULL, dwCreationDisposition, dwFlagsAndAttributes, NULL);
+#endif
+
+    return win32_build_iowin(hFile);
+}
+
+
+uLong ZCALLBACK win32_read_file_func(voidpf opaque, voidpf stream, void* buf,uLong size) {
+    (void)opaque;
+    uLong ret=0;
+    HANDLE hFile = NULL;
+    if (stream!=NULL)
+        hFile = ((WIN32FILE_IOWIN*)stream) -> hf;
+
+    if (hFile != NULL)
+    {
+        if (!ReadFile(hFile, buf, size, &ret, NULL))
+        {
+            DWORD dwErr = GetLastError();
+            if (dwErr == ERROR_HANDLE_EOF)
+                dwErr = 0;
+            ((WIN32FILE_IOWIN*)stream) -> error=(int)dwErr;
+        }
+    }
+
+    return ret;
+}
+
+
+uLong ZCALLBACK win32_write_file_func(voidpf opaque, voidpf stream, const void* buf, uLong size) {
+    (void)opaque;
+    uLong ret=0;
+    HANDLE hFile = NULL;
+    if (stream!=NULL)
+        hFile = ((WIN32FILE_IOWIN*)stream) -> hf;
+
+    if (hFile != NULL)
+    {
+        if (!WriteFile(hFile, buf, size, &ret, NULL))
+        {
+            DWORD dwErr = GetLastError();
+            if (dwErr == ERROR_HANDLE_EOF)
+                dwErr = 0;
+            ((WIN32FILE_IOWIN*)stream) -> error=(int)dwErr;
+        }
+    }
+
+    return ret;
+}
+
+static BOOL MySetFilePointerEx(HANDLE hFile, LARGE_INTEGER pos, LARGE_INTEGER *newPos, DWORD dwMoveMethod) {
+#ifdef IOWIN32_USING_WINRT_API
+    return SetFilePointerEx(hFile, pos, newPos, dwMoveMethod);
+#else
+    LONG lHigh = pos.HighPart;
+    DWORD dwNewPos = SetFilePointer(hFile, pos.LowPart, &lHigh, dwMoveMethod);
+    BOOL fOk = TRUE;
+    if (dwNewPos == 0xFFFFFFFF)
+        if (GetLastError() != NO_ERROR)
+            fOk = FALSE;
+    if ((newPos != NULL) && (fOk))
+    {
+        newPos->LowPart = dwNewPos;
+        newPos->HighPart = lHigh;
+    }
+    return fOk;
+#endif
+}
+
+long ZCALLBACK win32_tell_file_func(voidpf opaque, voidpf stream) {
+    (void)opaque;
+    long ret=-1;
+    HANDLE hFile = NULL;
+    if (stream!=NULL)
+        hFile = ((WIN32FILE_IOWIN*)stream) -> hf;
+    if (hFile != NULL)
+    {
+        LARGE_INTEGER pos;
+        pos.QuadPart = 0;
+
+        if (!MySetFilePointerEx(hFile, pos, &pos, FILE_CURRENT))
+        {
+            DWORD dwErr = GetLastError();
+            ((WIN32FILE_IOWIN*)stream) -> error=(int)dwErr;
+            ret = -1;
+        }
+        else
+            ret=(long)pos.LowPart;
+    }
+    return ret;
+}
+
+ZPOS64_T ZCALLBACK win32_tell64_file_func(voidpf opaque, voidpf stream) {
+    (void)opaque;
+    ZPOS64_T ret= (ZPOS64_T)-1;
+    HANDLE hFile = NULL;
+    if (stream!=NULL)
+        hFile = ((WIN32FILE_IOWIN*)stream)->hf;
+
+    if (hFile)
+    {
+        LARGE_INTEGER pos;
+        pos.QuadPart = 0;
+
+        if (!MySetFilePointerEx(hFile, pos, &pos, FILE_CURRENT))
+        {
+            DWORD dwErr = GetLastError();
+            ((WIN32FILE_IOWIN*)stream) -> error=(int)dwErr;
+            ret = (ZPOS64_T)-1;
+        }
+        else
+            ret=pos.QuadPart;
+    }
+    return ret;
+}
+
+
+long ZCALLBACK win32_seek_file_func(voidpf opaque, voidpf stream, uLong offset, int origin) {
+    (void)opaque;
+    DWORD dwMoveMethod=0xFFFFFFFF;
+    HANDLE hFile = NULL;
+
+    long ret=-1;
+    if (stream!=NULL)
+        hFile = ((WIN32FILE_IOWIN*)stream) -> hf;
+    switch (origin)
+    {
+    case ZLIB_FILEFUNC_SEEK_CUR :
+        dwMoveMethod = FILE_CURRENT;
+        break;
+    case ZLIB_FILEFUNC_SEEK_END :
+        dwMoveMethod = FILE_END;
+        break;
+    case ZLIB_FILEFUNC_SEEK_SET :
+        dwMoveMethod = FILE_BEGIN;
+        break;
+    default: return -1;
+    }
+
+    if (hFile != NULL)
+    {
+        LARGE_INTEGER pos;
+        pos.QuadPart = offset;
+        if (!MySetFilePointerEx(hFile, pos, NULL, dwMoveMethod))
+        {
+            DWORD dwErr = GetLastError();
+            ((WIN32FILE_IOWIN*)stream) -> error=(int)dwErr;
+            ret = -1;
+        }
+        else
+            ret=0;
+    }
+    return ret;
+}
+
+long ZCALLBACK win32_seek64_file_func(voidpf opaque, voidpf stream, ZPOS64_T offset, int origin) {
+    (void)opaque;
+    DWORD dwMoveMethod=0xFFFFFFFF;
+    HANDLE hFile = NULL;
+    long ret=-1;
+
+    if (stream!=NULL)
+        hFile = ((WIN32FILE_IOWIN*)stream)->hf;
+
+    switch (origin)
+    {
+        case ZLIB_FILEFUNC_SEEK_CUR :
+            dwMoveMethod = FILE_CURRENT;
+            break;
+        case ZLIB_FILEFUNC_SEEK_END :
+            dwMoveMethod = FILE_END;
+            break;
+        case ZLIB_FILEFUNC_SEEK_SET :
+            dwMoveMethod = FILE_BEGIN;
+            break;
+        default: return -1;
+    }
+
+    if (hFile)
+    {
+        LARGE_INTEGER pos;
+        pos.QuadPart = offset;
+        if (!MySetFilePointerEx(hFile, pos, NULL, dwMoveMethod))
+        {
+            DWORD dwErr = GetLastError();
+            ((WIN32FILE_IOWIN*)stream) -> error=(int)dwErr;
+            ret = -1;
+        }
+        else
+            ret=0;
+    }
+    return ret;
+}
+
+int ZCALLBACK win32_close_file_func(voidpf opaque, voidpf stream) {
+    (void)opaque;
+    int ret=-1;
+
+    if (stream!=NULL)
+    {
+        HANDLE hFile;
+        hFile = ((WIN32FILE_IOWIN*)stream) -> hf;
+        if (hFile != NULL)
+        {
+            CloseHandle(hFile);
+            ret=0;
+        }
+        free(stream);
+    }
+    return ret;
+}
+
+int ZCALLBACK win32_error_file_func(voidpf opaque, voidpf stream) {
+    (void)opaque;
+    int ret=-1;
+    if (stream!=NULL)
+    {
+        ret = ((WIN32FILE_IOWIN*)stream) -> error;
+    }
+    return ret;
+}
+
+void fill_win32_filefunc(zlib_filefunc_def* pzlib_filefunc_def) {
+    pzlib_filefunc_def->zopen_file = win32_open_file_func;
+    pzlib_filefunc_def->zread_file = win32_read_file_func;
+    pzlib_filefunc_def->zwrite_file = win32_write_file_func;
+    pzlib_filefunc_def->ztell_file = win32_tell_file_func;
+    pzlib_filefunc_def->zseek_file = win32_seek_file_func;
+    pzlib_filefunc_def->zclose_file = win32_close_file_func;
+    pzlib_filefunc_def->zerror_file = win32_error_file_func;
+    pzlib_filefunc_def->opaque = NULL;
+}
+
+void fill_win32_filefunc64(zlib_filefunc64_def* pzlib_filefunc_def) {
+    pzlib_filefunc_def->zopen64_file = win32_open64_file_func;
+    pzlib_filefunc_def->zread_file = win32_read_file_func;
+    pzlib_filefunc_def->zwrite_file = win32_write_file_func;
+    pzlib_filefunc_def->ztell64_file = win32_tell64_file_func;
+    pzlib_filefunc_def->zseek64_file = win32_seek64_file_func;
+    pzlib_filefunc_def->zclose_file = win32_close_file_func;
+    pzlib_filefunc_def->zerror_file = win32_error_file_func;
+    pzlib_filefunc_def->opaque = NULL;
+}
+
+
+void fill_win32_filefunc64A(zlib_filefunc64_def* pzlib_filefunc_def) {
+    pzlib_filefunc_def->zopen64_file = win32_open64_file_funcA;
+    pzlib_filefunc_def->zread_file = win32_read_file_func;
+    pzlib_filefunc_def->zwrite_file = win32_write_file_func;
+    pzlib_filefunc_def->ztell64_file = win32_tell64_file_func;
+    pzlib_filefunc_def->zseek64_file = win32_seek64_file_func;
+    pzlib_filefunc_def->zclose_file = win32_close_file_func;
+    pzlib_filefunc_def->zerror_file = win32_error_file_func;
+    pzlib_filefunc_def->opaque = NULL;
+}
+
+
+void fill_win32_filefunc64W(zlib_filefunc64_def* pzlib_filefunc_def) {
+    pzlib_filefunc_def->zopen64_file = win32_open64_file_funcW;
+    pzlib_filefunc_def->zread_file = win32_read_file_func;
+    pzlib_filefunc_def->zwrite_file = win32_write_file_func;
+    pzlib_filefunc_def->ztell64_file = win32_tell64_file_func;
+    pzlib_filefunc_def->zseek64_file = win32_seek64_file_func;
+    pzlib_filefunc_def->zclose_file = win32_close_file_func;
+    pzlib_filefunc_def->zerror_file = win32_error_file_func;
+    pzlib_filefunc_def->opaque = NULL;
+}

--- a/src/tools/iowin32.h
+++ b/src/tools/iowin32.h
@@ -1,0 +1,27 @@
+/* iowin32.h -- IO base function header for compress/uncompress .zip
+     part of the MiniZip project - ( https://www.winimage.com/zLibDll/minizip.html )
+
+         Copyright (C) 1998-2026 Gilles Vollant (minizip) ( https://www.winimage.com/zLibDll/minizip.html )
+
+         Modifications for Zip64 support
+         Copyright (C) 2009-2010 Mathias Svensson ( https://result42.com )
+
+         For more info read MiniZip_info.txt
+
+*/
+
+#include <windows.h>
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void fill_win32_filefunc(zlib_filefunc_def* pzlib_filefunc_def);
+void fill_win32_filefunc64(zlib_filefunc64_def* pzlib_filefunc_def);
+void fill_win32_filefunc64A(zlib_filefunc64_def* pzlib_filefunc_def);
+void fill_win32_filefunc64W(zlib_filefunc64_def* pzlib_filefunc_def);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
What does this implement/fix?
---------------------------------------------------
The library names for zlib and minizip have been modified in zlib 1.3.1.2 and the current 1.3.2 tags.

Hence adding "minizipsd" as possible static/debug name for minizip, and "minizips" as possible static/release name for minizip.

For ZLIB, this has been handled by the following patch in CMake 4.2.0:
https://github.com/Kitware/CMake/commit/b2c059e68f32034acb612d0418ef45ac7b8eed5d
Including a copy of this module provides compatibility for configuring the project with older versions of cmake

Does this close any currently open issues?
------------------------------------------
Yes: https://github.com/F2I-Consulting/fesapi/issues/373

Any relevant logs, error output, etc?
-------------------------------------
Not required, obvious

Any other comments?
-------------------
Several warnings are shown about missing PDB files for libminizip. These warnings are not new.

Where has this been tested?
---------------------------
**Operating System:** Windows 11

**Platform:** Microsoft Visual Studio 2022, CMake 3.30
Made a static build of zlib on Windows.
Compiling fesapi against it using cmake 3.30 and MSVC 2022. CMake project configuration OK (by setting ZLIB_ROOT and MINIZIP_ROOT)
